### PR TITLE
feat: add alias token story

### DIFF
--- a/packages/tokens/sd.config.js
+++ b/packages/tokens/sd.config.js
@@ -74,6 +74,14 @@ module.exports = {
     },
     json: {
       buildPath: 'stories/',
+      transforms: [
+        'attribute/cti',
+        'name/cti/kebab',
+        'time/seconds',
+        'content/icon',
+        'size/rem',
+        'color/rgb',
+      ],
       files: [
         {
           format: 'json/nested',

--- a/packages/tokens/stories/tokens.stories.tsx
+++ b/packages/tokens/stories/tokens.stories.tsx
@@ -1,39 +1,80 @@
+import { CopyToClipboard } from '@launchpad-ui/clipboard';
+
 import tokens from './tokens.json';
 
 export default {
   title: 'Tokens/Colors',
 };
 
+const flatten = (obj: Record<string, unknown>) => {
+  const result = {};
+
+  for (const i in obj) {
+    if (typeof obj[i] === 'object' && !Array.isArray(obj[i])) {
+      const temp = flatten(obj[i]);
+      for (const j in temp) {
+        const key = j !== ' ' ? `${i}-${j}` : i;
+        result[key] = temp[j];
+      }
+    } else {
+      result[i] = obj[i];
+    }
+  }
+  return result;
+};
+
+const getTokenTable = (tokens: Record<string, unknown>) => (
+  <table style={{ borderCollapse: 'separate', borderSpacing: '20px 0' }}>
+    <thead>
+      <tr>
+        <th></th>
+        <th style={{ textAlign: 'left' }}>Name</th>
+        <th style={{ textAlign: 'left' }}>Value</th>
+      </tr>
+    </thead>
+    <tbody>
+      {Object.entries(tokens).map(([key, value]) => (
+        <tr key={key}>
+          <td>
+            <div
+              style={{
+                backgroundColor: value,
+                height: '50px',
+                width: '150px',
+                border: '1px solid var(--lp-color-border-ui-primary)',
+              }}
+            ></div>
+          </td>
+          <td>
+            <CopyToClipboard text={`--lp-color-${key}`}>{`--lp-color-${key}`}</CopyToClipboard>
+          </td>
+          <td>{value}</td>
+        </tr>
+      ))}
+    </tbody>
+  </table>
+);
+
 const global = Object.keys(tokens.color)
   .filter((key) =>
-    ['black', 'blue', 'cyan', 'gray', 'pink', 'purple', 'white', 'yellow'].includes(key)
+    ['black', 'blue', 'cyan', 'gray', 'pink', 'purple', 'white', 'yellow', 'system'].includes(key)
   )
   .reduce((obj, key) => {
     obj[key] = tokens.color[key];
     return obj;
   }, {});
-const colors = Object.values(global).map((color) => Object.values(color));
-const system = Object.values(tokens.color.system).map((color) => Object.values(color));
 
-export const Colors = {
-  render: () => (
-    <>
-      {[...colors, ...system].map((color, index) => (
-        <ul style={{ display: 'flex', flexWrap: 'wrap' }} key={index}>
-          {color.map((token) => (
-            <li style={{ listStyleType: 'none', margin: '4px' }} key={token}>
-              <div
-                style={{
-                  backgroundColor: token,
-                  height: '100px',
-                  width: '100px',
-                  border: '1px solid var(--lp-color-border-ui-primary)',
-                }}
-              ></div>
-            </li>
-          ))}
-        </ul>
-      ))}
-    </>
-  ),
+export const Global = {
+  render: () => getTokenTable(flatten(global)),
+};
+
+const alias = Object.keys(tokens.color)
+  .filter((key) => ['bg', 'border', 'fill', 'shadow', 'text'].includes(key))
+  .reduce((obj, key) => {
+    obj[key] = tokens.color[key];
+    return obj;
+  }, {});
+
+export const Alias = {
+  render: () => getTokenTable(flatten(alias)),
 };


### PR DESCRIPTION
## Summary

Add story for alias tokens and update global tokens story to match. Token names can be copied for easy access.

## Screenshots (if appropriate):

<img width="794" alt="Screen Shot 2022-11-22 at 10 16 05 AM" src="https://user-images.githubusercontent.com/2147624/203353380-06295cc3-252b-41cb-9d97-b62cea610b9b.png">
