### PR TITLE
feat(split-button): add default placement to SplitButtonDropdown

### DIFF
--- a/.changeset/late-starfishes-bathe.md
+++ b/.changeset/late-starfishes-bathe.md
@@ -1,0 +1,6 @@
+---
+'@launchpad-ui/split-button': patch
+'@launchpad-ui/core': patch
+---
+
+[SplitButton]: Add default placement for SplitButtonDropdown

--- a/packages/split-button/src/SplitButtonDropdown.tsx
+++ b/packages/split-button/src/SplitButtonDropdown.tsx
@@ -11,13 +11,24 @@ type SplitButtonDropdownProps = Omit<
   'enableArrow' | 'restrictWidth'
 >;
 
-const SplitButtonDropdown = ({ disabled, children, ...rest }: SplitButtonDropdownProps) => {
+const SplitButtonDropdown = ({
+  disabled,
+  children,
+  placement = 'bottom-end',
+  ...rest
+}: SplitButtonDropdownProps) => {
   const { disabled: parentDisabled } = useContext(SplitButtonContext);
 
   const isDisabled = parentDisabled || disabled;
 
   return (
-    <Dropdown {...rest} enableArrow={false} restrictWidth={false} disabled={isDisabled}>
+    <Dropdown
+      {...rest}
+      placement={placement}
+      enableArrow={false}
+      restrictWidth={false}
+      disabled={isDisabled}
+    >
       {children}
     </Dropdown>
   );


### PR DESCRIPTION
Adds a default placement of `bottom-end` to SplitButtonDropdown