### PR TITLE
ci: address GH actions warnings

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -10,7 +10,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v2.2.1
+      - uses: pnpm/action-setup@v2
 
       - name: Setup Node 16.x
         uses: actions/setup-node@v3

--- a/.github/workflows/package-size.yml
+++ b/.github/workflows/package-size.yml
@@ -11,7 +11,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v2.2.1
+      - uses: pnpm/action-setup@v2
 
       - name: Setup Node 16.x
         uses: actions/setup-node@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
           # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v2.2.1
+      - uses: pnpm/action-setup@v2
 
       - name: Derive appropriate SHAs for base and head for `nx affected` commands
         uses: nrwl/nx-set-shas@v3

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -16,12 +16,12 @@ jobs:
         id: get-base-branch
         run: |
           if [[ "${{github.event.pull_request.base.ref}}" != "" ]]; then
-            echo "::set-output name=branch::${{github.event.pull_request.base.ref}}"
+            echo "BRANCH=${{github.event.pull_request.base.ref}}" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=branch::main"
+            echo "BRANCH=main" >> $GITHUB_OUTPUT
           fi
     outputs:
-      base-branch: ${{ steps.get-base-branch.outputs.branch }}
+      base-branch: ${{ steps.get-base-branch.outputs.BRANCH }}
 
   lint:
     name: Lint
@@ -32,7 +32,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v2.2.1
+      - uses: pnpm/action-setup@v2
 
       - name: Derive appropriate SHAs for base and head for `nx affected` commands
         uses: nrwl/nx-set-shas@v3
@@ -60,7 +60,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v2.2.1
+      - uses: pnpm/action-setup@v2
 
       - name: Derive appropriate SHAs for base and head for `nx affected` commands
         uses: nrwl/nx-set-shas@v3
@@ -88,7 +88,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v2.2.1
+      - uses: pnpm/action-setup@v2
 
       - name: Derive appropriate SHAs for base and head for `nx affected` commands
         uses: nrwl/nx-set-shas@v3
@@ -107,14 +107,14 @@ jobs:
       - name: Get Cypress Version
         id: get-version
         run: |
-          echo "::set-output name=version::$(pnpm cypress version --component package)"
+          echo "VERSION=$(pnpm cypress version --component package)" >> $GITHUB_OUTPUT
         shell: bash
 
       - name: Cache Cypress Binary
         uses: actions/cache@v3
         with:
           path: ~/.cache/Cypress
-          key: cypress-${{ runner.os }}-cypress-${{ steps.get-version.outputs.version }}
+          key: cypress-${{ runner.os }}-cypress-${{ steps.get-version.outputs.VERSION }}
           restore-keys: |
             cypress-${{ runner.os }}-cypress-
 
@@ -129,7 +129,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v2.2.1
+      - uses: pnpm/action-setup@v2
 
       - name: Derive appropriate SHAs for base and head for `nx affected` commands
         uses: nrwl/nx-set-shas@v3
@@ -146,14 +146,14 @@ jobs:
       - name: Get Cypress Version
         id: get-version
         run: |
-          echo "::set-output name=version::$(pnpm cypress version --component package)"
+          echo "VERSION=$(pnpm cypress version --component package)" >> $GITHUB_OUTPUT
         shell: bash
 
       - name: Cache Cypress Binary
         uses: actions/cache@v3
         with:
           path: ~/.cache/Cypress
-          key: cypress-${{ runner.os }}-cypress-${{ steps.get-version.outputs.version }}
+          key: cypress-${{ runner.os }}-cypress-${{ steps.get-version.outputs.VERSION }}
           restore-keys: |
             cypress-${{ runner.os }}-cypress-
 


### PR DESCRIPTION
## Summary

Address the warnings from [latest runs](https://github.com/launchdarkly/launchpad-ui/actions/runs/3284336594) related to [set-output](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/).