### PR TITLE
fix: add changeset for update to icons

### DIFF
--- a/.changeset/green-pants-fry.md
+++ b/.changeset/green-pants-fry.md
@@ -1,0 +1,6 @@
+---
+'@launchpad-ui/core': patch
+'@launchpad-ui/icons': patch
+---
+
+[Icons] Add ChevronLeft, ChevronRight, KeyboardDoubleArrowLeft, KeyboardDoubleArrowRight


### PR DESCRIPTION
## Summary

The `pagination` package got published but is unable to pull in the icons it needs because `icons` did not get a changeset as part of #214.