### PR TITLE
ci: add package size action

### DIFF
--- a/packages/lozenge/src/index.tsx
+++ b/packages/lozenge/src/index.tsx
@@ -1,10 +1,7 @@
 import type { ReactNode } from 'react';
 
 const Lozenge = ({ children }: { children: ReactNode }) => (
-  <>
-    <span style={{ background: 'lightcyan' }}>{children}</span>
-    <div style={{ background: 'pink' }}>test</div>
-  </>
+  <span style={{ background: 'lightcyan' }}>{children}</span>
 );
 
 export { Lozenge };


### PR DESCRIPTION
Add [compressed-size-action](https://github.com/preactjs/compressed-size-action) to communicate package size changes in pull requests.

Note: All the packages must be built as using the turbo filter `--filter=...[HEAD^1]` does not work on `main` (the baseline 😛 ) when the action builds the baseline sizes. We can iterate in the future to run a custom script to run separate build commands for the branch with changes and `main`.