### PR TITLE
ci(circle): updating sbom generation orb version to support pnpm workspaces

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  dependency-scan: launchdarkly/dependency-scan-orb@dev:2ddb0ad
+  dependency-scan: launchdarkly/dependency-scan-orb@1.3.0
 
 workflows:
   dependency_license_check:


### PR DESCRIPTION
## Summary

`s/org/orb`

After testing out the CircleCI SBOM generation jobs, the dependency scan orb needed a bit of updating to support pnpm node workspaces (old version only supports yarn-managed workspaces). 

That's been updated as part of 1.3.0, and so this job should be generating the SBOM properly for the launchpad-ui repo and applying the license checks.

## Screenshots (if appropriate):

<!-- Are there any visual changes that would be helpful to the reviewer to see? -->

## Testing approaches

<!-- How are these changes tested? -->
