### PR TITLE
fix: update turbo scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,10 +20,10 @@
     "storybook": "pnpm build && start-storybook -p 3000",
     "storybook:build": "pnpm build && build-storybook --quiet",
     "test": "vitest run --coverage",
-    "test:packages": "turbo run build --filter=[HEAD^1]^... && turbo run test --filter=...[HEAD^1]",
+    "test:packages": "turbo run test --filter=...[HEAD^1]",
     "test:watch": "vitest",
     "prepare": "husky install",
-    "release": "turbo run build --filter=[HEAD^1]... && changeset publish"
+    "release": "turbo run build --filter=[HEAD^1] && changeset publish"
   },
   "repository": {
     "type": "git",

--- a/turbo.json
+++ b/turbo.json
@@ -11,7 +11,7 @@
       "outputs": ["coverage/**"]
     },
     "test": {
-      "dependsOn": [],
+      "dependsOn": ["^build"],
       "outputs": ["coverage/**"]
     },
     "lint": {


### PR DESCRIPTION
Simplify test and release scripts to utilize the [dependsOn](https://turborepo.org/docs/reference/configuration#dependson) `^build` feature which instructs before running test/build for a package, first run `build` for each one of its dependencies.