### PR TITLE
fix(modal): move header props to standalone component

### DIFF
--- a/.changeset/nervous-pillows-brush.md
+++ b/.changeset/nervous-pillows-brush.md
@@ -1,0 +1,6 @@
+---
+'@launchpad-ui/modal': minor
+'@launchpad-ui/core': minor
+---
+
+[Modal] Move header props to standalone component

--- a/apps/remix/app/routes/components/modal.tsx
+++ b/apps/remix/app/routes/components/modal.tsx
@@ -1,4 +1,4 @@
-import { Button, Modal, ModalBody, ModalFooter } from '@launchpad-ui/core';
+import { Button, Modal, ModalBody, ModalFooter, ModalHeader } from '@launchpad-ui/core';
 import { useState } from 'react';
 
 export default function Index() {
@@ -7,7 +7,8 @@ export default function Index() {
   return show ? (
     <>
       {button}
-      <Modal onCancel={() => setShow(!show)} title="Title">
+      <Modal onCancel={() => setShow(!show)}>
+        <ModalHeader title="Title" />
         <ModalBody>
           <p>Body text</p>
         </ModalBody>

--- a/packages/modal/__tests__/Modal.cy.tsx
+++ b/packages/modal/__tests__/Modal.cy.tsx
@@ -1,9 +1,10 @@
-import { Modal, ModalBody, ModalFooter } from '../src';
+import { Modal, ModalBody, ModalFooter, ModalHeader } from '../src';
 
 describe('Modal', () => {
   it('renders', () => {
     cy.mount(
-      <Modal title="Title">
+      <Modal>
+        <ModalHeader title="Title" />
         <ModalBody>Body</ModalBody>
         <ModalFooter primaryButton={<button>Click me</button>} />
       </Modal>
@@ -13,7 +14,8 @@ describe('Modal', () => {
 
   it('is accessible', () => {
     cy.mount(
-      <Modal title="Title" withCloseButton>
+      <Modal>
+        <ModalHeader title="Title" withCloseButton />
         <ModalBody>Body</ModalBody>
         <ModalFooter primaryButton={<button>Click me</button>} />
       </Modal>
@@ -24,7 +26,8 @@ describe('Modal', () => {
   it('calls onCancel when escape key is pressed', () => {
     const onCancelSpy = cy.spy().as('onCancelSpy');
     cy.mount(
-      <Modal title="Title" onCancel={onCancelSpy}>
+      <Modal onCancel={onCancelSpy}>
+        <ModalHeader title="Title" />
         <ModalBody>Body</ModalBody>
         <ModalFooter primaryButton={<button>Click me</button>} />
       </Modal>

--- a/packages/modal/__tests__/Modal.spec.tsx
+++ b/packages/modal/__tests__/Modal.spec.tsx
@@ -1,7 +1,7 @@
 import { it, expect, describe, vi } from 'vitest';
 
 import { render, screen, userEvent } from '../../../test/utils';
-import { Modal, ModalBody, ModalFooter } from '../src';
+import { Modal, ModalBody, ModalFooter, ModalHeader } from '../src';
 
 globalThis.matchMedia = vi.fn().mockReturnValue({
   matches: true,
@@ -16,7 +16,8 @@ globalThis.matchMedia = vi.fn().mockReturnValue({
 describe('Modal', () => {
   it('renders', async () => {
     render(
-      <Modal title="a">
+      <Modal>
+        <ModalHeader title="Title" />
         <ModalBody>Body</ModalBody>
         <ModalFooter primaryButton={<button>Click me</button>} />
       </Modal>
@@ -27,11 +28,7 @@ describe('Modal', () => {
   it('calls onCancel when escape key is pressed', async () => {
     const spy = vi.fn();
     const user = userEvent.setup();
-    render(
-      <Modal title="a" onCancel={spy}>
-        Body
-      </Modal>
-    );
+    render(<Modal onCancel={spy}>Body</Modal>);
 
     await user.keyboard('{Escape}');
 
@@ -41,11 +38,7 @@ describe('Modal', () => {
   it('calls onReady when modal is rendered', async () => {
     const spy = vi.fn();
 
-    render(
-      <Modal title="a" onReady={spy}>
-        Body
-      </Modal>
-    );
+    render(<Modal onReady={spy}>Body</Modal>);
 
     expect(spy).toHaveBeenCalledTimes(1);
   });
@@ -53,11 +46,7 @@ describe('Modal', () => {
   it('calls onCancel when overlay is clicked', async () => {
     const spy = vi.fn();
     const user = userEvent.setup();
-    render(
-      <Modal title="a" onCancel={spy}>
-        Body
-      </Modal>
-    );
+    render(<Modal onCancel={spy}>Body</Modal>);
 
     const overlay = screen.getByTestId('modal-overlay');
     await user.click(overlay);
@@ -69,7 +58,8 @@ describe('Modal', () => {
     const spy = vi.fn();
     const user = userEvent.setup();
     render(
-      <Modal title="a" onCancel={spy}>
+      <Modal onCancel={spy}>
+        <ModalHeader title="Title" />
         Body
       </Modal>
     );
@@ -82,7 +72,8 @@ describe('Modal', () => {
 
   it('renders header icon when warning status is passed', async () => {
     render(
-      <Modal title="a" status="warning">
+      <Modal status="warning">
+        <ModalHeader title="Title" />
         Body
       </Modal>
     );
@@ -94,7 +85,8 @@ describe('Modal', () => {
 
   it('renders required field when prop is passed', async () => {
     render(
-      <Modal title="a" hasRequiredField>
+      <Modal>
+        <ModalHeader title="Title" hasRequiredField />
         Body
       </Modal>
     );
@@ -108,7 +100,8 @@ describe('Modal', () => {
     const content = 'test';
 
     render(
-      <Modal title="a" description={content}>
+      <Modal>
+        <ModalHeader title="Title" description={content} />
         Body
       </Modal>
     );

--- a/packages/modal/src/Modal.tsx
+++ b/packages/modal/src/Modal.tsx
@@ -3,53 +3,43 @@ import type { ReactNode } from 'react';
 import { Portal } from '@launchpad-ui/portal';
 
 import { ModalContainer } from './ModalContainer';
-import { ModalHeader } from './ModalHeader';
+import { ModalContext } from './context';
 
 type ModalProps = {
   children: ReactNode;
   className?: string;
-  withCloseButton?: boolean;
   cancelWithOverlayClick?: boolean;
   onReady?(): void;
   onCancel?(): void;
-  size?: 'small' | 'normal';
   status?: 'warning';
-  hasRequiredField?: boolean;
-  title: ReactNode;
-  description?: ReactNode;
+  size?: 'small' | 'normal';
   'data-test-id'?: string;
 };
 
 const Modal = ({
   className,
-  withCloseButton = true,
+  onCancel,
   cancelWithOverlayClick = true,
   children,
   onReady,
-  onCancel,
-  size,
   status,
-  title,
-  hasRequiredField,
-  description,
+  size,
   'data-test-id': testId = 'modal',
 }: ModalProps) => {
   return (
     <Portal>
-      <ModalContainer
-        onCancel={onCancel}
-        onReady={onReady}
-        cancelWithOverlayClick={cancelWithOverlayClick}
-        size={size}
-        className={className}
-        data-test-id={testId}
-      >
-        <ModalHeader
-          {...{ withCloseButton, title, status, onCancel, description, hasRequiredField }}
-        />
-
-        {children}
-      </ModalContainer>
+      <ModalContext.Provider value={{ onCancel, status }}>
+        <ModalContainer
+          onCancel={onCancel}
+          onReady={onReady}
+          cancelWithOverlayClick={cancelWithOverlayClick}
+          size={size}
+          className={className}
+          data-test-id={testId}
+        >
+          {children}
+        </ModalContainer>
+      </ModalContext.Provider>
     </Portal>
   );
 };

--- a/packages/modal/src/ModalHeader.tsx
+++ b/packages/modal/src/ModalHeader.tsx
@@ -1,54 +1,64 @@
-import type { ModalProps } from './Modal';
+import type { ReactNode } from 'react';
 
 import { IconButton } from '@launchpad-ui/button';
 import { Close, Warning } from '@launchpad-ui/icons';
+import cx from 'classix';
 
 import { MODAL_LABELLED_BY } from './constants';
+import { useModalContext } from './context';
 import styles from './styles/Modal.module.css';
 
-type ModalHeaderProps = Pick<
-  ModalProps,
-  'withCloseButton' | 'onCancel' | 'status' | 'hasRequiredField' | 'title' | 'description'
->;
+type ModalHeaderProps = {
+  className?: string;
+  withCloseButton?: boolean;
+  hasRequiredField?: boolean;
+  title: ReactNode;
+  description?: ReactNode;
+  'data-test-id'?: string;
+};
 
 const ModalHeader = ({
   withCloseButton = true,
-  onCancel,
-  status,
   title,
   hasRequiredField,
   description,
-}: ModalHeaderProps) => (
-  <div className={styles.header}>
-    <div className={styles.headerMain}>
-      {status === 'warning' && (
-        <Warning data-test-id="modal-header-icon" size="medium" className={styles.headerIcon} />
+  className,
+  'data-test-id': testId = 'modal-header',
+}: ModalHeaderProps) => {
+  const { onCancel, status } = useModalContext();
+
+  return (
+    <div className={cx(styles.header, className)} data-test-id={testId}>
+      <div className={styles.headerMain}>
+        {status === 'warning' && (
+          <Warning data-test-id="modal-header-icon" size="medium" className={styles.headerIcon} />
+        )}
+        <h2 id={MODAL_LABELLED_BY} data-test-id="modal-title" className={styles.title}>
+          {title}
+        </h2>
+        {withCloseButton && (
+          <IconButton
+            aria-label="close"
+            icon={<Close size="medium" />}
+            className={styles.closeButton}
+            onClick={onCancel}
+            data-test-id="modal-close-button"
+          />
+        )}
+      </div>
+      {description && (
+        <p className={styles.headerDescription} data-test-id="modal-description">
+          {description}
+        </p>
       )}
-      <h2 id={MODAL_LABELLED_BY} data-test-id="modal-title" className={styles.title}>
-        {title}
-      </h2>
-      {withCloseButton && (
-        <IconButton
-          aria-label="close"
-          icon={<Close size="medium" />}
-          className={styles.closeButton}
-          onClick={onCancel}
-          data-test-id="modal-close-button"
-        />
+      {hasRequiredField && (
+        <div className={styles.headerRequiredFields} data-test-id="modal-required-field">
+          <span className={styles.requiredAsterisk}>*</span> Required field
+        </div>
       )}
     </div>
-    {description && (
-      <p className={styles.headerDescription} data-test-id="modal-description">
-        {description}
-      </p>
-    )}
-    {hasRequiredField && (
-      <div className={styles.headerRequiredFields} data-test-id="modal-required-field">
-        <span className={styles.requiredAsterisk}>*</span> Required field
-      </div>
-    )}
-  </div>
-);
+  );
+};
 
 export { ModalHeader };
 export type { ModalHeaderProps };

--- a/packages/modal/src/context.ts
+++ b/packages/modal/src/context.ts
@@ -1,0 +1,26 @@
+import type { ModalProps } from './Modal';
+
+import { createContext, useContext } from 'react';
+
+type ModalContextState = {
+  onCancel: ModalProps['onCancel'];
+  status: ModalProps['status'];
+};
+
+const ModalContext = createContext<ModalContextState>({
+  onCancel: undefined,
+  status: undefined,
+});
+
+const useModalContext = () => {
+  const context = useContext(ModalContext);
+
+  if (context === undefined) {
+    throw new Error('useModalContext must be used within a ModalContext provider');
+  }
+
+  return context;
+};
+
+export { ModalContext, useModalContext };
+export type { ModalContextState };

--- a/packages/modal/src/index.ts
+++ b/packages/modal/src/index.ts
@@ -2,6 +2,8 @@ export type { ModalProps } from './Modal';
 export { Modal } from './Modal';
 export type { ModalBodyProps } from './ModalBody';
 export { ModalBody } from './ModalBody';
+export type { ModalHeaderProps } from './ModalHeader';
+export { ModalHeader } from './ModalHeader';
 export type { ModalFooterProps } from './ModalFooter';
 export { ModalFooter } from './ModalFooter';
 export { AbsoluteModalFooter } from './AbsoluteModalFooter';

--- a/packages/modal/stories/Modal.stories.tsx
+++ b/packages/modal/stories/Modal.stories.tsx
@@ -8,7 +8,7 @@ import { userEvent, within } from '@storybook/testing-library';
 import { useRef } from 'react';
 
 import { sleep, REACT_NODE_TYPE_DOCS } from '../../../.storybook/utils';
-import { Modal, ModalBody, ModalFooter } from '../src';
+import { Modal, ModalBody, ModalFooter, ModalHeader } from '../src';
 import { AbsoluteModalFooter } from '../src/AbsoluteModalFooter';
 
 export default {
@@ -119,6 +119,9 @@ type Story = StoryObj<
     primaryButton: string;
     secondaryButton: string;
     children: string;
+    description: string;
+    hasRequiredField: boolean;
+    withCloseButton: boolean;
   }
 >;
 
@@ -137,13 +140,28 @@ const play = async ({
 };
 
 export const Default: Story = {
-  render: ({ primaryButton, secondaryButton, children, ...rest }) => {
+  render: ({
+    primaryButton,
+    secondaryButton,
+    title,
+    description,
+    hasRequiredField,
+    withCloseButton,
+    children,
+    ...rest
+  }) => {
     const [show, setShow] = useState(false);
     const button = <Button onClick={() => setShow(true)}>Open modal</Button>;
     return show ? (
       <div style={{ width: '100vw', height: '100vh' }}>
         {button}
         <Modal {...rest} onCancel={() => setShow(!show)}>
+          <ModalHeader
+            title={title}
+            description={description}
+            hasRequiredField={hasRequiredField}
+            withCloseButton={withCloseButton}
+          />
           <ModalBody>{children}</ModalBody>
           <ModalFooter
             primaryButton={
@@ -166,7 +184,8 @@ export const Default: Story = {
 export const Destructive: Story = {
   render: () => {
     return (
-      <Modal status="warning" title="Unsaved changes" size="small">
+      <Modal status="warning" size="small">
+        <ModalHeader title="Unsaved changes" />
         <ModalBody>
           <p>If you leave this page, any unsaved changes will be lost.</p>
         </ModalBody>
@@ -183,7 +202,8 @@ export const Destructive: Story = {
 export const Small: Story = {
   render: () => {
     return (
-      <Modal title="Heading" size="small">
+      <Modal size="small">
+        <ModalHeader title="Heading" />
         <ModalBody>
           <p>Body text</p>
         </ModalBody>
@@ -200,22 +220,21 @@ export const Small: Story = {
 export const KitchenSink: Story = {
   render: () => {
     return (
-      <Modal
-        title={
-          <>
-            Heading <ClickMetric size="small" />
-          </>
-        }
-        hasRequiredField
-        status="warning"
-        description={
-          <>
-            This example shows how the modal responds to passing custom components that use HTML.
-            This is useful for <i>doing</i> <strong>things like this</strong>.
-          </>
-        }
-        size="normal"
-      >
+      <Modal status="warning" size="normal">
+        <ModalHeader
+          title={
+            <>
+              Heading <ClickMetric size="small" />
+            </>
+          }
+          description={
+            <>
+              This example shows how the modal responds to passing custom components that use HTML.
+              This is useful for <i>doing</i> <strong>things like this</strong>.
+            </>
+          }
+          hasRequiredField
+        />
         <ModalBody>
           <h3>More information</h3>
           <p>Lorem ipsum</p>
@@ -243,17 +262,18 @@ export const TallBody: Story = {
   render: () => {
     const [showLess, setShowLess] = useState(false);
     return (
-      <Modal
-        title="Title"
-        description={
-          <>
-            This example is meant to illustrate how the modal overflows when there is a lot of text.
-            You can make your viewport smaller to get a better idea. Lorem ipsum dolor sit amet,
-            consectetur adipiscing elit. Ut malesuada ultricies mauris, in gravida nibh vehicula
-            vel.
-          </>
-        }
-      >
+      <Modal>
+        <ModalHeader
+          title="Title"
+          description={
+            <>
+              This example is meant to illustrate how the modal overflows when there is a lot of
+              text. You can make your viewport smaller to get a better idea. Lorem ipsum dolor sit
+              amet, consectetur adipiscing elit. Ut malesuada ultricies mauris, in gravida nibh
+              vehicula vel.
+            </>
+          }
+        />
         <ModalBody>
           <p>
             Phasellus vulputate varius orci, ut auctor mi pretium a. Duis vestibulum sagittis nulla
@@ -325,10 +345,11 @@ export const WithForm: Story = {
     const inputRef = useRef<HTMLInputElement>(null);
 
     return (
-      <Modal
-        title="Title"
-        description="This example shows how the modal works when a form wraps the body and footer."
-      >
+      <Modal>
+        <ModalHeader
+          title="Title"
+          description="This example shows how the modal works when a form wraps the body and footer."
+        />
         <ModalBody>
           <p>Try out this form:</p>
           <form
@@ -365,17 +386,18 @@ export const WithAbsolutelyPositionedFooter: Story = {
     const inputRef = useRef<HTMLInputElement>(null);
 
     return (
-      <Modal
-        title="Title"
-        description={
-          <>
-            In the case of forms, it&apos;s possible you need the modal body and footer contents to
-            be wrapped in a form. In this case, you lose the default positioning with the normal
-            implementation. In these cases, you can absolutely position the footer so it can be
-            nested within the modal body.
-          </>
-        }
-      >
+      <Modal>
+        <ModalHeader
+          title="Title"
+          description={
+            <>
+              In the case of forms, it&apos;s possible you need the modal body and footer contents
+              to be wrapped in a form. In this case, you lose the default positioning with the
+              normal implementation. In these cases, you can absolutely position the footer so it
+              can be nested within the modal body.
+            </>
+          }
+        />
         <ModalBody>
           <p>Try out this form:</p>
           <form


### PR DESCRIPTION
Exports `ModalHeader` and adds new inner modal context for `onCancel` and `status`. This is useful so that you can pass the cancel context down to ModalHeader's close icon, and `status` can also be defined on the `Modal` instead of `ModalHeader` so that we're more future-proof if other components need to respond to having the `status` updated.