### PR TITLE
chore: ignore react-router-dom in renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,5 +13,6 @@
       "enabled": false
     }
   ],
-  "rangeStrategy": "bump"
+  "rangeStrategy": "bump",
+  "ignoreDeps": ["react-router-dom"]
 }


### PR DESCRIPTION
## Summary

Gonfalon is not ready for the 6.4 upgrade.