### PR TITLE
chore(tokens,button): update tokens based on design feedback

### DIFF
--- a/.changeset/tricky-horses-hope.md
+++ b/.changeset/tricky-horses-hope.md
@@ -1,0 +1,6 @@
+---
+'@launchpad-ui/button': patch
+'@launchpad-ui/tokens': patch
+---
+
+Updated tokens based on design team feedback

--- a/.changeset/tricky-horses-hope.md
+++ b/.changeset/tricky-horses-hope.md
@@ -1,6 +1,7 @@
 ---
 '@launchpad-ui/button': patch
 '@launchpad-ui/tokens': patch
+'@launchpad-ui/core': patch
 ---
 
 Update tokens based on design team feedback

--- a/.changeset/tricky-horses-hope.md
+++ b/.changeset/tricky-horses-hope.md
@@ -3,4 +3,12 @@
 '@launchpad-ui/tokens': patch
 ---
 
-Updated tokens based on design team feedback
+Update tokens based on design team feedback
+
+[Button]: Destructive buttons in dark mode should have no background color in their default state
+
+[Tokens]: Update the following:
+
+- Tweak Gray 600 and Red 600 to comply with contrast ratio criteria
+- Update interactive secondary border color to increase contrast
+- Update link color in darkmode from Cyan 600 to 500.

--- a/packages/button/src/styles/ButtonVariables.css
+++ b/packages/button/src/styles/ButtonVariables.css
@@ -79,7 +79,7 @@
   --Button-color-text-primary-withIcon: var(--lp-color-text-interactive-primary);
 
   /* ------- DESTRUCTIVE ------- */
-  --Button-color-background-destructive: var(--lp-color-bg-interactive-destructive);
+  --Button-color-background-destructive: transparent;
   --Button-color-background-destructive-hover: var(--lp-color-bg-interactive-destructive-hover);
   --Button-color-background-destructive-focus: var(--lp-color-bg-interactive-destructive-focus);
   --Button-color-background-destructive-active: var(--lp-color-bg-interactive-destructive-active);

--- a/packages/tokens/src/color.yaml
+++ b/packages/tokens/src/color.yaml
@@ -111,7 +111,7 @@ color:
     500:
       value: hsl(216, 2.4%, 58.6%)
     600:
-      value: hsl(225, 1.8%, 43.5%)
+      value: hsl(225, 1.8%, 45%)
     700:
       value: hsl(220, 1.7%, 35.1%)
     800:
@@ -159,7 +159,7 @@ color:
       500:
         value: hsl(0, 79%, 57.1%)
       600:
-        value: hsl(0, 59.5%, 48.4%)
+        value: hsl(0, 59.5%, 49%)
       700:
         value: hsl(0, 59.6%, 42.7%)
       800:
@@ -327,7 +327,7 @@ color:
       secondary:
         ' ':
           value: '{ color.gray.300.value }'
-          dark: '{ color.gray.600.value }'
+          dark: '{ color.gray.300.value }'
         active:
           value: '{ color.gray.700.value }'
           dark: '{ color.gray.100.value }'
@@ -415,7 +415,7 @@ color:
       # links
       ' ':
         value: '{ color.blue.600.value }'
-        dark: '{ color.cyan.600.value }'
+        dark: '{ color.cyan.500.value }'
       active:
         value: '{ color.purple.600.value }'
         dark: '{ color.purple.400.value }'


### PR DESCRIPTION
## Summary
After meeting with the design team, we decided to implement the following changes:
- Destructive buttons in dark mode should have no background color in their default state
- Tweak Gray 600 and Red 600 to comply with contrast ratio criteria
- Update interactive secondary border color to increase contrast
- Update link color in darkmode from Cyan 600 to 500.
