### PR TITLE
refactor(notification): make onDismiss optional

### DIFF
--- a/.changeset/odd-nails-sniff.md
+++ b/.changeset/odd-nails-sniff.md
@@ -1,0 +1,8 @@
+---
+'@launchpad-ui/notification': patch
+'@launchpad-ui/core': patch
+---
+
+Make onDismiss optional in Notification component:
+
+- [Notification] Make onDismiss optional

--- a/packages/notification/src/Notification.tsx
+++ b/packages/notification/src/Notification.tsx
@@ -14,7 +14,7 @@ type NotificationProps = {
   details?: string;
   level: NotificationLevel;
   message: ReactNode;
-  onDismiss: () => void;
+  onDismiss?: () => void;
   ttl?: number;
   json?: string;
 };


### PR DESCRIPTION
## Summary
`onDismiss` should be optional. Note that we define a default value in the destructured props object