### PR TITLE
refactor(form,tokens): improve theming with new field tokens

### DIFF
--- a/.changeset/loud-dolphins-retire.md
+++ b/.changeset/loud-dolphins-retire.md
@@ -1,0 +1,8 @@
+---
+'@launchpad-ui/form': patch
+'@launchpad-ui/tokens': patch
+'@launchpad-ui/core': patch
+---
+
+[Tokens]: Add `-field-` variant tokens
+[Form]: Improve theming with new field tokens

--- a/packages/form/src/styles/Form.module.css
+++ b/packages/form/src/styles/Form.module.css
@@ -31,9 +31,9 @@
   font-size: 1.3rem;
   font-family: var(--lp-font-family-base);
   line-height: var(--lp-line-height-300);
-  background-color: var(--lp-color-bg-interactive-secondary);
+  background-color: var(--lp-color-bg-field);
   color: var(--lp-color-text-ui-primary);
-  border: 1px solid var(--lp-color-border-interactive-secondary);
+  border: 1px solid var(--lp-color-border-field);
   border-radius: var(--lp-border-radius-regular);
   transition: all var(--lp-duration-100) linear;
   height: 3.2rem;
@@ -47,7 +47,7 @@
 .formInput.isFocused,
 .formInput:focus {
   outline: 0;
-  border-color: var(--lp-color-border-interactive-focus);
+  border-color: var(--lp-color-border-field-focus);
   box-shadow: 0 0 0 3px hsl(231.5 100% 62.5% / 0.1);
 }
 
@@ -150,7 +150,7 @@ select.formInput {
 }
 
 ::placeholder {
-  color: var(--lp-color-gray-600);
+  color: var(--lp-color-text-field-placeholder);
 }
 
 .form .isInvalid :global(.Select-control),
