### PR TITLE
refactor(snackbar,toast): add snackbar variant, style links in toast

### DIFF
--- a/.changeset/real-actors-change.md
+++ b/.changeset/real-actors-change.md
@@ -1,0 +1,8 @@
+---
+'@launchpad-ui/snackbar': patch
+'@launchpad-ui/toast': patch
+'@launchpad-ui/core': patch
+---
+
+[Snackbar]: Add `success` variant and trigger onDismiss when `cta` is clicked.
+[Toast]: Style anchor elements properly when used in content.

--- a/packages/snackbar/__tests__/Snackbar.spec.tsx
+++ b/packages/snackbar/__tests__/Snackbar.spec.tsx
@@ -29,4 +29,16 @@ describe('Snackbar', () => {
       expect(spy).toHaveBeenCalledTimes(1);
     });
   });
+
+  it('dismisses when cta is clicked', async () => {
+    const spy = vi.fn();
+    const user = userEvent.setup();
+    render(<Snackbar {...props} cta={<a href="/">Click me</a>} onDismiss={spy} />);
+
+    await user.click(screen.getByRole('link'));
+
+    await waitFor(() => {
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/packages/snackbar/src/Snackbar.tsx
+++ b/packages/snackbar/src/Snackbar.tsx
@@ -1,16 +1,17 @@
-import type { HTMLAttributes, ReactElement, ReactNode } from 'react';
+import type { AnchorHTMLAttributes, HTMLAttributes, ReactElement, ReactNode } from 'react';
 
 import { IconButton } from '@launchpad-ui/button';
 import { Close, StatusIcon } from '@launchpad-ui/icons';
 import { cx } from 'classix';
+import { cloneElement } from 'react';
 
 import styles from './styles/Snackbar.module.css';
 
 type SnackbarBaseProps = {
-  kind: 'info' | 'error' | 'warning';
+  kind: 'info' | 'error' | 'warning' | 'success';
   header?: ReactNode;
   description: ReactNode;
-  cta?: ReactElement<HTMLAnchorElement>;
+  cta?: ReactElement<AnchorHTMLAttributes<HTMLAnchorElement>>;
   onDismiss?: () => void;
   'data-test-id'?: string;
 };
@@ -27,6 +28,12 @@ const Snackbar = ({
   'data-test-id': testId = 'snackbar',
   ...rest
 }: SnackbarProps) => {
+  const CTA =
+    cta &&
+    cloneElement(cta, {
+      onClick: onDismiss,
+    });
+
   return (
     <div
       {...rest}
@@ -37,7 +44,7 @@ const Snackbar = ({
       <StatusIcon kind={kind} className={styles['Snackbar-icon']} />
       <div className={styles['Snackbar-content']}>
         {header && <h4 className={styles['Snackbar-heading']}>{header}</h4>}
-        <span className={styles['Snackbar-description']}>{description}</span> {cta}
+        <span className={styles['Snackbar-description']}>{description}</span> {CTA}
       </div>
       <IconButton
         icon={<Close size="small" />}

--- a/packages/snackbar/src/styles/Snackbar.module.css
+++ b/packages/snackbar/src/styles/Snackbar.module.css
@@ -14,20 +14,20 @@
   top: auto;
 }
 
-.Snackbar--error {
-  & .Snackbar-icon {
-    fill: var(--lp-color-pink-500);
-  }
+.Snackbar--error .Snackbar-icon {
+  fill: var(--lp-color-pink-500);
 }
 
 .Snackbar--info .Snackbar-icon {
   fill: var(--lp-color-cyan-500);
 }
 
-.Snackbar--warning {
-  & .Snackbar-icon {
-    fill: var(--lp-color-yellow-500);
-  }
+.Snackbar--warning .Snackbar-icon {
+  fill: var(--lp-color-yellow-500);
+}
+
+.Snackbar--success .Snackbar-icon {
+  fill: var(--lp-color-system-green-500);
 }
 
 .Snackbar-heading {

--- a/packages/snackbar/stories/Snackbar.stories.tsx
+++ b/packages/snackbar/stories/Snackbar.stories.tsx
@@ -19,19 +19,47 @@ export const Error: Story = {
   args: {
     kind: 'error',
     header: 'Snackbar header',
-    description: 'This is a message about an app process.',
-    cta: <a href="/">Please try again</a>,
+    description: 'This is a message.',
+    cta: (
+      <a href="/" target="_blank">
+        Link
+      </a>
+    ),
   },
 };
 
 export const Info: Story = {
-  args: { kind: 'info', description: 'This is a message about an app process.' },
+  args: {
+    kind: 'info',
+    description: 'This is a message.',
+    cta: (
+      <a href="/" target="_blank">
+        Link
+      </a>
+    ),
+  },
 };
 
 export const Warning: Story = {
   args: {
     kind: 'warning',
-    description: 'This is a message about an app process.',
-    cta: <a href="/">Please try again</a>,
+    description: 'This is a message.',
+    cta: (
+      <a href="/" target="_blank">
+        Link
+      </a>
+    ),
+  },
+};
+
+export const Success: Story = {
+  args: {
+    kind: 'success',
+    description: 'This is a message.',
+    cta: (
+      <a href="/" target="_blank">
+        Link
+      </a>
+    ),
   },
 };

--- a/packages/snackbar/stories/SnackbarCenter.stories.tsx
+++ b/packages/snackbar/stories/SnackbarCenter.stories.tsx
@@ -27,7 +27,12 @@ const makeSnackbar = (id: string) => {
   return {
     _id: id,
     kind,
-    description: 'The snackbar description.',
+    description: 'This is a message.',
+    cta: (
+      <a href="/" target="_blank">
+        Link
+      </a>
+    ),
   };
 };
 

--- a/packages/toast/src/styles/Toast.module.css
+++ b/packages/toast/src/styles/Toast.module.css
@@ -36,4 +36,9 @@
   margin: 0;
   line-height: 1.5;
   font-size: 1.6rem;
+
+  & a,
+  & a:hover {
+    color: var(--lp-color-cyan-500);
+  }
 }

--- a/packages/toast/stories/Toast.stories.tsx
+++ b/packages/toast/stories/Toast.stories.tsx
@@ -32,3 +32,14 @@ export const Success: Story = {
     content: 'This is a message about an app process.',
   },
 };
+
+export const WithLink: Story = {
+  args: {
+    kind: 'success',
+    content: (
+      <>
+        This has a link. <a href="/">Link</a>
+      </>
+    ),
+  },
+};


### PR DESCRIPTION
## Summary
- Adds a success variant to snackbar
- Trigger `onDismiss` when a `cta` is clicked (just added a simple implementation for now, if we need/want something more sophisticated we can modify it)
- Style links in toasts.
