### PR TITLE
chore(tokens,popover): update background color of primary overlay

### DIFF
--- a/.changeset/hot-glasses-burn.md
+++ b/.changeset/hot-glasses-burn.md
@@ -1,0 +1,7 @@
+---
+'@launchpad-ui/tokens': patch
+'@launchpad-ui/core': patch
+---
+
+[Popover]: Update background color
+[Tokens]: Update `lp-color-bg-overlay-primary` token value

--- a/packages/tokens/src/color.yaml
+++ b/packages/tokens/src/color.yaml
@@ -269,7 +269,7 @@ color:
     overlay:
       primary:
         value: '{ color.white. .value }'
-        dark: '{ color.black.200.value }'
+        dark: '{ color.black.100.value }'
       secondary:
         value: '{ color.black.300.value }'
         dark: '{ color.white. .value }'


### PR DESCRIPTION
## Summary
Based on feedback from designers that there is not enough contract between primary ui backgrounds and primary overlay backgrounds.