### PR TITLE
fix(snackbar): style anchor tag hover state

### DIFF
--- a/.changeset/dirty-coats-attack.md
+++ b/.changeset/dirty-coats-attack.md
@@ -1,0 +1,6 @@
+---
+'@launchpad-ui/snackbar': patch
+'@launchpad-ui/core': patch
+---
+
+[Snackbar] style anchor tag hover

--- a/packages/snackbar/src/styles/Snackbar.module.css
+++ b/packages/snackbar/src/styles/Snackbar.module.css
@@ -36,18 +36,19 @@
 .Snackbar-content {
   flex-grow: 1;
 
-  & :global(a) {
-    color: var(--color-cyan-500);
-  }
-
   & .Snackbar-description,
-  & :global(a) {
+  & a {
     font-size: var(--osmo-font-size-small);
     font-weight: var(--font-weight-regular);
     line-height: 1.5;
   }
+
+  & a,
+  & a:hover {
+    color: var(--color-cyan-500);
+  }
 }
 
-.Snackbar-close:global(.Button):global(.Button--close) :global(svg) {
+.Snackbar-close:global(.Button):global(.Button--close) svg {
   fill: var(--color-gray-400);
 }


### PR DESCRIPTION
## Summary
<!-- What is changing and why? -->
One part of the solution to fix an issue in Gonfalon where we're seeing inconsistent link styles in snackbars.

The other part of the solution is actually using an anchor tag via the `asChild` Snackbar property in Gonfalon where this occurs. Currently it's a button element, and I think treating it as an anchor instead of styling all buttons inside snackbars is a safer bet.
## Screenshots (if appropriate):
<img width="352" alt="Screen Shot 2022-10-10 at 10 14 00 AM" src="https://user-images.githubusercontent.com/104940219/194932843-233d246b-01d0-4609-b821-8a204109f227.png">