### PR TITLE
feat(remix): enable streaming

### DIFF
--- a/apps/remix/app/entry.server.tsx
+++ b/apps/remix/app/entry.server.tsx
@@ -1,6 +1,11 @@
-import type { EntryContext } from '@remix-run/node';
+import type { EntryContext, Headers } from '@remix-run/node';
 import { RemixServer } from '@remix-run/react';
-import { renderToString } from 'react-dom/server';
+import { Response } from '@remix-run/node';
+import { renderToPipeableStream } from 'react-dom/server';
+import isbot from 'isbot';
+import { PassThrough } from 'stream';
+
+const ABORT_DELAY = 5000;
 
 export default function handleRequest(
   request: Request,
@@ -8,12 +13,36 @@ export default function handleRequest(
   responseHeaders: Headers,
   remixContext: EntryContext
 ) {
-  const markup = renderToString(<RemixServer context={remixContext} url={request.url} />);
+  const callbackName = isbot(request.headers.get('user-agent')) ? 'onAllReady' : 'onShellReady';
 
-  responseHeaders.set('Content-Type', 'text/html');
+  return new Promise((resolve, reject) => {
+    let didError = false;
 
-  return new Response('<!DOCTYPE html>' + markup, {
-    status: responseStatusCode,
-    headers: responseHeaders,
+    const { pipe, abort } = renderToPipeableStream(
+      <RemixServer context={remixContext} url={request.url} />,
+      {
+        [callbackName]() {
+          let body = new PassThrough();
+
+          responseHeaders.set('Content-Type', 'text/html');
+
+          resolve(
+            new Response(body, {
+              status: didError ? 500 : responseStatusCode,
+              headers: responseHeaders,
+            })
+          );
+          pipe(body);
+        },
+        onShellError(error) {
+          reject(error);
+        },
+        onError(error) {
+          didError = true;
+          console.error(error);
+        },
+      }
+    );
+    setTimeout(abort, ABORT_DELAY);
   });
 }

--- a/apps/remix/package.json
+++ b/apps/remix/package.json
@@ -23,6 +23,7 @@
     "@remix-run/node": "^1.5.1",
     "@remix-run/react": "^1.5.1",
     "@remix-run/serve": "^1.5.1",
+    "isbot": "^3.5.0",
     "react": "^18.1.0",
     "react-dom": "^18.1.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -153,6 +153,7 @@ importers:
       '@remix-run/react': ^1.5.1
       '@remix-run/serve': ^1.5.1
       eslint: ^8.16.0
+      isbot: ^3.5.0
       react: ^18.1.0
       react-dom: ^18.1.0
       typescript: ^4.6.3
@@ -167,6 +168,7 @@ importers:
       '@remix-run/node': 1.5.1_ef5jwxihqo6n7gxfmzogljlgcm
       '@remix-run/react': 1.5.1_ef5jwxihqo6n7gxfmzogljlgcm
       '@remix-run/serve': 1.5.1_ef5jwxihqo6n7gxfmzogljlgcm
+      isbot: 3.5.0
       react: 18.1.0
       react-dom: 18.1.0_react@18.1.0
     devDependencies:
@@ -3446,7 +3448,7 @@ packages:
       '@storybook/core-events': 6.5.0
       '@storybook/csf': 0.0.2--canary.4566f4d.1
       '@storybook/docs-tools': 6.5.0_ef5jwxihqo6n7gxfmzogljlgcm
-      '@storybook/mdx1-csf': 0.0.1-canary.1.867dcd5.0_@babel+core@7.18.0
+      '@storybook/mdx1-csf': 0.0.1-canary.1.eed86d7.0_@babel+core@7.18.0
       '@storybook/node-logger': 6.5.0
       '@storybook/postinstall': 6.5.0
       '@storybook/preview-web': 6.5.0_ef5jwxihqo6n7gxfmzogljlgcm
@@ -4221,7 +4223,7 @@ packages:
       '@babel/traverse': 7.18.0
       '@babel/types': 7.18.0
       '@storybook/csf': 0.0.2--canary.4566f4d.1
-      '@storybook/mdx1-csf': 0.0.1-canary.1.867dcd5.0_@babel+core@7.18.0
+      '@storybook/mdx1-csf': 0.0.1-canary.1.eed86d7.0_@babel+core@7.18.0
       core-js: 3.22.0
       fs-extra: 9.1.0
       global: 4.4.0
@@ -4368,8 +4370,8 @@ packages:
       - webpack-command
     dev: true
 
-  /@storybook/mdx1-csf/0.0.1-canary.1.867dcd5.0_@babel+core@7.18.0:
-    resolution: {integrity: sha512-VnlE825M9SpjyJCPLCXbo+RbvqllsqXqRDCouzHKSpCE3Q79KR7MMURBsJo/vrTG1zeNG68Z4TZrLAu6IoyYaA==}
+  /@storybook/mdx1-csf/0.0.1-canary.1.eed86d7.0_@babel+core@7.18.0:
+    resolution: {integrity: sha512-KOoTWeseRyJYU5qzEWahgNRhRLgHzPrWx4jIiK4oI9MmNx81cD0B0o24Gq04Iyt89X4jTk+VPHc5REJO1Gs99Q==}
     dependencies:
       '@babel/generator': 7.18.0
       '@babel/parser': 7.18.0
@@ -11490,6 +11492,11 @@ packages:
   /isarray/2.0.5:
     resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
     dev: true
+
+  /isbot/3.5.0:
+    resolution: {integrity: sha512-QOFF7IE7hUdzo8pbhCubeiMzKdLZt+W/UwRZWwg+zghmnqXoMwh2V0bi5UT+oIvoD0IWCWjzAtp30ZrrRwJVCg==}
+    engines: {node: '>=12'}
+    dev: false
 
   /isexe/2.0.0:
     resolution: {integrity: sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=}


### PR DESCRIPTION
Enable React 18 streaming features with [renderToPipeableStream](https://reactjs.org/blog/2022/03/08/react-18-upgrade-guide.html#react-dom-server). This allows us to use `React.lazy` on the server.