### PR TITLE
fix(modal): bump modal z-index

### DIFF
--- a/.changeset/tall-peas-remain.md
+++ b/.changeset/tall-peas-remain.md
@@ -1,0 +1,6 @@
+---
+'@launchpad-ui/modal': patch
+'@launchpad-ui/core': patch
+---
+
+[Modal] increase z-index

--- a/packages/modal/src/styles/Modal.css
+++ b/packages/modal/src/styles/Modal.css
@@ -15,7 +15,7 @@
 }
 
 .Modal {
-  z-index: 10000;
+  z-index: 30000;
   position: fixed;
   top: 0;
   right: 0;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7883,8 +7883,8 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
     dependencies:
-      JSONStream: 1.3.5
       is-text-path: 1.0.1
+      JSONStream: 1.3.5
       lodash: 4.17.21
       meow: 8.1.2
       split2: 3.2.2


### PR DESCRIPTION
## Summary

Bumping up the `z-index` of `Modal` in order to resolve an issue where the sticky header on the flag targeting page obstructs the CommandBar. 

<img width="1351" alt="screenshot of sticky header covering the CommandBar" src="https://user-images.githubusercontent.com/109114820/193341951-d74932c0-2889-4d61-951c-80581b8f55df.png">

The `z-index` of the `.Topbar` nav element needs to be greater than the `.ManagerControls.is-sticky` element, without obstructing drawer components. Currently, all these elements have the same `z-index`.

<img width="1322" alt="screenshot demonstrating modal that is covered by the top nav bar" src="https://user-images.githubusercontent.com/109114820/193342360-5911ff76-ba4b-4761-9d05-b51fcda71c60.png">

