### PR TITLE
refactor(button): update button destructive styles

### DIFF
--- a/.changeset/quiet-cheetahs-laugh.md
+++ b/.changeset/quiet-cheetahs-laugh.md
@@ -1,0 +1,6 @@
+---
+'@launchpad-ui/button': patch
+'@launchpad-ui/core': patch
+---
+
+[Button] Update style for destructive dark mode button

--- a/packages/button/src/styles/ButtonVariables.css
+++ b/packages/button/src/styles/ButtonVariables.css
@@ -84,6 +84,7 @@
   --Button-color-background-destructive-focus: var(--lp-color-bg-interactive-destructive-focus);
   --Button-color-background-destructive-active: var(--lp-color-bg-interactive-destructive-active);
   --Button-color-border-destructive: var(--lp-color-border-interactive-destructive);
+  --Button-color-border-destructive-hover: var(--lp-color-border-interactive-destructive);
   --Button-color-text-destructive: var(--lp-color-text-interactive-destructive);
   --Button-color-text-destructive-hover: var(--lp-color-text-interactive-destructive);
   --Button-color-text-destructive-active: var(--lp-color-text-interactive-destructive);
@@ -147,4 +148,12 @@
   /* SEARCH BAR CLEAR BUTTON ICON */
   --Button-icon-clear-color-fill: var(--lp-color-blue-600);
   --Button-icon-clear-color-text: var(--lp-color-blue-600);
+}
+
+:root[data-theme='dark'] {
+  --Button-color-border-destructive: var(--lp-color-system-red-600);
+  --Button-color-background-destructive: var(--lp-color-system-red-600);
+  --Button-color-background-destructive-hover: var(--lp-color-system-red-700);
+  --Button-color-background-destructive-focus: var(--lp-color-system-red-700);
+  --Button-color-background-destructive-active: var(--lp-color-system-red-700);
 }


### PR DESCRIPTION
## Summary
This PR improves button styles in LaunchPad for destructive buttons in dark mode
Before:
<img width="324" alt="Screen Shot 2022-12-13 at 5 20 38 PM" src="https://user-images.githubusercontent.com/104940219/207466300-6004141b-ffaf-4d8f-a98e-e1d6d5d3473d.png">

After:
<img width="623" alt="Screen Shot 2022-12-13 at 5 20 27 PM" src="https://user-images.githubusercontent.com/104940219/207466273-7beb362a-7bce-408b-9e69-8ee027f1e2a5.png">