### PR TITLE
fix: update darkmode values across system

### DIFF
--- a/.changeset/twenty-jobs-allow.md
+++ b/.changeset/twenty-jobs-allow.md
@@ -10,13 +10,42 @@
 '@launchpad-ui/notification': patch
 '@launchpad-ui/popover': patch
 '@launchpad-ui/slider': patch
-'@launchpad-ui/tokens': patch
-'@launchpad-ui/core': patch
+'@launchpad-ui/tokens': minor
+'@launchpad-ui/core': minor
 ---
 
 Update theme tokens
 
-[Tokens]
+[Tokens]:
 
 - Add `lp-color-shadow-ui-primary`
 - Add a dark theme value to `lp-color-border-ui-primary`
+- Rename `lp-border-radius` to `lp-border-radius-regular` and add `lp-border-radius-medium`
+
+[Alert]: Rename `lp-border-radius` to `lp-border-radius-regular`
+
+[Button]: Rename `lp-border-radius` to `lp-border-radius-regular`
+
+[Chip]: Rename `lp-border-radius` to `lp-border-radius-regular`
+
+[Alert]: Rename `lp-border-radius` to `lp-border-radius-regular`
+
+[Form]: Rename `lp-border-radius` to `lp-border-radius-regular`
+
+[Menu]: Rename `lp-border-radius` to `lp-border-radius-regular`
+
+[Popover]: Rename `lp-border-radius` to `lp-border-radius-regular`
+
+[Clipboard]: Support theming in `CopyCodeButton`
+
+[Filter]:
+
+- Rename `lp-border-radius` to `lp-border-radius-regular`
+- Support theming in filter button and applied filter button components
+
+[Modal]: Support theming for border and box shadow on modal
+
+[Notification]:
+
+- Rename `lp-border-radius` to `lp-border-radius-regular`
+- Improve theming for links in notifications

--- a/.changeset/twenty-jobs-allow.md
+++ b/.changeset/twenty-jobs-allow.md
@@ -1,0 +1,22 @@
+---
+'@launchpad-ui/alert': patch
+'@launchpad-ui/button': patch
+'@launchpad-ui/chip': patch
+'@launchpad-ui/clipboard': patch
+'@launchpad-ui/filter': patch
+'@launchpad-ui/form': patch
+'@launchpad-ui/menu': patch
+'@launchpad-ui/modal': patch
+'@launchpad-ui/notification': patch
+'@launchpad-ui/popover': patch
+'@launchpad-ui/slider': patch
+'@launchpad-ui/tokens': patch
+'@launchpad-ui/core': patch
+---
+
+Update theme tokens
+
+[Tokens]
+
+- Add `lp-color-shadow-ui-primary`
+- Add a dark theme value to `lp-color-border-ui-primary`

--- a/packages/alert/src/styles/CollapsibleAlert.module.css
+++ b/packages/alert/src/styles/CollapsibleAlert.module.css
@@ -32,7 +32,7 @@ backround support in CollapsibleAlert */
   color: var(--CollapsibleAlert-button-color-text);
   background-color: transparent;
   border: hsl(0 0% 0% / 0);
