### PR TITLE
chore: add Apache 2.0 license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,13 @@
+Copyright 2022 Catamorphic, Co.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,5 @@
-#Reporting and Fixing Security Issues
+# Reporting and Fixing Security Issues
 
 Please report all security issues to the LaunchDarkly security team by submitting a bug bounty report to our [HackerOne program](https://hackerone.com/launchdarkly?type=team). LaunchDarkly will triage and address all valid security issues following the response targets defined in our program policy. Valid security issues may be eligible for a bounty.
 
 Please do not open issues or pull requests for security issues. This makes the problem immediately visible to everyone, including potentially malicious actors.
-


### PR DESCRIPTION
## Summary

Add an Apache 2.0 license as instructed in our open source policy.