### PR TITLE
docs: add migration guidelines

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,53 @@
+# Migration @launchpad-ui/core
+
+## 0.8.0
+
+### Reworked split-button
+
+The `split-button` package's API as been reworked for improved composition and DX:
+
+Before:
+
+```jsx
+<SplitButton
+  kind={ButtonKind.DEFAULT}
+  onClickMainButton={() => undefined}
+  dropButtonTooltip="Dropdown tooltip"
+  mainButtonTooltip="Main tooltip"
+  onSelect={handleSelect}
+  name="Save changes"
+  isOpen={open}
+  onInteraction={() => setOpen(!open)}
+  // and a bunch of other props
+>
+  <Menu>
+    <MenuItem>Item 1</MenuItem>
+    <MenuItem>Item 2</MenuItem>
+  </Menu>
+</SplitButton>
+```
+
+After:
+
+```jsx
+<SplitButton>
+  <Tooltip content="Main tooltip">
+    <SplitButtonMainButton>Save changes</SplitButtonMainButton>
+  </Tooltip>
+  <SplitButtonDropdown isOpen={open} onInteraction={() => setOpen(!open)} onSelect={handleSelect}>
+    <Tooltip content="Dropdown tooltip">
+      <SplitButtonDropdownButton />
+    </Tooltip>
+    <Menu>
+      <MenuItem>Save changes</MenuItem>
+      <MenuItem>Save with comment</MenuItem>
+    </Menu>
+  </SplitButtonDropdown>
+</SplitButton>
+```
+
+## 0.7.0
+
+### React 18
+
+Due to updating to `framer-motion` v7, the minimum required version of React is v18 for Launchpad components.


### PR DESCRIPTION
## Summary

Start a migration doc to instruct consumers what changes they need to make to migrate to the next 0.x major version of the core package.