### PR TITLE
fix: update lockfile after automated renovate updates

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -776,8 +776,8 @@ importers:
       '@launchpad-ui/button': link:../button
       '@launchpad-ui/icons': link:../icons
       '@launchpad-ui/tokens': link:../tokens
-      classix: 2.1.13
-      framer-motion: 7.4.0_biqbaboplfbrettd7655fr4n2y
+      classix: 2.1.16
+      framer-motion: 7.5.1_biqbaboplfbrettd7655fr4n2y
     devDependencies:
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
@@ -850,8 +850,8 @@ importers:
     dependencies:
       '@launchpad-ui/icons': link:../icons
       '@launchpad-ui/tokens': link:../tokens
-      classix: 2.1.13
-      framer-motion: 7.4.0_biqbaboplfbrettd7655fr4n2y
+      classix: 2.1.16
+      framer-motion: 7.5.1_biqbaboplfbrettd7655fr4n2y
     devDependencies:
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0


### PR DESCRIPTION
## Summary
This [renovatebot PR](https://github.com/launchdarkly/launchpad-ui/pull/452) resulted in a broken lockfile, this PR resolves issues.