### PR TITLE
docs: adding SECURITY.md security policy to Github repo for vulnerability reporting instructions

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,6 @@
+#Reporting and Fixing Security Issues
+
+Please report all security issues to the LaunchDarkly security team by submitting a bug bounty report to our [HackerOne program](https://hackerone.com/launchdarkly?type=team). LaunchDarkly will triage and address all valid security issues following the response targets defined in our program policy. Valid security issues may be eligible for a bounty.
+
+Please do not open issues or pull requests for security issues. This makes the problem immediately visible to everyone, including potentially malicious actors.
+


### PR DESCRIPTION
## Summary

Adding SECURITY.md to address Github security standard: https://launchdarkly.atlassian.net/wiki/spaces/SEC/pages/1997013332/GitHub+security+standard#GitHub-Security-Policy

More info on Github security policies: https://docs.github.com/en/code-security/getting-started/adding-a-security-policy-to-your-repository

## Screenshots (if appropriate):

<!-- Are there any visual changes that would be helpful to the reviewer to see? -->

## Testing approaches

<!-- How are these changes tested? -->