@@ -204,8 +204,8 @@ select.formInput {
 input.formInput:disabled,
 select.formInput:disabled,
 input.formInput:read-only {
-  background-color: var(--lp-color-bg-interactive-disabled);
-  color: var(--lp-color-text-interactive-disabled);
+  background-color: var(--lp-color-bg-field-disabled);
+  color: var(--lp-color-text-field-disabled);
 }
 
 .formInput.isDisabled:hover,
@@ -221,11 +221,11 @@ textarea.formInput {
 
 textarea.formInput:disabled,
 textarea.formInput:read-only {
-  background-color: var(--lp-color-bg-interactive-disabled);
+  background-color: var(--lp-color-bg-field-disabled);
 }
 
 input.formInput::-webkit-autofill {
-  box-shadow: 0 0 0 50px var(--lp-color-bg-interactive-secondary) inset;
+  box-shadow: 0 0 0 50px var(--lp-color-bg-field) inset;
 }
 
 /* Hide the type=search cancel button in Webkit for consistency */
@@ -279,21 +279,21 @@ input[type='checkbox']:disabled {
 
 .suffixContainer {
   display: inline-flex;
-  border: 1px solid var(--lp-color-gray-500);
+  border: 1px solid var(--lp-color-border-field);
   border-radius: var(--lp-border-radius-regular);
   overflow: hidden;
   transition: all 0.1s linear;
 }
 
 .suffixContainer:focus-within {
-  border-color: var(--lp-color-border-interactive-focus);
+  border-color: var(--lp-color-border-field-focus);
   box-shadow: 0 0 0 3px hsl(231.5 100% 62.5% / 0.1);
 }
 
 .suffixContainer .suffix {
   padding: 0 2px;
-  background-color: var(--lp-color-gray-100);
-  color: var(--lp-color-gray-500);
+  background-color: var(--lp-color-bg-field-aside);
+  color: var(--lp-color-text-ui-secondary);
   cursor: text;
   display: inline-flex;
   align-items: center;
@@ -313,7 +313,7 @@ input[type='checkbox']:disabled {
 
 .iconFieldIcon {
   position: absolute;
-  fill: var(--lp-color-gray-600);
+  fill: var(--lp-color-fill-field);
   top: 50%;
   transform: translateY(-50%);
   left: 1rem;

--- a/packages/form/stories/TextArea.stories.tsx
+++ b/packages/form/stories/TextArea.stories.tsx
@@ -16,11 +16,7 @@ const withRestingAndDisabledStates: DecoratorFn = (story, context) => {
   if (viewMode === 'docs') {
     return story();
   }
-  const finalArgs = {
-    ...args,
-    id: 'Disabled',
-    disabled: true,
-  };
+
   return (
     <div className="Textarea-storygroup-wrapper">
       <span className="Textarea-state-label">Resting</span>
@@ -28,7 +24,12 @@ const withRestingAndDisabledStates: DecoratorFn = (story, context) => {
       {originalTemplate && (
         <>
           <span className="Textarea-state-label">Disabled</span>
-          {originalTemplate(finalArgs, context)}
+          {originalTemplate({ ...args, disabled: true, id: 'Disabled' }, context)}
+          <span className="Textarea-state-label">Empty</span>
+          {originalTemplate(
+            { ...args, value: '', placeholder: 'Enter text here', id: 'Placeholder' },
+            context
+          )}
         </>
       )}
     </div>

--- a/packages/form/stories/TextField.stories.tsx
+++ b/packages/form/stories/TextField.stories.tsx
@@ -24,6 +24,11 @@ const withRestingAndDisabledStates: DecoratorFn = (story, context) => {
         <>
           <span className="Textarea-state-label">Disabled</span>
           {originalTemplate({ ...args, disabled: true, id: 'Disabled' }, context)}
+          <span className="Textarea-state-label">Empty</span>
+          {originalTemplate(
+            { ...args, value: '', placeholder: 'Enter text here', id: 'Placeholder' },
+            context
+          )}
         </>
       )}
     </div>

--- a/packages/tokens/src/color.yaml
+++ b/packages/tokens/src/color.yaml
@@ -273,6 +273,16 @@ color:
       secondary:
         value: '{ color.black.300.value }'
         dark: '{ color.white. .value }'
+    field:
+      ' ':
+        value: '{ color.white. .value }'
+        dark: '{ color.black.300.value }'
+      disabled:
+        value: '{ color.gray.100.value }'
+        dark: '{ color.gray.800.value }'
+      aside:
+        value: '{ color.gray.100.value }'
+        dark: '{ color.gray.800.value }'
 
   border:
     feedback:
@@ -288,6 +298,16 @@ color:
       warning:
         value: '{ color.system.yellow.700.value }'
         dark: '{ color.system.yellow.400.value }'
+    field:
+      ' ':
+        value: '{ color.gray.300.value }'
+        dark: '{ color.gray.500.value }'
+      active:
+        value: '{ color.blue.500.value }'
+        dark: '{ color.cyan.500.value }'
+      focus:
+        value: '{ color.blue.500.value }'
+        dark: '{ color.cyan.500.value }'
     interactive:
       focus:
         value: '{ color.blue.500.value }'
@@ -353,6 +373,10 @@ color:
       primary:
         value: currentvalue
         dark: '{ color.white. .value }'
+    field:
+      ' ':
+        value: '{ color.gray.600.value }'
+        dark: '{ color.gray.400.value }'
 
   shadow:
     interactive:
@@ -425,3 +449,13 @@ color:
       secondary:
         value: '{ color.white. .value }'
         dark: '{ color.black.300.value }'
+    field:
+      ' ':
+        value: '{ color.gray.600.value }'
+        dark: '{ color.gray.400.value }'
+      disabled:
+        value: '{ color.gray.700.value }'
+        dark: '{ color.gray.500.value }'
+      placeholder:
+        value: '{ color.gray.500.value }'
+        dark: '{ color.gray.500.value }'


### PR DESCRIPTION
## Summary
- Adds new `-field-` variant tokens. Previously, we were using the `interactive` variant, which is also used by buttons and focusable elements, but for the case of fields, we can be more explicit and granular so styling can be safely applied to only fields, and in consumer applications we can confidently use these tokens when styling forms.