### PR TITLE
feat(filter, menu): update styles and stories; use TextField in MenuSearch

### DIFF
--- a/.changeset/spicy-kiwis-give.md
+++ b/.changeset/spicy-kiwis-give.md
@@ -1,0 +1,9 @@
+---
+'@launchpad-ui/filter': patch
+'@launchpad-ui/menu': patch
+---
+
+Updating styles for Filter components
+
+- [Filter] Minor updates to styles
+- [Menu] Use TextField in MenuSearch rather than raw input; minor updates to styles

--- a/packages/filter/src/FilterButton.tsx
+++ b/packages/filter/src/FilterButton.tsx
@@ -76,7 +76,7 @@ const FilterButton = forwardRef<Ref, FilterButtonProps>((props, ref) => {
         {!isClearable && <ExpandMore size={IconSize.SMALL} />}
       </button>
       {isClearable && (
-        <Tooltip className="Filter-clearTooltip" content={clearTooltip}>
+        <Tooltip targetClassName="Filter-clearTooltip" content={clearTooltip}>
           <Button
             className="Filter-clear"
             size={ButtonSize.SMALL}

--- a/packages/filter/src/styles/Filter.css
+++ b/packages/filter/src/styles/Filter.css
@@ -1,3 +1,7 @@
+.Filter {
+  font-family: var(--font-family-base);
+}
+
 .Filter-buttonContainer {
   cursor: pointer;
   display: inline-flex;
@@ -10,7 +14,6 @@
   border-radius: var(--border-radius);
   padding-top: 0;
   padding-bottom: 0;
-  font-size: var(--osmo-font-size-small);
   line-height: 3.2rem;
   display: flex;
   align-items: center;
@@ -23,7 +26,6 @@
   color: var(--color-text);
   height: 2rem;
   background-color: var(--color-gray-100);
-  font-size: var(--osmo-font-size-small);
   padding: 0.2rem 0.6rem;
   border-radius: 0.2rem;
   display: flex;
@@ -31,6 +33,8 @@
 
 .Filter-button,
 .AppliedFilter-button {
+  font-family: inherit;
+  font-size: 1.3rem;
   cursor: pointer;
   border-width: 1px;
   border-style: solid;
@@ -124,4 +128,10 @@
   &:hover {
     background-color: var(--color-background-hover);
   }
+}
+
+.Filter-clearTooltip {
+  line-height: 1;
+  position: absolute;
+  right: 0.7rem;
 }

--- a/packages/filter/stories/Filter.stories.tsx
+++ b/packages/filter/stories/Filter.stories.tsx
@@ -129,29 +129,52 @@ type Story = ComponentStoryObj<typeof Filter>;
 
 export const Basic: Story = {
   args: {
-    searchValue: '',
-    searchPlaceholder: 'filter here',
-    onSearchChange: () => undefined,
-    isClearable: false,
-    onClear: () => undefined,
     name: 'Author',
     description: 'Osmo',
     options: [
       { name: 'Mickey Mouse', value: 'mickey' },
       { name: 'Osmo', value: 'osmo' },
     ],
+    isClearable: false,
+    onClear: () => undefined,
   },
 };
 
-export const WithoutName: Story = {
+export const IsLoading: Story = {
+  args: {
+    name: 'Author',
+    isLoading: true,
+    options: [{ name: 'Osmo', value: 'osmo' }],
+    isClearable: false,
+    onClear: () => undefined,
+  },
+};
+
+export const WithNameOnly: Story = {
+  args: {
+    name: 'Author',
+    options: [{ name: 'Osmo', value: 'osmo' }],
+    isClearable: false,
+    onClear: () => undefined,
+  },
+};
+
+export const WithDescriptionOnly: Story = {
   args: {
     hideName: true,
-    searchValue: '',
-    searchPlaceholder: 'filter here',
-    name: 'created by',
-    description: 'description',
-    options: [{ value: 'value' }],
-    onSearchChange: () => undefined,
+    name: 'Author',
+    description: 'Osmo',
+    options: [{ name: 'Osmo', value: 'osmo' }],
+    isClearable: false,
+    onClear: () => undefined,
+  },
+};
+
+export const WithIconOnly: Story = {
+  args: {
+    hideName: true,
+    name: 'Author',
+    options: [{ name: 'Osmo', value: 'osmo' }],
     isClearable: false,
     onClear: () => undefined,
   },
@@ -159,11 +182,6 @@ export const WithoutName: Story = {
 
 export const WithAllMenuOptionVariants: Story = {
   args: {
-    searchValue: '',
-    searchPlaceholder: 'filter here',
-    onSearchChange: () => undefined,
-    isClearable: false,
-    onClear: () => undefined,
     name: 'Author',
     description: 'Osmo',
     disabledOptionTooltip: 'tooltip for disabled options',
@@ -173,5 +191,19 @@ export const WithAllMenuOptionVariants: Story = {
       { name: 'Osmo', value: 'osmo', isChecked: true },
       { name: 'Pluto', value: 'pluto' },
     ],
+    searchPlaceholder: 'filter here',
+    onSearchChange: () => undefined,
+    isClearable: false,
+    onClear: () => undefined,
+  },
+};
+
+export const WithClearButton: Story = {
+  args: {
+    name: 'Author',
+    description: 'Osmo',
+    options: [{ name: 'Osmo', value: 'osmo' }],
+    isClearable: true,
+    onClear: () => undefined,
   },
 };

--- a/packages/filter/stories/FilterButton.stories.tsx
+++ b/packages/filter/stories/FilterButton.stories.tsx
@@ -23,6 +23,12 @@ export const Basic: Story = {
   },
 };
 
+export const WithNameOnly: Story = {
+  args: {
+    name: 'Author',
+  },
+};
+
 export const WithDescriptionOnly: Story = {
   args: {
     name: 'Author',

--- a/packages/menu/package.json
+++ b/packages/menu/package.json
@@ -33,6 +33,7 @@
     "test": "vitest run --coverage"
   },
   "dependencies": {
+    "@launchpad-ui/form": "workspace:~",
     "@launchpad-ui/icons": "workspace:~",
     "@launchpad-ui/popover": "workspace:~",
     "@launchpad-ui/tokens": "workspace:~",

--- a/packages/menu/src/MenuSearch.tsx
+++ b/packages/menu/src/MenuSearch.tsx
@@ -1,5 +1,6 @@
 import type { ChangeEvent } from 'react';
 
+import { TextField } from '@launchpad-ui/form';
 import { forwardRef } from 'react';
 
 import './styles/Menu.css';
@@ -16,21 +17,16 @@ const MenuSearch = forwardRef<HTMLInputElement, MenuSearchProps>((props, ref) =>
 
   return (
     <div className="Menu-search">
-      <input
+      <TextField
         {...finalProps}
         ref={ref}
-        className="Menu-search-input FormInput FormInput--tiny"
+        className="Menu-search-input"
+        tiny
         type="search"
         autoComplete="off"
         placeholder={placeholder}
         aria-label={ariaLabel || 'Search'}
       />
-      <div
-        className="Menu-search-hidden-placeholder Menu-search-input FormInput FormInput--tiny"
-        aria-hidden="true"
-      >
-        {placeholder}
-      </div>
     </div>
   );
 });

--- a/packages/menu/src/styles/Menu.css
+++ b/packages/menu/src/styles/Menu.css
@@ -8,6 +8,7 @@
   outline: none;
   padding: 0.6rem 2.5rem;
   text-align: left;
+  font-family: inherit;
   font-size: 1.3rem;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -65,6 +66,8 @@
 }
 
 .Menu {
+  font-family: var(--font-family-base);
+
   &:focus {
     outline: none;
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -464,6 +464,7 @@ importers:
 
   packages/menu:
     specifiers:
+      '@launchpad-ui/form': workspace:~
       '@launchpad-ui/icons': workspace:~
       '@launchpad-ui/popover': workspace:~
       '@launchpad-ui/tokens': workspace:~
@@ -479,6 +480,7 @@ importers:
       react-virtual: ^2.10.4
       uuid: ^8.3.2
     dependencies:
+      '@launchpad-ui/form': link:../form
       '@launchpad-ui/icons': link:../icons
       '@launchpad-ui/popover': link:../popover
       '@launchpad-ui/tokens': link:../tokens


### PR DESCRIPTION
## Summary

- Updates to stories for Filters to provide more examples
- Fix an issue where font family was not propagating to buttons due to user agent stylesheet conflict
- Fix font size on buttons
- Update MenuSearch to use TextField instead of raw input to ensure consuming components (in this case FilterMenu) would get the underlying styles
- Fix an issue where the clear button in the FilterButton was appearing outside its parent container visually