### PR TITLE
fix(form): update formgroup component to use fieldset tag instead of div

### DIFF
--- a/.changeset/light-coins-marry.md
+++ b/.changeset/light-coins-marry.md
@@ -1,0 +1,6 @@
+---
+'@launchpad-ui/form': patch
+'@launchpad-ui/core': patch
+---
+
+[Form] Update FormGroup component to use `fieldset` tag instead of `div`

--- a/packages/form/src/FormGroup.tsx
+++ b/packages/form/src/FormGroup.tsx
@@ -4,7 +4,7 @@ import { cx } from 'classix';
 
 import styles from './styles/Form.module.css';
 
-type FormGroupProps = HTMLAttributes<HTMLDivElement> & {
+type FormGroupProps = HTMLAttributes<HTMLFieldSetElement> & {
   name?: string | string[];
   ignoreValidation?: boolean;
   isInvalid?: boolean;
@@ -29,9 +29,9 @@ const FormGroup = (props: FormGroupProps) => {
   );
 
   return (
-    <div className={classes} data-test-id={testId} {...rest}>
+    <fieldset className={classes} data-test-id={testId} {...rest}>
       {children}
-    </div>
+    </fieldset>
   );
 };
 

--- a/packages/form/src/styles/Form.module.css
+++ b/packages/form/src/styles/Form.module.css
@@ -1,5 +1,7 @@
 .formGroup {
   margin: 2rem 0;
+  padding: 0;
+  border: none;
 }
 
 /* The margin for .formGroup and the min-height of .form-fieldError

--- a/packages/form/stories/FormGroup.stories.tsx
+++ b/packages/form/stories/FormGroup.stories.tsx
@@ -1,0 +1,58 @@
+import type { ComponentStoryObj } from '@storybook/react';
+
+import { Label, RequiredAsterisk, TextField, FormHint, FormGroup } from '../src';
+
+export default {
+  component: FormGroup,
+  title: 'Components/Form/FormGroup',
+  description: 'A group of form fields.',
+  parameters: {
+    status: {
+      type: import.meta.env.PACKAGE_STATUS__FORM,
+    },
+  },
+  argTypes: {
+    className: {
+      table: {
+        category: 'Presentation',
+      },
+    },
+    children: {
+      table: {
+        category: 'Content',
+      },
+    },
+    isInvalid: {
+      table: {
+        category: 'Content',
+      },
+    },
+    ignoreValidation: {
+      table: {
+        category: 'Content',
+      },
+    },
+    name: {
+      table: {
+        category: 'DOM Attributes',
+      },
+    },
+  },
+};
+
+type Story = ComponentStoryObj<typeof FormGroup>;
+
+export const Default: Story = {
+  args: {
+    name: 'key',
+    children: (
+      <>
+        <Label htmlFor="key">
+          Key <RequiredAsterisk />
+        </Label>
+        <TextField id="key" name="key" />
+        <FormHint>Use this key in your code.</FormHint>
+      </>
+    ),
+  },
+};

--- a/packages/form/stories/RadioGroup.stories.tsx
+++ b/packages/form/stories/RadioGroup.stories.tsx
@@ -5,7 +5,7 @@ import { RadioGroup, Radio, Label } from '../src';
 export default {
   component: RadioGroup,
   title: 'Components/Form/RadioGroup',
-  description: 'A radio button group allows the user to select one of a set of options."',
+  description: 'A radio button group allows the user to select one of a set of options.',
   parameters: {
     status: {
       type: import.meta.env.PACKAGE_STATUS__FORM,


### PR DESCRIPTION
## Summary
A fieldset is semantically correct for the use case and is more accessible. Visually, it looks good after overriding a few browser default styles, and it behaves the same as a div.

I noticed we're targeting .FormGroup a lot in our app and I'd like to be able to just target a semantic html tag instead of applying a custom class.