### PR TITLE
feat: use TurboSnap for fewer snapshots

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -27,3 +27,4 @@ jobs:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           buildScriptName: 'storybook:build'
           exitOnceUploaded: true
+          onlyChanged: true

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,7 +1,10 @@
 const path = require('path');
-const tsconfig = require('../tsconfig.json');
 const fs = require('fs');
+
 const fg = require('fast-glob');
+const turbosnap = require('vite-plugin-turbosnap');
+
+const tsconfig = require('../tsconfig.json');
 
 const getStories = () =>
   fg.sync([path.resolve(__dirname, `../packages/**/stories/*.stories.tsx`), '!**/node_modules']);
@@ -31,6 +34,13 @@ module.exports = {
     const packageStatuses = getPackageStatusEnvVars();
 
     return { ...config, ...packageStatuses };
+  },
+  async viteFinal(config, { configType }) {
+    if (configType === 'PRODUCTION') {
+      config.plugins.push(turbosnap({ rootDir: config.root }));
+    }
+
+    return config;
   },
 };
 

--- a/package.json
+++ b/package.json
@@ -126,6 +126,7 @@
     "typescript": "^4.8.2",
     "typescript-plugin-css-modules": "^3.4.0",
     "vite": "^3.1.0",
+    "vite-plugin-turbosnap": "^1.0.1",
     "vitest": "^0.23.1",
     "wait-on": "^6.0.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,6 +97,7 @@ importers:
       typescript: ^4.8.2
       typescript-plugin-css-modules: ^3.4.0
       vite: ^3.1.0
+      vite-plugin-turbosnap: ^1.0.1
       vitest: ^0.23.1
       wait-on: ^6.0.1
     devDependencies:
@@ -188,6 +189,7 @@ importers:
       typescript: 4.8.2
       typescript-plugin-css-modules: 3.4.0_typescript@4.8.2
       vite: 3.1.0
+      vite-plugin-turbosnap: 1.0.1
       vitest: 0.23.1_dy3eolvvquedhjwqma34rzkxmm
       wait-on: 6.0.1
 
@@ -18350,6 +18352,10 @@ packages:
       is-buffer: 2.0.5
       unist-util-stringify-position: 3.0.2
       vfile-message: 3.1.2
+    dev: true
+
+  /vite-plugin-turbosnap/1.0.1:
+    resolution: {integrity: sha512-isVvISdXZyflIsXYrpTMBnyrtZq92ftohL8/xHi1H0kUwXIFDegqedX1kCKIQ04tjUkphB0cFbGzuvOGVwVTnQ==}
     dev: true
 
   /vite/3.1.0:


### PR DESCRIPTION
## Summary

Use [TurboSnap](https://www.chromatic.com/docs/turbosnap) via [vite-plugin-turbosnap](https://github.com/IanVS/vite-plugin-turbosnap) to take snapshots of only the stories that might be affected by a change.

<img width="1666" alt="Screen Shot 2022-09-07 at 11 29 05 AM" src="https://user-images.githubusercontent.com/2147624/188918203-6b4c90b3-df00-4921-9ae9-d36bb63c63a5.png">

Note: Notice the TurboSnap popover with info