### PR TITLE
fix: adjust changeset for filter package addition

### DIFF
--- a/.changeset/calm-buses-fetch.md
+++ b/.changeset/calm-buses-fetch.md
@@ -1,7 +1,7 @@
 ---
-'@launchpad-ui/core': minor
+'@launchpad-ui/core': patch
 '@launchpad-ui/filter': minor
-'@launchpad-ui/icons': minor
+'@launchpad-ui/icons': patch
 ---
 
 Introduce Filter component and Check icon


### PR DESCRIPTION
## Summary

[In previous instances](https://github.com/launchdarkly/launchpad-ui/pull/222/files#diff-88a51ed70741ccc16fc9c881486a6dd8381be819007506460d11edd989c56c83R3) where we've added a new package, we consider it a patch change for core as breaking changes are not introduced. Also the change to `icons` is a patch since only a new icon was added. Perhaps our [versioning strategy](https://github.com/launchdarkly/launchpad-ui/blob/main/CONTRIBUTING.md#how-does-versioning-work-in-launchpad) should include a new package scenario.