### PR TITLE
fix(remix): add react-aria ssr provider

### DIFF
--- a/apps/remix/app/root.tsx
+++ b/apps/remix/app/root.tsx
@@ -1,4 +1,5 @@
 import type { LinksFunction, MetaFunction } from '@remix-run/node';
+import { SSRProvider } from '@react-aria/ssr';
 import {
   Links,
   LiveReload,
@@ -41,11 +42,13 @@ export const meta: MetaFunction = () => ({
 
 export default function App() {
   return (
-    <Document>
-      <Layout>
-        <Outlet />
-      </Layout>
-    </Document>
+    <SSRProvider>
+      <Document>
+        <Layout>
+          <Outlet />
+        </Layout>
+      </Document>
+    </SSRProvider>
   );
 }
 

--- a/apps/remix/package.json
+++ b/apps/remix/package.json
@@ -21,6 +21,7 @@
     "@launchpad-ui/tab-list": "workspace:~",
     "@launchpad-ui/toggle": "workspace:~",
     "@launchpad-ui/tokens": "workspace:~",
+    "@react-aria/ssr": "^3.1.2",
     "@react-stately/collections": "^3.3.8",
     "@remix-run/node": "^1.5.1",
     "@remix-run/react": "^1.5.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -152,6 +152,7 @@ importers:
       '@launchpad-ui/tab-list': workspace:~
       '@launchpad-ui/toggle': workspace:~
       '@launchpad-ui/tokens': workspace:~
+      '@react-aria/ssr': ^3.1.2
       '@react-stately/collections': ^3.3.8
       '@remix-run/dev': ^1.5.1
       '@remix-run/eslint-config': ^1.5.1
@@ -172,6 +173,7 @@ importers:
       '@launchpad-ui/tab-list': link:../../packages/tab-list
       '@launchpad-ui/toggle': link:../../packages/toggle
       '@launchpad-ui/tokens': link:../../packages/tokens
+      '@react-aria/ssr': 3.1.2_react@18.1.0
       '@react-stately/collections': 3.3.8_react@18.1.0
       '@remix-run/node': 1.5.1_ef5jwxihqo6n7gxfmzogljlgcm
       '@remix-run/react': 1.5.1_ef5jwxihqo6n7gxfmzogljlgcm


### PR DESCRIPTION
When navigating to the tab-list element in Remix the following message is shown:
```
When server rendering, you must wrap your application in an <SSRProvider> to ensure consistent ids are generated between the client and server.
```

Wrapping the app with [the ssr provider](https://react-spectrum.adobe.com/react-aria/ssr.html#ssr-provider) fixes things.