### PR TITLE
ci(circle): creating CircleCI config for SBOM generation/license policy check jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,14 @@
+version: 2.1
+
+orbs:
+  dependency-scan: launchdarkly/dependency-scan-org@1.0.0
+
+workflows:
+  dependency_license_check:
+    jobs:
+      - dependency-scan/generate-node-sbom
+      - dependency-scan/get-license-policy
+      - dependency-scan/evaluate-policy:
+          requires:
+            - dependency-scan/generate-node-sbom
+            - dependency-scan/get-license-policy


### PR DESCRIPTION
## Summary

Creating a CircleCI config to run the following jobs:
- Generate Node software bill of materials (SBOM)
- Evaluate SBOM against license policy to ensure repo has no license issues 

Part of https://launchdarkly.atlassian.net/browse/SEC-2844 and SDR https://launchdarkly.atlassian.net/wiki/spaces/SEC/pages/2072579730/Launchpad+npm+packages+security+design+review

Helps satisfy our Github security standard: https://launchdarkly.atlassian.net/wiki/spaces/SEC/pages/1997013332 

I think having this config file is a prereq for setting up the project in CircleCI; once this is merged we should be able to initialize/configure the CircleCI project and include these jobs as part of the build checks. 

## Screenshots (if appropriate):

<!-- Are there any visual changes that would be helpful to the reviewer to see? -->

## Testing approaches

<!-- How are these changes tested? -->
