### PR TITLE
fix: add delay before opening popovers

### DIFF
--- a/.storybook/utils.tsx
+++ b/.storybook/utils.tsx
@@ -67,3 +67,7 @@ export enum PseudoClasses {
   FOCUS_VISIBLE = 'pseudo-focus-visible',
   ACTIVE = 'pseudo-active',
 }
+
+export const sleep = (ms: number) => {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+};

--- a/packages/popover/stories/Popover.stories.tsx
+++ b/packages/popover/stories/Popover.stories.tsx
@@ -3,6 +3,7 @@ import type { Story } from '@storybook/react';
 import { Button } from '@launchpad-ui/button';
 import { userEvent, within } from '@storybook/testing-library';
 
+import { sleep } from '../../../.storybook/utils';
 import { Popover } from '../src';
 
 export default {
@@ -69,6 +70,7 @@ export const Default = {
   },
   play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
     const canvas = within(canvasElement);
+    await sleep(500);
     await userEvent.click(canvas.getByRole('button'));
   },
 };

--- a/packages/tooltip/stories/Tooltip.stories.tsx
+++ b/packages/tooltip/stories/Tooltip.stories.tsx
@@ -3,6 +3,7 @@ import type { Story } from '@storybook/react';
 import { Button } from '@launchpad-ui/button';
 import { userEvent, within } from '@storybook/testing-library';
 
+import { sleep } from '../../../.storybook/utils';
 import { Tooltip } from '../src';
 
 export default {
@@ -49,6 +50,7 @@ export const Default = {
   },
   play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
     const canvas = within(canvasElement);
+    await sleep(500);
     await userEvent.click(canvas.getByRole('button'));
   },
 };


### PR DESCRIPTION
Our Chromatic snapshots for popovers and tooltips have been inconsistent. This is likely due to shifting caused by `font-display: swap;` for our font. To address this we can add a delay in the play functions to open the popovers a little later.