-  border-radius: var(--lp-border-radius);
+  border-radius: var(--lp-border-radius-regular);
   cursor: pointer;
 
   &:focus {

--- a/packages/button/src/styles/ButtonGroup.css
+++ b/packages/button/src/styles/ButtonGroup.css
@@ -33,10 +33,10 @@
 
 .ButtonGroup--compact > .Button:first-child,
 .ButtonGroup--compact > [class*='_Popover-target_']:first-child button {
-  border-radius: var(--lp-border-radius) 0 0 var(--lp-border-radius);
+  border-radius: var(--lp-border-radius-regular) 0 0 var(--lp-border-radius-regular);
 }
 
 .ButtonGroup--compact > .Button:last-child,
 .ButtonGroup--compact > [class*='_Popover-target_']:last-child button {
-  border-radius: 0 var(--lp-border-radius) var(--lp-border-radius) 0;
+  border-radius: 0 var(--lp-border-radius-regular) var(--lp-border-radius-regular) 0;
 }

--- a/packages/button/src/styles/ButtonVariables.css
+++ b/packages/button/src/styles/ButtonVariables.css
@@ -23,7 +23,7 @@
   --Button-line-height-small: 1.5455; /* 17px */
   --Button-line-height-large: 1.111; /* 20px */
   --Button-border-radius-default: 0.6rem;
-  --Button-border-radius-small: var(--lp-border-radius);
+  --Button-border-radius-small: var(--lp-border-radius-regular);
   --Button-border-radius-link: 1px;
   --Button-border-radius-withIcon: 50%;
   --Button-text-transform: none;

--- a/packages/chip/src/styles/Chip.module.css
+++ b/packages/chip/src/styles/Chip.module.css
@@ -30,7 +30,7 @@
   font-size: 1.1rem;
   line-height: 1.2;
   border: 1px solid var(--Chip-border-color);
-  border-radius: var(--lp-border-radius);
+  border-radius: var(--lp-border-radius-regular);
   vertical-align: bottom;
   text-align: center;
   white-space: nowrap;
@@ -158,7 +158,7 @@
 
 .Chip--clickable:focus {
   outline: 0;
-  border-radius: var(--lp-border-radius);
+  border-radius: var(--lp-border-radius-regular);
   box-shadow: 0 0 4px var(--lp-color-shadow-interactive-focus);
   z-index: 2;
 }

--- a/packages/clipboard/src/styles/CopyCodeButton.module.css
+++ b/packages/clipboard/src/styles/CopyCodeButton.module.css
@@ -7,6 +7,7 @@
   padding: 0.4rem 0.8rem;
   border: none;
   cursor: pointer;
+  color: var(--lp-color-text-ui-primary);
 }
 
 .CopyCodeButton:focus {
@@ -17,4 +18,8 @@
 
 .CopyCodeButton:focus-visible {
   outline-color: var(--lp-color-bg-interactive-secondary-hover);
+}
+
+:root[data-theme='dark'] .CopyCodeButton {
+  background-color: var(--lp-color-gray-800);
 }

--- a/packages/filter/src/styles/Filter.module.css
+++ b/packages/filter/src/styles/Filter.module.css
@@ -10,7 +10,7 @@
 }
 
 .button {
-  border-radius: var(--lp-border-radius);
+  border-radius: var(--lp-border-radius-medium);
   padding-top: 0;
   padding-bottom: 0;
   line-height: 3.2rem;
@@ -37,17 +37,17 @@
   cursor: pointer;
   border-width: var(--lp-border-width-200);
   border-style: solid;
-  border-color: var(--lp-color-white);
+  border-color: transparent;
 
   &:hover {
     background-color: var(--lp-color-bg-interactive-secondary-hover);
-    border-color: var(--lp-color-border-ui-primary);
+    border-color: var(--lp-color-border-interactive-secondary-hover);
   }
 
   &:focus-visible {
     box-shadow: 0 0 0 2px var(--lp-color-shadow-interactive-primary),
       0 0 0 4px var(--lp-color-shadow-interactive-focus);
-    border-color: var(--lp-color-border-ui-primary);
+    border-color: var(--lp-color-border-interactive-secondary-focus);
     outline: none;
   }
 }
@@ -129,7 +129,7 @@
   font-weight: var(--lp-font-weight-medium);
   padding: 1rem;
   width: 100%;
-  border-bottom: 1px solid var(--lp-color-border-ui-primary);
+  border-bottom: 1px solid var(--lp-color-border-interactive-secondary);
 }
 
 .filterClearButton:active,
@@ -138,7 +138,20 @@
   outline: none;
   box-shadow: unset;
   color: var(--lp-color-text-interactive-destructive);
-  border-bottom-color: var(--lp-color-border-ui-primary);
+}
+
+.filterClearButton:active {
+  border-bottom-color: var(--lp-color-border-interactive-secondary-active);
+  background-color: var(--lp-color-bg-interactive-secondary-active);
+}
+
+.filterClearButton:focus {
+  border-bottom-color: var(--lp-color-border-interactive-secondary-focus);
+  background-color: var(--lp-color-bg-interactive-secondary-focus);
+}
+
+.filterClearButton:hover {
+  border-bottom-color: var(--lp-color-border-interactive-secondary-hover);
   background-color: var(--lp-color-bg-interactive-secondary-hover);
 }
 
@@ -146,12 +159,14 @@
   /* stylelint-disable-next-line no-descending-specificity */
   .button.isClearable {
     background-color: var(--lp-color-cyan-900);
+    border-color: var(--lp-color-cyan-900);
     padding-right: 3.1rem;
 
     &:focus,
     &:hover,
     &:active {
       background-color: var(--lp-color-cyan-800);
+      border-color: var(--lp-color-cyan-800);
     }
   }
 

--- a/packages/form/src/styles/Form.module.css
+++ b/packages/form/src/styles/Form.module.css
@@ -34,7 +34,7 @@
   background-color: var(--lp-color-bg-interactive-secondary);
   color: var(--lp-color-text-ui-primary);
   border: 1px solid var(--lp-color-border-interactive-secondary);
-  border-radius: var(--lp-border-radius);
+  border-radius: var(--lp-border-radius-regular);
   transition: all var(--lp-duration-100) linear;
   height: 3.2rem;
 }
