### PR TITLE
ci: add GH action to lint

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,0 +1,28 @@
+name: Verify changes
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: pnpm/action-setup@v2.2.1
+
+      - name: Setup Node 16.x
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16.x
+          cache: pnpm
+
+      - name: Install Dependencies
+        run: pnpm install
+
+      - name: Lint
+        run: pnpm lint

--- a/package.json
+++ b/package.json
@@ -34,5 +34,6 @@
     "lint-staged": "^12.3.8",
     "prettier": "^2.6.2",
     "typescript": "^4.6.3"
-  }
+  },
+  "packageManager": "pnpm@6.32.8"
 }


### PR DESCRIPTION
Add [Github Action](https://pnpm.io/continuous-integration#github-actions) to install dependencies and lint the code.