### PR TITLE
fix(modal): specify only direct children of body when applying margin styles

### DIFF
--- a/.changeset/large-seals-bake.md
+++ b/.changeset/large-seals-bake.md
@@ -1,0 +1,6 @@
+---
+'@launchpad-ui/modal': patch
+'@launchpad-ui/core': patch
+---
+
+[Modal] Specify only direct children of body to receive margin styles

--- a/packages/modal/src/styles/Modal.module.css
+++ b/packages/modal/src/styles/Modal.module.css
@@ -89,11 +89,11 @@
   color: var(--lp-color-text);
   overflow-y: auto;
 
-  *:first-child {
+  > *:first-child {
     margin-top: 0;
   }
 
-  *:last-child {
+  > *:last-child {
     margin-bottom: 0;
   }
 }


### PR DESCRIPTION
This selector was previously targeting any first/last children of any node depth.