### PR TITLE
fix(modal): make has-modal class globally accessible

### DIFF
--- a/.changeset/tall-lies-explain.md
+++ b/.changeset/tall-lies-explain.md
@@ -1,0 +1,6 @@
+---
+'@launchpad-ui/modal': patch
+'@launchpad-ui/core': patch
+---
+
+[Modal] Make has-modal class globally accessible

--- a/packages/modal/src/styles/Modal.module.css
+++ b/packages/modal/src/styles/Modal.module.css
@@ -10,7 +10,7 @@
   }
 }
 
-.has-modal {
+:global(.has-modal) {
   overflow: hidden;
 }
 


### PR DESCRIPTION
This is used throughout the app and design system.