### PR TITLE
refactor: remove React shim from build

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -26,7 +26,6 @@ const build = async () => {
       ...Object.keys(packageJSON.peerDependencies || {}),
       '*.css',
     ],
-    inject: [path.resolve(__dirname, './react-shim.js')],
   };
 
   await esbuild

--- a/scripts/react-shim.js
+++ b/scripts/react-shim.js
@@ -1,2 +1,0 @@
-import * as React from 'react';
-export { React };


### PR DESCRIPTION
## Summary

Remove the React shim from our build since esbuild [supports the new JSX transform](https://github.com/evanw/esbuild/releases/tag/v0.14.51).