### PR TITLE
refactor: enforce type imports

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -44,6 +44,8 @@ module.exports = {
         ignoreRestSiblings: true,
       },
     ],
+    '@typescript-eslint/consistent-type-imports': 'error',
+    '@typescript-eslint/consistent-type-definitions': ['error', 'type'],
     'testing-library/prefer-user-event': 'error',
     'import/order': [
       'error',

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,6 @@
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.codeActionsOnSave": {
     "source.fixAll.stylelint": true
-  }
+  },
+  "eslint.workingDirectories": ["./", "./apps/remix"]
 }

--- a/packages/alert/src/CollapsibleAlert.tsx
+++ b/packages/alert/src/CollapsibleAlert.tsx
@@ -1,9 +1,11 @@
+import type { AlertKind } from './types';
+
 import { ExpandMore, IconSize } from '@launchpad-ui/icons';
 import { useRef, useState } from 'react';
 
 import { Alert } from './Alert';
 import './styles/CollapsibleAlert.css';
-import { AlertKind, AlertSize } from './types';
+import { AlertSize } from './types';
 
 type CollapsibleAlertProps = {
   /**

--- a/packages/dropdown/src/DropdownButton.tsx
+++ b/packages/dropdown/src/DropdownButton.tsx
@@ -1,4 +1,6 @@
-import { Button, ButtonKind, ButtonSize } from '@launchpad-ui/button';
+import type { ButtonKind, ButtonSize } from '@launchpad-ui/button';
+
+import { Button } from '@launchpad-ui/button';
 import { ExpandMore, IconSize } from '@launchpad-ui/icons';
 import { forwardRef } from 'react';
 

--- a/packages/form/src/CompactTextField.tsx
+++ b/packages/form/src/CompactTextField.tsx
@@ -1,3 +1,4 @@
+import type { TextFieldProps } from './TextField';
 import type { FocusEvent } from 'react';
 
 import cx from 'clsx';
@@ -5,7 +6,7 @@ import { isBoolean } from 'lodash-es';
 import { forwardRef, useState } from 'react';
 
 import { Label } from './Label';
-import { TextField, TextFieldProps } from './TextField';
+import { TextField } from './TextField';
 import './styles/CompactTextField.css';
 import './styles/FormInput.css';
 

--- a/packages/menu/src/Menu.tsx
+++ b/packages/menu/src/Menu.tsx
@@ -1,6 +1,8 @@
+import type { MenuItemProps } from './MenuItem';
+import type { FocusManager } from '@react-aria/focus';
 import type { KeyboardEvent, ReactElement } from 'react';
 
-import { FocusManager, useFocusManager } from '@react-aria/focus';
+import { useFocusManager } from '@react-aria/focus';
 import cx from 'clsx';
 import { isNil, noop } from 'lodash-es';
 import { Children, cloneElement, useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -9,7 +11,7 @@ import { v4 } from 'uuid';
 
 import { MenuBase } from './MenuBase';
 import { MenuDivider } from './MenuDivider';
-import { MenuItem, MenuItemLink, MenuItemProps } from './MenuItem';
+import { MenuItem, MenuItemLink } from './MenuItem';
 import { MenuItemList } from './MenuItemList';
 import { MenuSearch } from './MenuSearch';
 import {

--- a/packages/menu/src/MenuDivider.tsx
+++ b/packages/menu/src/MenuDivider.tsx
@@ -1,4 +1,6 @@
-import { SeparatorProps, useSeparator } from '@react-aria/separator';
+import type { SeparatorProps } from '@react-aria/separator';
+
+import { useSeparator } from '@react-aria/separator';
 
 import './styles/Menu.css';
 

--- a/packages/menu/src/MenuItem.tsx
+++ b/packages/menu/src/MenuItem.tsx
@@ -1,6 +1,7 @@
+import type { Icon } from '@launchpad-ui/icons';
 import type { PopoverPlacement } from '@launchpad-ui/popover';
 
-import { Icon, IconSize } from '@launchpad-ui/icons';
+import { IconSize } from '@launchpad-ui/icons';
 import { Tooltip } from '@launchpad-ui/tooltip';
 import { FocusRing } from '@react-aria/focus';
 import cx from 'clsx';

--- a/packages/navigation/src/NavBarLozenge.tsx
+++ b/packages/navigation/src/NavBarLozenge.tsx
@@ -1,4 +1,6 @@
-import { Lozenge, LozengeKind } from '@launchpad-ui/lozenge';
+import type { LozengeKind } from '@launchpad-ui/lozenge';
+
+import { Lozenge } from '@launchpad-ui/lozenge';
 import cx from 'clsx';
 
 import { titlecase } from './utils';

--- a/packages/notification/__tests__/NotificationCenter.spec.tsx
+++ b/packages/notification/__tests__/NotificationCenter.spec.tsx
@@ -1,8 +1,10 @@
+import type { NotificationRecord } from '../src/types';
+
 import { it, expect, describe } from 'vitest';
 
 import { render, screen } from '../../../test/utils';
 import { NotificationCenter } from '../src';
-import { NotificationLevel, NotificationRecord } from '../src/types';
+import { NotificationLevel } from '../src/types';
 
 const notifications: NotificationRecord[] = [
   {

--- a/packages/notification/src/Notification.tsx
+++ b/packages/notification/src/Notification.tsx
@@ -1,13 +1,13 @@
 /* eslint-disable functional/no-class */
 import type { NotificationLevel } from './types';
-import type { ReactNode } from 'react';
+import type { KeyboardEvent, ReactNode } from 'react';
 
 import { Button, ButtonSize, ButtonType } from '@launchpad-ui/button';
 import { CopyToClipboard } from '@launchpad-ui/clipboard';
 import { KindIcon, Close, ExpandMore, IconSize } from '@launchpad-ui/icons';
 import { FocusScope } from '@react-aria/focus';
 import cx from 'clsx';
-import { Component, KeyboardEvent } from 'react';
+import { Component } from 'react';
 
 import './styles/Notification.css';
 

--- a/packages/notification/stories/NotificationCenter.stories.tsx
+++ b/packages/notification/stories/NotificationCenter.stories.tsx
@@ -1,4 +1,5 @@
 /* eslint-disable react-hooks/rules-of-hooks */
+import type { NotificationRecord } from '../src/types';
 import type { ComponentStoryObj } from '@storybook/react';
 
 import { Button } from '@launchpad-ui/button';
@@ -7,7 +8,7 @@ import { useState } from 'react';
 import { v4 } from 'uuid';
 
 import { NotificationCenter } from '../src';
-import { NotificationLevel, NotificationRecord } from '../src/types';
+import { NotificationLevel } from '../src/types';
 
 export default {
   component: NotificationCenter,

--- a/packages/popover/src/Popover.tsx
+++ b/packages/popover/src/Popover.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable functional/no-class */
 import type { OffsetOptions } from '@floating-ui/core';
 import type { ComputePositionConfig, Placement, Strategy } from '@floating-ui/dom';
-import type { CSSProperties } from 'react';
+import type { CSSProperties, ReactHTML, Ref } from 'react';
 
 import { arrow, computePosition, flip, offset as floatOffset, shift } from '@floating-ui/dom';
 import { Overlay } from '@launchpad-ui/overlay';
@@ -9,15 +9,7 @@ import { FocusScope } from '@react-aria/focus';
 import cx from 'clsx';
 import { m } from 'framer-motion';
 import { isFunction, isNil } from 'lodash-es';
-import {
-  Children,
-  cloneElement,
-  Component,
-  createElement,
-  isValidElement,
-  ReactHTML,
-  Ref,
-} from 'react';
+import { Children, cloneElement, Component, createElement, isValidElement } from 'react';
 import { v4 } from 'uuid';
 
 import './styles/Popover.css';

--- a/packages/progress-bubbles/__tests__/ProgressBubbles.e2e.tsx
+++ b/packages/progress-bubbles/__tests__/ProgressBubbles.e2e.tsx
@@ -1,6 +1,8 @@
+import type { ProgressBubblesProps } from '../src/ProgressBubbles';
+
 import { test, expect } from '@playwright/experimental-ct-react';
 
-import { ProgressBubbles, ProgressBubblesProps } from '../src/ProgressBubbles';
+import { ProgressBubbles } from '../src/ProgressBubbles';
 
 test.use({ viewport: { width: 500, height: 500 } });
 

--- a/packages/progress-bubbles/__tests__/ProgressBubbles.spec.tsx
+++ b/packages/progress-bubbles/__tests__/ProgressBubbles.spec.tsx
@@ -1,8 +1,10 @@
+import type { ProgressBubblesProps } from '../src';
+
 import { Info } from '@launchpad-ui/icons';
 import { it, expect, describe } from 'vitest';
 
 import { render, screen } from '../../../test/utils';
-import { ProgressBubbles, ProgressBubblesProps } from '../src';
+import { ProgressBubbles } from '../src';
 
 const createComponent = (props?: Partial<ProgressBubblesProps>) => {
   const allProps = {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 
-import { PlaywrightTestConfig, devices } from '@playwright/test';
+import { type PlaywrightTestConfig, devices } from '@playwright/test';
 
 const config: PlaywrightTestConfig = {
   testDir: path.resolve(),


### PR DESCRIPTION
## Summary

Enforce [eslint rule](https://typescript-eslint.io/rules/consistent-type-imports) to ensure imports only used as types are specified as such.