### PR TITLE
ci: update renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,42 +2,15 @@
   "extends": [
     "config:base",
     ":separateMultipleMajorReleases",
-    ":separatePatchReleases",
-    ":maintainLockFilesWeekly",
-    ":widenPeerDependencies"
+    ":maintainLockFilesMonthly",
+    ":widenPeerDependencies",
+    "schedule:weekly",
+    "group:allNonMajor"
   ],
   "packageRules": [
     {
       "updateTypes": ["patch"],
       "enabled": false
-    },
-    {
-      "matchPackagePatterns": ["^eslint"],
-      "groupName": "eslint packages"
-    },
-    {
-      "matchPackagePatterns": ["^stylelint"],
-      "groupName": "stylelint packages"
-    },
-    {
-      "matchPackagePatterns": ["^@storybook/"],
-      "groupName": "storybook packages"
-    },
-    {
-      "matchPackagePatterns": ["^@testing-library/"],
-      "groupName": "testing-library packages"
-    },
-    {
-      "matchPackagePatterns": ["^@remix-run/"],
-      "groupName": "remix packages"
-    },
-    {
-      "matchPackagePatterns": ["^@react-aria/"],
-      "groupName": "react-aria packages"
-    },
-    {
-      "matchPackagePatterns": ["^@react-stately/"],
-      "groupName": "react-stately packages"
     }
   ],
   "rangeStrategy": "bump"


### PR DESCRIPTION
To reduce Renovate frequency:

- Maintain lockfile monthly (instead of weekly)
- Group all non major upgrades in a PR weekly