### PR TITLE
refactor(modal): update modal layout logic

### DIFF
--- a/packages/modal/src/AbsoluteModalFooter.tsx
+++ b/packages/modal/src/AbsoluteModalFooter.tsx
@@ -1,0 +1,17 @@
+import type { ModalFooterProps } from './ModalFooter';
+
+import { cx } from 'classix';
+import { useRef } from 'react';
+
+import { ModalFooter } from './ModalFooter';
+import styles from './styles/Modal.module.css';
+import { useAbsoluteFooter } from './utils';
+
+const AbsoluteModalFooter = ({ className, ...rest }: ModalFooterProps) => {
+  const ref = useRef<HTMLDivElement>(null);
+  useAbsoluteFooter(ref);
+
+  return <ModalFooter ref={ref} className={cx(className, styles.absoluteFooter)} {...rest} />;
+};
+
+export { AbsoluteModalFooter };

--- a/packages/modal/src/styles/Modal.module.css
+++ b/packages/modal/src/styles/Modal.module.css
@@ -104,6 +104,14 @@
   justify-content: flex-end;
 }
 
+.footer.absoluteFooter {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  padding: 1.6rem;
+}
+
 @media screen and (max-width: 429px) {
   .footerActions {
     width: 100%;
@@ -129,6 +137,10 @@
 
   .footer {
     padding: 2.4rem 2.4rem 0;
+  }
+
+  .footer.absoluteFooter {
+    padding: 2.4rem;
   }
 
   .body {

--- a/packages/modal/src/utils.ts
+++ b/packages/modal/src/utils.ts
@@ -48,4 +48,31 @@ const useOverflowY = (ref: MutableRefObject<HTMLDivElement | null>) => {
   }, [ref, observer]);
 };
 
-export { useOverflowY, useMediaQuery };
+const useAbsoluteFooter = (ref: MutableRefObject<HTMLDivElement | null>) => {
+  const observer = useRef(
+    new ResizeObserver((entries) => {
+      const target = entries[0].target as HTMLDivElement;
+      const modal = target.closest<HTMLDivElement>('[role=dialog]');
+      if (modal) {
+        modal.style.paddingBottom = `${target.clientHeight}px`;
+      }
+    })
+  );
+
+  useEffect(() => {
+    const currentObserver = observer.current;
+    const { current } = ref;
+
+    if (current) {
+      currentObserver.observe(current);
+    }
+
+    return () => {
+      if (current) {
+        currentObserver.unobserve(current);
+      }
+    };
+  }, [ref, observer]);
+};
+
+export { useOverflowY, useMediaQuery, useAbsoluteFooter };

--- a/packages/modal/stories/Modal.stories.tsx
+++ b/packages/modal/stories/Modal.stories.tsx
@@ -5,9 +5,11 @@ import { Button } from '@launchpad-ui/button';
 import { Check, ClickMetric } from '@launchpad-ui/icons';
 import { useState } from '@storybook/client-api';
 import { userEvent, within } from '@storybook/testing-library';
+import { useRef } from 'react';
 
 import { sleep, REACT_NODE_TYPE_DOCS } from '../../../.storybook/utils';
 import { Modal, ModalBody, ModalFooter } from '../src';
+import { AbsoluteModalFooter } from '../src/AbsoluteModalFooter';
 
 export default {
   component: Modal,
@@ -208,7 +210,8 @@ export const KitchenSink: Story = {
         status="warning"
         description={
           <>
-            <i>This is a</i> <code>ReactNode</code> <strong>description</strong>
+            This example shows how the modal responds to passing custom components that use HTML.
+            This is useful for <i>doing</i> <strong>things like this</strong>.
           </>
         }
         size="normal"
@@ -240,13 +243,24 @@ export const TallBody: Story = {
   render: () => {
     const [showLess, setShowLess] = useState(false);
     return (
-      <Modal title="Title">
-        <ModalBody>
-          <p>
+      <Modal
+        title="Title"
+        description={
+          <>
             This example is meant to illustrate how the modal overflows when there is a lot of text.
             You can make your viewport smaller to get a better idea. Lorem ipsum dolor sit amet,
             consectetur adipiscing elit. Ut malesuada ultricies mauris, in gravida nibh vehicula
             vel.
+          </>
+        }
+      >
+        <ModalBody>
+          <p>
+            Phasellus vulputate varius orci, ut auctor mi pretium a. Duis vestibulum sagittis nulla
+            sit amet varius. Donec suscipit mi dui, eu ultrices felis gravida non. Proin vitae enim
+            velit. Nunc luctus suscipit quam, a bibendum metus malesuada in. Mauris eleifend turpis
+            vitae posuere rutrum. Mauris sit amet tortor quam. Mauris ac lacinia nibh, in egestas
+            ligula. Donec vel leo a metus egestas venenatis id feugiat augue. vel.
           </p>
 
           {!showLess && (
@@ -308,17 +322,78 @@ export const TallBody: Story = {
 
 export const WithForm: Story = {
   render: () => {
+    const inputRef = useRef<HTMLInputElement>(null);
+
     return (
       <Modal
         title="Title"
         description="This example shows how the modal works when a form wraps the body and footer."
       >
-        <form>
-          <ModalBody>
-            <input type="text" />
-          </ModalBody>
-          <ModalFooter primaryButton={<Button kind="primary">Submit</Button>} />
-        </form>
+        <ModalBody>
+          <p>Try out this form:</p>
+          <form
+            id="my-form"
+            onSubmit={(event) => {
+              if (inputRef.current) {
+                alert('A name was submitted: ' + inputRef.current.value);
+              }
+
+              event.preventDefault();
+            }}
+          >
+            <label htmlFor="name">
+              Your Name
+              <input type="text" name="name" id="name" ref={inputRef} />
+            </label>
+          </form>
+        </ModalBody>
+        <ModalFooter
+          primaryButton={
+            <Button type="submit" form="my-form">
+              Submit
+            </Button>
+          }
+        />
+      </Modal>
+    );
+  },
+  parameters: { docs: { disable: true } },
+};
+
+export const WithAbsolutelyPositionedFooter: Story = {
+  render: () => {
+    const inputRef = useRef<HTMLInputElement>(null);
+
+    return (
+      <Modal
+        title="Title"
+        description={
+          <>
+            In the case of forms, it&apos;s possible you need the modal body and footer contents to
+            be wrapped in a form. In this case, you lose the default positioning with the normal
+            implementation. In these cases, you can absolutely position the footer so it can be
+            nested within the modal body.
+          </>
+        }
+      >
+        <ModalBody>
+          <p>Try out this form:</p>
+          <form
+            onSubmit={(event) => {
+              if (inputRef.current) {
+                alert('A name was submitted: ' + inputRef.current.value);
+              }
+
+              event.preventDefault();
+            }}
+          >
+            <label htmlFor="name">
+              Your Name
+              <input type="text" name="name" id="name" ref={inputRef} />
+            </label>
+            <AbsoluteModalFooter primaryButton={<Button type="submit">Submit</Button>} />
+          </form>
+        </ModalBody>
       </Modal>
     );
   },


### PR DESCRIPTION
## Summary
Problem: many modals in the app use forms which require footer buttons to be nested within a form. As I've been doing the modal migration, I've decided this is just a reality of how people will need to build components, so these adjustments remove the need for direct parent-child relationship between the modal and the modal subcomponents, unlocking the ability to use the modal components consistently with forms as shown by [these two new stories](https://github.com/launchdarkly/launchpad-ui/blob/94c3ac39273220ebdccded34d642baf2a7a50619/packages/modal/stories/Modal.stories.tsx#L323)

Considerations:
1. Does this mean we can remove the `AbsoluteModalFooter` component? Not exactly... some forms in the app still need `ModalFooter` to be a child of `ModalBody`, but in many cases we can refactor these components to make them siblings with these changes.
2. Padding between subcomponents should look visually correct in these cases: both body and footer are present, just body is present, or just footer is present.
