### PR TITLE
feat(icons): add plus-circle-fill and plus-circle-outline icons

### DIFF
--- a/.changeset/twelve-dogs-taste.md
+++ b/.changeset/twelve-dogs-taste.md
@@ -1,0 +1,6 @@
+---
+'@launchpad-ui/core': patch
+'@launchpad-ui/icons': patch
+---
+
+[Icons] Add `plus-circle-fill` and `plus-circle-outline`

--- a/packages/icons/icons/plus-circle-fill.svg
+++ b/packages/icons/icons/plus-circle-fill.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M17 13h-4v4h-2v-4H7v-2h4V7h2v4h4m-5-9a10 10 0 1 0 0 20 10 10 0 0 0 0-20Z" fill="#000"/>
+</svg>

--- a/packages/icons/icons/plus-circle-outline.svg
+++ b/packages/icons/icons/plus-circle-outline.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M12 20c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8Zm0-18a10 10 0 1 0 0 20 10 10 0 0 0 0-20Zm1 5h-2v4H7v2h4v4h2v-4h4v-2h-4V7Z" fill="#000"/>
+</svg>


### PR DESCRIPTION
## Summary

Adding plus circle icons provided by design

Contribution docs were 👍 