### PR TITLE
refactor(clipboard): remove unneeded classes from clipboard package

### DIFF
--- a/.changeset/nervous-toes-tie.md
+++ b/.changeset/nervous-toes-tie.md
@@ -1,0 +1,8 @@
+---
+'@launchpad-ui/clipboard': patch
+'@launchpad-ui/core': patch
+---
+
+Removed or moved styles for u- classes in clipboard package
+
+- [Clipboard] removed or moved styles for u- classes

--- a/packages/clipboard/src/CopyToClipboard.tsx
+++ b/packages/clipboard/src/CopyToClipboard.tsx
@@ -23,9 +23,9 @@ type CopyToClipboardHandleRef = {
 };
 
 const CopyConfirmation = () => (
-  <span className="u-flex-middle">
+  <span className="Clipboard-confirmation">
     <CheckCircle className="Clipboard-checkmark" size={IconSize.MEDIUM} />
-    <span className="u-ml-s">Copied!</span>
+    <span className="Clipboard-copied">Copied!</span>
   </span>
 );
 

--- a/packages/clipboard/src/styles/Clipboard.css
+++ b/packages/clipboard/src/styles/Clipboard.css
@@ -55,6 +55,14 @@
   fill: var(--color-system-green-500);
 }
 
+.Clipboard-confirmation {
+  align-items: center;
+}
+
+.Clipboard-copied {
+  margin-left: 0.5rem;
+}
+
 .CopyToClipboard-button:focus code,
 .CopyToClipboard:hover code {
   background-color: var(--color-background-hover);


### PR DESCRIPTION
## Summary
There are a few u- classes left over from the migration so we should clean these up.
