### PR TITLE
ci: update TurboSnap externals to include token changes

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -28,6 +28,4 @@ jobs:
           buildScriptName: 'storybook:build'
           exitOnceUploaded: true
           onlyChanged: true
-          externals: |
-            - 'packages/icons/icons/**'
-            - 'packages/tokens/src/**'
+          externals: packages/(icons/icons|tokens/src)/**

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -28,4 +28,6 @@ jobs:
           buildScriptName: 'storybook:build'
           exitOnceUploaded: true
           onlyChanged: true
-          externals: 'packages/icons/icons/**'
+          externals: |
+            - 'packages/icons/icons/**'
+            - 'packages/tokens/src/**'

--- a/packages/tokens/src/color.yaml
+++ b/packages/tokens/src/color.yaml
@@ -97,6 +97,8 @@ color:
   white:
     100:
       value: hsl(0, 0%, 97.3%)
+    200:
+      value: hsl(0, 0%, 95%)
     ' ':
       value: hsl(0, 0%, 100%)
   gray:

--- a/packages/tokens/src/color.yaml
+++ b/packages/tokens/src/color.yaml
@@ -97,8 +97,6 @@ color:
   white:
     100:
       value: hsl(0, 0%, 97.3%)
-    200:
-      value: hsl(0, 0%, 95%)
     ' ':
       value: hsl(0, 0%, 100%)
   gray:


### PR DESCRIPTION
## Summary

Both icons and tokens are transformed (processed externally) outside of Vite and so we need to set the [externals](https://www.chromatic.com/docs/turbosnap#specify-external-files-to-trigger-a-full-re-test-when-they-change) option for Chromatic to a picomatch glob to match those files. This updates it to include the token yaml files and ensure snapshots are compared.