### PR TITLE
fix: add workaround for vitest to run unit tests again

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -31,6 +31,11 @@ export default defineConfig({
       statements: 80,
       exclude: ['**/*.spec.tsx', '**/test/'],
     },
+    /*
+     * An issue occurs when running all the unit tests with vitest
+     * See: https://github.com/vitest-dev/vitest/issues/1753
+     * TODO: remove the registerNodeLoader workaround when the issue has been resolved
+     */
     deps: {
       registerNodeLoader: false,
     },


### PR DESCRIPTION
## Summary
The unit tests started breaking in this commit: [1a9695f](https://github.com/launchdarkly/launchpad-ui/commit/1a9695f7ba72427e1ccd2b4c60dbb1f263ebba85)

A github issue exists in vitest where they describe a workaround for the time being: https://github.com/vitest-dev/vitest/issues/1753


