### PR TITLE
chore: add changeset for react-aria upgrade

### DIFF
--- a/.changeset/moody-geckos-enjoy.md
+++ b/.changeset/moody-geckos-enjoy.md
@@ -1,0 +1,15 @@
+---
+'@launchpad-ui/clipboard': patch
+'@launchpad-ui/core': patch
+'@launchpad-ui/form': patch
+'@launchpad-ui/menu': patch
+'@launchpad-ui/modal': patch
+'@launchpad-ui/navigation': patch
+'@launchpad-ui/notification': patch
+'@launchpad-ui/pagination': patch
+'@launchpad-ui/popover': patch
+'@launchpad-ui/tab-list': patch
+'@launchpad-ui/toggle': patch
+---
+
+Update `@react-aria` for smaller bundle sizes


### PR DESCRIPTION
## Summary

Add a changeset for the react-aria upgrade in #232 as those changes introduced a [reduction in those package sizes](https://react-spectrum.adobe.com/releases/2022-07-09.html#bundle-size) that consumers would like to take advantage of.