@@ -67,7 +67,7 @@ select.formInput {
 
 .suffixContainer .formInput {
   border: none;
-  border-radius: var(--lp-border-radius) 0 0 var(--lp-border-radius);
+  border-radius: var(--lp-border-radius-regular) 0 0 var(--lp-border-radius-regular);
 }
 
 .suffixContainer .formInput:focus {
@@ -280,7 +280,7 @@ input[type='checkbox']:disabled {
 .suffixContainer {
   display: inline-flex;
   border: 1px solid var(--lp-color-gray-500);
-  border-radius: var(--lp-border-radius);
+  border-radius: var(--lp-border-radius-regular);
   overflow: hidden;
   transition: all 0.1s linear;
 }
@@ -344,7 +344,7 @@ input[type='checkbox']:disabled {
 }
 
 .compactTextField.isActive .label {
-  border-radius: var(--lp-border-radius);
+  border-radius: var(--lp-border-radius-regular);
   opacity: 1;
   pointer-events: auto;
   transform: translate(0, -8px) scale(0.9); /* 2d transform to avoid webkit blurry text */

--- a/packages/menu/src/styles/Menu.css
+++ b/packages/menu/src/styles/Menu.css
@@ -19,13 +19,13 @@
   width: 100%;
 
   &:first-child {
-    border-top-left-radius: var(--lp-border-radius);
-    border-top-right-radius: var(--lp-border-radius);
+    border-top-left-radius: var(--lp-border-radius-regular);
+    border-top-right-radius: var(--lp-border-radius-regular);
   }
 
   &:last-child {
-    border-bottom-left-radius: var(--lp-border-radius);
-    border-bottom-right-radius: var(--lp-border-radius);
+    border-bottom-left-radius: var(--lp-border-radius-regular);
+    border-bottom-right-radius: var(--lp-border-radius-regular);
   }
 }
 
@@ -36,8 +36,8 @@
 }
 
 .Menu-item-list > .Menu-item:last-child {
-  border-bottom-left-radius: var(--lp-border-radius);
-  border-bottom-right-radius: var(--lp-border-radius);
+  border-bottom-left-radius: var(--lp-border-radius-regular);
+  border-bottom-right-radius: var(--lp-border-radius-regular);
 }
 
 .Menu .Menu-item:not([disabled]):not([aria-disabled]) {
@@ -61,8 +61,8 @@
 
 /* stylelint-disable-next-line no-descending-specificity */
 .Menu-item-list > .VirtualMenu-item-list .VirtualMenu-item:last-child .Menu-item {
-  border-bottom-left-radius: var(--lp-border-radius);
-  border-bottom-right-radius: var(--lp-border-radius);
+  border-bottom-left-radius: var(--lp-border-radius-regular);
+  border-bottom-right-radius: var(--lp-border-radius-regular);
 }
 
 .Menu {
@@ -91,13 +91,13 @@
   & [hidden]:first-child + & .Menu-item-list {
     /* stylelint-disable-next-line no-descending-specificity */
     & > .Menu-item:first-child {
-      border-top-left-radius: var(--lp-border-radius);
-      border-top-right-radius: var(--lp-border-radius);
+      border-top-left-radius: var(--lp-border-radius-regular);
+      border-top-right-radius: var(--lp-border-radius-regular);
     }
 
     & > .VirtualMenu-item-list .VirtualMenu-item:first-child .Menu-item {
-      border-top-left-radius: var(--lp-border-radius);
-      border-top-right-radius: var(--lp-border-radius);
+      border-top-left-radius: var(--lp-border-radius-regular);
+      border-top-right-radius: var(--lp-border-radius-regular);
     }
   }
 }
@@ -149,8 +149,8 @@
 }
 
 .Menu-search:first-child {
-  border-top-left-radius: var(--lp-border-radius);
-  border-top-right-radius: var(--lp-border-radius);
+  border-top-left-radius: var(--lp-border-radius-regular);
+  border-top-right-radius: var(--lp-border-radius-regular);
 }
 
 [class^='_Popover-content_'] .Menu-search {

--- a/packages/modal/src/styles/Modal.module.css
+++ b/packages/modal/src/styles/Modal.module.css
@@ -23,9 +23,9 @@
 .modal {
   background-color: var(--lp-color-bg-ui-primary);
   position: relative;
-  border: 1px solid var(--lp-color-gray-100);
+  border: 1px solid var(--lp-color-border-ui-primary);
   border-radius: 0.2rem;
-  box-shadow: 0 0 6px var(--lp-color-gray-700);
+  box-shadow: 0 0 6px var(--lp-color-shadow-ui-primary);
   display: flex;
   flex-direction: column;
   width: 100%;

--- a/packages/notification/src/styles/Notification.css
+++ b/packages/notification/src/styles/Notification.css
@@ -88,7 +88,7 @@
   color: var(--Notification-detailsExpand-color-text);
   background-color: transparent;
   border: hsl(0 0% 0% / 0);
-  border-radius: var(--lp-border-radius);
+  border-radius: var(--lp-border-radius-regular);
 
   &:focus {
     outline: none;
@@ -143,7 +143,7 @@ will zero out that positioning adjustment for now */
 }
 
 .Notification-message a {
-  color: var(--Notification-color-text);
+  color: var(--lp-color-text-interactive);
 
   &:hover {
     text-decoration: none;

--- a/packages/popover/src/styles/Popover.module.css
+++ b/packages/popover/src/styles/Popover.module.css
@@ -25,7 +25,7 @@
 
 .Popover-content {
   background: var(--lp-color-bg-overlay-primary);
-  border-radius: var(--lp-border-radius);
+  border-radius: var(--lp-border-radius-regular);
 
   /* --color-black-100 */
   box-shadow: 0 0 4px hsl(0 0% 15.7% / 0.12), 0 1px 2px hsl(0 0% 15.7% / 0.1),

--- a/packages/slider/src/styles/Slider.module.css
+++ b/packages/slider/src/styles/Slider.module.css
@@ -54,7 +54,7 @@
   cursor: not-allowed;
   background-color: var(--lp-color-bg-ui-secondary);
   background-image: linear-gradient(#fafafa, #f5f5f5);
-  border-radius: var(--lp-border-radius);
+  border-radius: var(--lp-border-radius-regular);
   border: solid 1px var(--lp-color-border-ui-primary);
   box-shadow: 0 0 0 1px var(--lp-color-white);
   box-sizing: border-box;
@@ -76,7 +76,7 @@
   cursor: not-allowed;
   background-color: var(--lp-color-bg-ui-secondary);
   background-image: linear-gradient(#fafafa, #f5f5f5);
-  border-radius: var(--lp-border-radius);
+  border-radius: var(--lp-border-radius-regular);
   border: solid 1px var(--lp-color-border-ui-primary);
   box-shadow: 0 0 0 1px var(--lp-color-white);
   box-sizing: border-box;
@@ -98,7 +98,7 @@
   max-width: 100%;
   height: var(--slider-height);
   background-color: var(--lp-color-bg-ui-secondary);
-  border-radius: var(--lp-border-radius);
+  border-radius: var(--lp-border-radius-regular);
 }
 
 .Slider-fill {
@@ -108,8 +108,8 @@
   max-width: 100%;
   height: var(--slider-height);
   background-color: var(--lp-color-border-ui-primary);
-  border-top-left-radius: var(--lp-border-radius);
-  border-bottom-left-radius: var(--lp-border-radius);
+  border-top-left-radius: var(--lp-border-radius-regular);
+  border-bottom-left-radius: var(--lp-border-radius-regular);
 }
 
 .Slider:not(.Slider--disabled):hover .Slider-fill {

--- a/packages/tokens/src/border.yaml
+++ b/packages/tokens/src/border.yaml
@@ -1,6 +1,9 @@
 border:
   radius:
-    value: 0.3rem
+    regular:
+      value: 0.3rem
+    medium:
+      value: 0.6rem
   width:
     100:
       value: 0rem

--- a/packages/tokens/src/color.yaml
+++ b/packages/tokens/src/color.yaml
@@ -311,6 +311,7 @@ color:
     ui:
       primary:
         value: '{ color.gray.200.value }'
+        dark: '{ color.gray.700.value }'
 
   fill:
     feedback:
@@ -344,6 +345,10 @@ color:
       primary:
         value: '{ color.white. .value }'
         dark: '{ color.black.300.value }'
+    ui:
+      primary:
+        value: '{ color.gray.700.value }'
+        dark: '{ color.black. .value }'
 
   text:
     feedback:


### PR DESCRIPTION
## Summary

Update theme tokens and usage in LaunchPad

### Tokens
- Add `lp-color-shadow-ui-primary`
- Add a dark theme value to `lp-color-border-ui-primary`
- Rename `lp-border-radius` to `lp-border-radius-regular` and add `lp-border-radius-medium`

### Alert
Rename `lp-border-radius` to `lp-border-radius-regular`

### Button
Rename `lp-border-radius` to `lp-border-radius-regular`

### Chip
Rename `lp-border-radius` to `lp-border-radius-regular`

### Alert
Rename `lp-border-radius` to `lp-border-radius-regular`

### Form
Rename `lp-border-radius` to `lp-border-radius-regular`

### Menu
Rename `lp-border-radius` to `lp-border-radius-regular`

### Popover
Rename `lp-border-radius` to `lp-border-radius-regular`

### Clipboard
Support theming in `CopyCodeButton`

### Filter
- Rename `lp-border-radius` to `lp-border-radius-regular`
- Support theming in filter button and applied filter button components

### Modal
Support theming for border and box shadow on modal

### Notification
- Rename `lp-border-radius` to `lp-border-radius-regular`
- Improve theming for links in notifications
