### PR TITLE
refactor(button): update upload button types

### DIFF
--- a/.changeset/giant-turtles-flash.md
+++ b/.changeset/giant-turtles-flash.md
@@ -1,0 +1,6 @@
+---
+'@launchpad-ui/button': patch
+'@launchpad-ui/core': patch
+---
+
+[Button] Update onSelect type for UploadButton component

--- a/packages/button/src/UploadButton.tsx
+++ b/packages/button/src/UploadButton.tsx
@@ -6,7 +6,7 @@ import { useRef } from 'react';
 
 import { Button } from './Button';
 
-type UploadButtonProps = ButtonProps & {
+type UploadButtonProps = Omit<ButtonProps, 'onSelect'> & {
   onSelect(file?: File | null): void;
   maxSize: number;
   accept?: string;


### PR DESCRIPTION
## Summary

This type is not currently accurate since we intercept the `onSelect` prop in `UploadButton`:
<img width="876" alt="Screen Shot 2022-09-06 at 10 59 43 AM" src="https://user-images.githubusercontent.com/104940219/188682627-51c73a62-d091-4ccb-89ef-b545ea45ec81.png">

Solution: omit the `onSelect` prop.