### PR TITLE
fix: update nx affected scripts for release branches

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -8,8 +8,24 @@ on:
       - 'release/**'
 
 jobs:
+  branch-info:
+    name: Branch Info
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get base branch
+        id: get-base-branch
+        run: |
+          if [[ "${{github.event.pull_request.base.ref}}" != "" ]]; then
+            echo "::set-output name=branch::${{github.event.pull_request.base.ref}}"
+          else
+            echo "::set-output name=branch::main"
+          fi
+    outputs:
+      base-branch: ${{ steps.get-base-branch.outputs.branch }}
+
   lint:
     name: Lint
+    needs: [branch-info]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -20,6 +36,8 @@ jobs:
 
       - name: Derive appropriate SHAs for base and head for `nx affected` commands
         uses: nrwl/nx-set-shas@v3
+        with:
+          main-branch-name: ${{needs.branch-info.outputs.base-branch}}
 
       - name: Setup Node 16.x
         uses: actions/setup-node@v3
@@ -35,6 +53,7 @@ jobs:
 
   test:
     name: Test
+    needs: [branch-info]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -45,6 +64,8 @@ jobs:
 
       - name: Derive appropriate SHAs for base and head for `nx affected` commands
         uses: nrwl/nx-set-shas@v3
+        with:
+          main-branch-name: ${{needs.branch-info.outputs.base-branch}}
 
       - name: Setup Node 16.x
         uses: actions/setup-node@v3
@@ -60,6 +81,7 @@ jobs:
 
   e2e:
     name: e2e
+    needs: [branch-info]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -70,6 +92,8 @@ jobs:
 
       - name: Derive appropriate SHAs for base and head for `nx affected` commands
         uses: nrwl/nx-set-shas@v3
+        with:
+          main-branch-name: ${{needs.branch-info.outputs.base-branch}}
 
       - name: Setup Node 16.x
         uses: actions/setup-node@v3

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "LaunchDarkly's design system",
   "scripts": {
     "build": "nx run-many --target=build --all --exclude=@launchpad-ui/remix",
-    "build:packages": "nx affected --target=build --base=origin/main --head=HEAD",
+    "build:packages": "nx affected --target=build",
     "build:transform": "nx run-many --target=build --projects=@launchpad-ui/tokens,@launchpad-ui/icons",
     "chromatic": "chromatic",
     "clean": "nx run-many --target=clean --all",
@@ -16,16 +16,16 @@
     "graph": "nx affected:graph",
     "lint": "eslint '**/*.{ts,tsx,js}' --ignore-pattern '/packages/' --ignore-pattern '/apps/'",
     "lint:ci": "pnpm build:transform && pnpm lint && pnpm lint:packages",
-    "lint:packages": "nx affected --target=lint --base=origin/main --head=HEAD",
+    "lint:packages": "nx affected --target=lint",
     "remix": "nx run-many --target=build --projects=@launchpad-ui/remix && pnpm --filter=\"remix\" start",
     "storybook": "pnpm build:transform && sb dev -p 3000",
     "storybook:build": "pnpm build:transform && sb build --quiet",
     "test": "pnpm build && vitest run --coverage",
-    "test:packages": "nx affected --target=test --base=origin/main --head=HEAD --exclude=@launchpad-ui/remix",
+    "test:packages": "nx affected --target=test --exclude=@launchpad-ui/remix",
     "test:ui": "vitest --ui",
     "test:watch": "vitest",
     "prepare": "husky install",
-    "release": "nx run-many --target=build --projects=@launchpad-ui/core && changeset publish"
+    "release": "nx affected --target=build --base=HEAD~1 --head=HEAD --exclude=@launchpad-ui/remix && changeset publish"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Previously the scripts were set with `main` as the base branch. Instead we can get the base branch info from GH and set it for `nrwl/nx-set-shas` for our verify jobs. Also updated the `release` script to be branch agnostic.