### PR TITLE
fix(alert,clipboard,popover,progress-bubbles,tooltip): remove unneeded global psuedoclasses

### DIFF
--- a/.changeset/silver-games-vanish.md
+++ b/.changeset/silver-games-vanish.md
@@ -1,0 +1,14 @@
+---
+'@launchpad-ui/alert': patch
+'@launchpad-ui/clipboard': patch
+'@launchpad-ui/popover': patch
+'@launchpad-ui/progress-bubbles': patch
+'@launchpad-ui/tooltip': patch
+'@launchpad-ui/core': patch
+---
+
+[Alert] Remove unneeded global pseudoclasses
+[Clipboard] Remove unneeded global pseudoclasses
+[Popover] Remove unneeded global pseudoclasses
+[ProgressBubbles] Remove unneeded global pseudoclasses
+[Tooltip] Remove unneeded global pseudoclasses

--- a/packages/alert/src/styles/Alert.module.css
+++ b/packages/alert/src/styles/Alert.module.css
@@ -106,19 +106,19 @@
 
 /* Alert kind variants */
 
-.Alert.Alert--info .Alert-icon :global(svg) {
+.Alert.Alert--info .Alert-icon svg {
   fill: var(--reskin-info-blue-base);
 }
 
-.Alert.Alert--success .Alert-icon :global(svg) {
+.Alert.Alert--success .Alert-icon svg {
   fill: var(--reskin-success-green-base);
 }
 
-.Alert.Alert--warning .Alert-icon :global(svg) {
+.Alert.Alert--warning .Alert-icon svg {
   fill: var(--reskin-warn-gold-base);
 }
 
-.Alert.Alert--error .Alert-icon :global(svg) > :global(path) {
+.Alert.Alert--error .Alert-icon svg > path {
   fill: var(--reskin-error-red-base);
 }
 
@@ -177,7 +177,7 @@
   }
 }
 
-.Alert-content :global(ul) {
+.Alert-content ul {
   margin: 0 0 0.5em;
 }
 
@@ -185,8 +185,8 @@
   margin-bottom: 0;
 }
 
-.Alert-content :global(p),
-.Alert :global(ul) {
+.Alert-content p,
+.Alert ul {
   list-style-position: outside;
   margin: 0 0 0.5em;
 }

--- a/packages/alert/src/styles/CollapsibleAlert.module.css
+++ b/packages/alert/src/styles/CollapsibleAlert.module.css
@@ -78,7 +78,7 @@ https://www.scottohara.me/blog/2017/04/14/inclusively-hidden.html
   transition: visibility 0.5s, max-height 0.5s, opacity 0.5s, transform 0.5s;
   transition-timing-function: ease-in-out;
 
-  & > :global(a) {
+  & > a {
     color: var(--CollapsibleAlert-color-link);
 
     &:hover {
@@ -117,7 +117,7 @@ https://www.scottohara.me/blog/2017/04/14/inclusively-hidden.html
 }
 
 /* animate content container when button toggled */
-:global([aria-expanded='true']) + .CollapsibleAlert--contentContainer {
+[aria-expanded='true'] + .CollapsibleAlert--contentContainer {
   margin-top: 0.4rem;
   visibility: visible;
   max-height: 31.25rem;

--- a/packages/clipboard/src/styles/CopyToClipboard.module.css
+++ b/packages/clipboard/src/styles/CopyToClipboard.module.css
@@ -2,7 +2,7 @@
   position: relative;
 }
 
-.Clipboard-checkmark :global(svg) {
+.Clipboard-checkmark svg {
   fill: var(--color-system-green-500);
 }
 

--- a/packages/popover/src/styles/Popover.module.css
+++ b/packages/popover/src/styles/Popover.module.css
@@ -17,7 +17,7 @@
   display: inline-block;
 }
 
-.Popover-target--disabled > :global([disabled]) {
+.Popover-target--disabled > [disabled] {
   pointer-events: none;
 }
 

--- a/packages/progress-bubbles/src/styles/ProgressBubbles.module.css
+++ b/packages/progress-bubbles/src/styles/ProgressBubbles.module.css
@@ -89,34 +89,34 @@
   z-index: 1;
 }
 
-:global(div).ProgressBubbles-icon--current {
+div.ProgressBubbles-icon--current {
   border: var(--border-width-2) solid var(--color-system-green-700);
 }
 
-.ProgressBubbles-icon--pending :global(svg) {
+.ProgressBubbles-icon--pending svg {
   fill: var(--color-white);
 }
 
-:global(div).ProgressBubbles-icon--current :global(svg) {
+div.ProgressBubbles-icon--current svg {
   fill: var(--color-system-green-700);
 }
 
-.ProgressBubbles-icon :global(.Icon svg) {
+.ProgressBubbles-icon :global(.Icon) svg {
   fill: var(--color-white);
   height: 1.6rem;
   width: 1.6rem;
 }
 
-:global(div).ProgressBubbles-icon--pending {
+div.ProgressBubbles-icon--pending {
   background-color: var(--color-gray-200);
 }
 
-:global(div).ProgressBubbles-icon--warning {
+div.ProgressBubbles-icon--warning {
   background-color: inherit;
   border: none;
 }
 
-:global(div).ProgressBubbles-icon--warning :global(.Icon svg) {
+div.ProgressBubbles-icon--warning :global(.Icon) svg {
   fill: hsl(29.2 100% 58.4%);
   height: 3.6rem;
   width: 3.6rem;
@@ -149,7 +149,7 @@
   white-space: normal;
 }
 
-:global(:root[data-theme]) {
+:root[data-theme] {
   & .ProgressBubbles-label {
     color: var(--color-gray-700);
   }

--- a/packages/tooltip/src/styles/Tooltip.module.css
+++ b/packages/tooltip/src/styles/Tooltip.module.css
@@ -2,7 +2,7 @@
   z-index: 30000;
 }
 
-:global([class^='_Popover-content_']).Tooltip-popover-content {
+[class^='_Popover-content_'].Tooltip-popover-content {
   font-size: 1.3rem;
   background: var(--color-text);
   color: var(--color-text-inverse);
@@ -13,7 +13,7 @@
     0 4px 4px hsl(0 0% 15.7% / 0.08);
 }
 
-:global([class^='_Popover-content_']).Tooltip-popover-content :global(kbd) {
+[class^='_Popover-content_'].Tooltip-popover-content kbd {
   color: var(--color-gray-100);
   background-color: var(--color-black-100);
   border: 0.1rem solid var(--color-gray-700);


### PR DESCRIPTION
## Summary
The `:global` pseudoselector is only necessary when targeting classnames or IDs. It won't generate a hashed value for element selectors, so we can remove there.