### PR TITLE
feat: add legacy Navigation components

### DIFF
--- a/.changeset/spicy-llamas-dream.md
+++ b/.changeset/spicy-llamas-dream.md
@@ -1,0 +1,6 @@
+---
+'@launchpad-ui/navigation': patch
+'@launchpad-ui/core': patch
+---
+
+Add legacy Navigation components

--- a/packages/navigation/__tests__/LegacyNavigation.cy.tsx
+++ b/packages/navigation/__tests__/LegacyNavigation.cy.tsx
@@ -1,0 +1,87 @@
+import type { LegacyNavigationItemProps } from '../src';
+
+import { MemoryRouter } from 'react-router-dom';
+
+import { LegacyNavigation, LegacyNavigationItem } from '../src';
+
+const createComponent = (items: LegacyNavigationItemProps[]) => (
+  <MemoryRouter>
+    <LegacyNavigation items={items} title="nav" kind="primary">
+      {(item) => (
+        <LegacyNavigationItem
+          key={item.to}
+          name={item.name}
+          to={item.to}
+          tooltip={item.tooltip}
+          tooltipContent={item.tooltipContent}
+          status={item.status}
+        />
+      )}
+    </LegacyNavigation>
+  </MemoryRouter>
+);
+
+describe('Navigation', () => {
+  it('renders', () => {
+    cy.mount(
+      createComponent([
+        {
+          name: 'First',
+          to: '/first',
+        },
+        {
+          name: 'Second',
+          to: '/second',
+        },
+      ])
+    );
+    cy.getByTestId('navigation').should('be.visible');
+  });
+
+  it('is accessible', () => {
+    cy.mount(
+      createComponent([
+        {
+          name: 'First',
+          to: '/first',
+        },
+        {
+          name: 'Second',
+          to: '/second',
+        },
+      ])
+    );
+    cy.checkA11y();
+  });
+
+  context('mobile viewport', () => {
+    beforeEach(() => {
+      cy.viewport(320, 500);
+    });
+
+    it('renders as a dropdown menu', () => {
+      cy.mount(
+        createComponent([
+          {
+            name: 'First',
+            to: '/first',
+          },
+          {
+            name: 'Second',
+            to: '/second',
+          },
+          {
+            name: 'Third',
+            to: '/third',
+          },
+          {
+            name: 'Fourth',
+            to: '/fourth',
+          },
+        ])
+      );
+
+      cy.getByTestId('navigation-menu-button').should('be.visible');
+    });
+  });
+});

--- a/packages/navigation/__tests__/LegacyNavigation.spec.tsx
+++ b/packages/navigation/__tests__/LegacyNavigation.spec.tsx
@@ -1,0 +1,119 @@
+import type { LegacyNavigationItemProps } from '../src';
+
+import { MemoryRouter } from 'react-router-dom';
+import { it, expect, describe, vi } from 'vitest';
+
+import { render, screen, userEvent, waitFor } from '../../../test/utils';
+import { LegacyNavigation, LegacyNavigationItem } from '../src';
+import * as ctx from '../src/legacy/NavigationContext';
+
+globalThis.matchMedia = vi.fn().mockReturnValue({
+  matches: true,
+  onchange: null,
+  addEventListener: vi.fn(),
+  removeEventListener: vi.fn(),
+  dispatchEvent: vi.fn(),
+  addListener: vi.fn(),
+  removeListener: vi.fn(),
+});
+
+const createComponent = (items: LegacyNavigationItemProps[]) => (
+  <MemoryRouter>
+    <LegacyNavigation items={items} title="nav" kind="primary">
+      {(item) => (
+        <LegacyNavigationItem
+          key={item.to}
+          name={item.name}
+          to={item.to}
+          tooltip={item.tooltip}
+          tooltipContent={item.tooltipContent}
+          status={item.status}
+        />
+      )}
+    </LegacyNavigation>
+  </MemoryRouter>
+);
+
+describe('Navigation', () => {
+  it('renders', () => {
+    render(
+      createComponent([
+        {
+          name: 'First',
+          to: '/first',
+        },
+        {
+          name: 'Second',
+          to: '/second',
+        },
+      ])
+    );
+    expect(screen.getByRole('navigation')).toBeInTheDocument();
+  });
+
+  it('can render items with a tooltip', async () => {
+    const user = userEvent.setup();
+    render(
+      createComponent([
+        {
+          name: 'First',
+          to: '/first',
+          tooltip: true,
+          tooltipContent: 'one',
+        },
+        {
+          name: 'Second',
+          to: '/second',
+        },
+      ])
+    );
+
+    await user.hover(screen.getByText('First'));
+    await waitFor(() => {
+      expect(screen.getByRole('tooltip')).toBeInTheDocument();
+    });
+  });
+
+  it('can render items with a chip', async () => {
+    render(
+      createComponent([
+        {
+          name: 'First',
+          to: '/first',
+          status: 'new',
+        },
+        {
+          name: 'Second',
+          to: '/second',
+          tooltip: <>tooltip</>,
+        },
+      ])
+    );
+    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+    expect(screen.getByTestId('nav-item-chip')).not.toBeNull();
+  });
+
+  it('renders collapsed dropdown', async () => {
+    vi.spyOn(ctx, 'useNavigationContext').mockReturnValue({
+      shouldCollapse: true,
+      refs: { wrapperRef: { current: null }, itemListRef: { current: null } },
+    });
+
+    render(
+      createComponent([
+        {
+          name: 'First',
+          to: '/first',
+          status: 'new',
+        },
+        {
+          name: 'Second',
+          to: '/second',
+          tooltip: <>tooltip</>,
+        },
+      ])
+    );
+    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+    expect(screen.getByTestId('navigation-menu-button')).not.toBeNull();
+  });
+});

--- a/packages/navigation/src/index.ts
+++ b/packages/navigation/src/index.ts
@@ -4,3 +4,10 @@ export type { NavigationItemProps } from './NavigationItem';
 export { Navigation } from './Navigation';
 export { NavigationItem } from './NavigationItem';
 /* c8 ignore stop */
+
+export type { NavigationProps as LegacyNavigationProps } from './legacy/Navigation';
+export type { NavigationItemProps as LegacyNavigationItemProps } from './legacy/NavigationItem';
+/* c8 ignore start */
+export { Navigation as LegacyNavigation } from './legacy/Navigation';
+export { NavigationItem as LegacyNavigationItem } from './legacy/NavigationItem';
+/* c8 ignore stop */

--- a/packages/navigation/src/legacy/Nav.tsx
+++ b/packages/navigation/src/legacy/Nav.tsx
@@ -1,0 +1,45 @@
+import type { HTMLAttributes, Ref } from 'react';
+
+import { cx } from 'classix';
+import { forwardRef } from 'react';
+
+import styles from './styles/Navigation.module.css';
+
+type NavBaseProps = HTMLAttributes<HTMLElement> & {
+  kind?: 'primary' | 'secondary';
+  innerRef?: Ref<HTMLDivElement>;
+  'data-test-id'?: string;
+};
+
+const NavBase = ({
+  kind = 'primary',
+  className,
+  children,
+  innerRef,
+  'aria-label': ariaLabel,
+  'data-test-id': testId = 'nav',
+  ...rest
+}: NavBaseProps) => {
+  return (
+    <nav
+      {...rest}
+      aria-label={ariaLabel ?? `${kind} navigation`}
+      className={cx(styles.Nav, styles[`Nav--${kind}`], className)}
+      data-test-id={testId}
+      ref={innerRef}
+    >
+      {children}
+    </nav>
+  );
+};
+
+type NavProps = Omit<NavBaseProps, 'innerRef'>;
+
+const Nav = forwardRef<HTMLDivElement, NavBaseProps>((props, ref) => (
+  <NavBase {...props} innerRef={ref} />
+));
+
+Nav.displayName = 'Nav';
+
+export { Nav };
+export type { NavProps };

--- a/packages/navigation/src/legacy/NavItem.tsx
+++ b/packages/navigation/src/legacy/NavItem.tsx
@@ -1,0 +1,64 @@
+import type { ChipProps } from '@launchpad-ui/chip';
+import type { MouseEvent } from 'react';
+
+import { Chip } from '@launchpad-ui/chip';
+import { cx } from 'classix';
+import { NavLink, useLocation } from 'react-router-dom';
+
+import styles from './styles/Navigation.module.css';
+import { titlecase } from './utils';
+
+type NavItemProps = {
+  to: string | { pathname: string; search: string };
+  name: string;
+  end?: boolean;
+  onClick?(event: MouseEvent): void;
+  activeClassName?: string;
+  status?: ChipProps['kind'];
+  id?: string;
+  role?: string;
+  'data-test-id'?: string;
+};
+
+const NavItem = ({
+  to,
+  name,
+  onClick,
+  status,
+  role,
+  end,
+  'data-test-id': testId = 'nav-item',
+  ...other
+}: NavItemProps) => {
+  const { pathname } = useLocation();
+  const selected = pathname === to ? 'true' : 'false';
+
+  return (
+    <NavLink
+      {...other}
+      end={end}
+      to={to}
+      className={({ isActive }) => cx(styles.NavItem, isActive && styles['is-active'])}
+      data-text={name}
+      onClick={onClick}
+      role={role}
+      data-nav-target="true" // used by Navigation to check rendered width
+      data-test-id={testId}
+      aria-selected={role === 'tab' ? selected : undefined}
+    >
+      {status ? (
+        <div style={{ display: 'flex', alignItems: 'flex-end' }}>
+          <span className={styles['NavItem-name']}>{name}</span>
+          <Chip className={styles['NavItem-chip']} data-test-id="nav-item-chip" kind={status}>
+            {titlecase(status)}
+          </Chip>
+        </div>
+      ) : (
+        <span className={styles['NavItem-name']}>{name}</span>
+      )}
+    </NavLink>
+  );
+};
+
+export { NavItem };
+export type { NavItemProps };

--- a/packages/navigation/src/legacy/NavItemWithTooltip.tsx
+++ b/packages/navigation/src/legacy/NavItemWithTooltip.tsx
@@ -1,0 +1,68 @@
+import type { Offset, PopoverPlacement } from '@launchpad-ui/popover';
+import type { MouseEvent } from 'react';
+
+import { Tooltip } from '@launchpad-ui/tooltip';
+
+import { NavItem } from './NavItem';
+import styles from './styles/Navigation.module.css';
+
+type NavItemWithTooltipProps = {
+  to: string;
+  name: string;
+  end?: boolean;
+  tooltipContent?: string | JSX.Element;
+  tooltipPlacement?: PopoverPlacement;
+  tooltipOffset?: Offset;
+  onClick?(event: MouseEvent): void;
+  id?: string;
+  role?: string;
+  'aria-controls'?: string;
+  'data-test-id'?: string;
+};
+
+const defaultContent = (
+  <>
+    Upgrade your plan to use this feature.
+    <br />
+    Click to learn more.
+  </>
+);
+
+const NavItemWithTooltip = ({
+  to,
+  name,
+  tooltipContent = defaultContent,
+  onClick,
+  tooltipPlacement = 'top',
+  tooltipOffset,
+  role,
+  end,
+  id,
+  'aria-controls': ariaControls,
+  'data-test-id': testId = 'nav-item-with-tooltip',
+}: NavItemWithTooltipProps) => {
+  const centeredContent = <div className={styles['NavItem-tooltip']}>{tooltipContent}</div>;
+  return (
+    <Tooltip
+      content={centeredContent}
+      placement={tooltipPlacement}
+      offset={tooltipOffset}
+      allowBoundaryElementOverflow
+      targetClassName={styles['NavPopover-target']}
+      data-test-id={testId}
+    >
+      <NavItem
+        end={end}
+        to={to}
+        name={name}
+        onClick={onClick}
+        role={role}
+        id={id}
+        aria-controls={ariaControls}
+      />
+    </Tooltip>
+  );
+};
+
+export { NavItemWithTooltip };
+export type { NavItemWithTooltipProps };

--- a/packages/navigation/src/legacy/Navigation.tsx
+++ b/packages/navigation/src/legacy/Navigation.tsx
@@ -1,0 +1,91 @@
+import type { NavProps } from './Nav';
+import type { CollectionBase } from '@react-types/shared';
+
+import { useResizeObserver, useValueEffect } from '@react-aria/utils';
+import { cx } from 'classix';
+import { useCallback, useEffect, useRef } from 'react';
+
+import { NavigationContext } from './NavigationContext';
+import { NavigationList } from './NavigationList';
+import styles from './styles/Navigation.module.css';
+import { useMediaQuery } from './utils';
+
+type NavigationProps<T extends object> = CollectionBase<T> & {
+  title: string;
+  kind?: NavProps['kind'];
+  role?: string;
+  'data-test-id'?: string;
+  className?: string;
+};
+
+const Navigation = <T extends object>(props: NavigationProps<T>) => {
+  const { children, className, 'data-test-id': testId = 'navigation' } = props;
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const itemListRef = useRef<HTMLDivElement>(null);
+  const [shouldCollapse, setCollapse] = useValueEffect(false);
+
+  const isWideViewport = useMediaQuery('(min-width: 740px)');
+
+  // From react-spectrum: https://github.com/adobe/react-spectrum/blob/main/packages/%40react-spectrum/tabs/src/Tabs.tsx#L82
+  const checkShouldCollapse = useCallback(() => {
+    function computeShouldCollapse() {
+      if (!wrapperRef.current || !itemListRef.current) {
+        return false;
+      }
+
+      // This is where we're explicitly tied to NavItem
+      const tabs = itemListRef.current.querySelectorAll("[data-nav-target='true']");
+      const lastTab = tabs[tabs.length - 1];
+
+      const containerEdge = wrapperRef.current.getBoundingClientRect().right;
+      const lastTabEdge = lastTab?.getBoundingClientRect().right;
+
+      return containerEdge < lastTabEdge;
+    }
+
+    setCollapse(function* () {
+      if (isWideViewport) {
+        yield false;
+        return;
+      }
+
+      // Make Tabs render in non-collapsed state
+      yield false;
+
+      // Compute if Tabs should collapse and update
+      yield computeShouldCollapse();
+    });
+  }, [wrapperRef, itemListRef, isWideViewport, setCollapse]);
+
+  useEffect(() => {
+    checkShouldCollapse();
+  }, [children, checkShouldCollapse, isWideViewport]);
+
+  useResizeObserver({ ref: wrapperRef, onResize: checkShouldCollapse });
+
+  return (
+    <div
+      className={cx(
+        styles.Navigation,
+        shouldCollapse && styles['Navigation--collapsed'],
+        className
+      )}
+      data-test-id={testId}
+    >
+      <NavigationContext.Provider
+        value={{
+          shouldCollapse,
+          refs: {
+            wrapperRef,
+            itemListRef,
+          },
+        }}
+      >
+        <NavigationList {...props} />
+      </NavigationContext.Provider>
+    </div>
+  );
+};
+
+export { Navigation };
+export type { NavigationProps };

--- a/packages/navigation/src/legacy/NavigationContext.ts
+++ b/packages/navigation/src/legacy/NavigationContext.ts
@@ -1,0 +1,26 @@
+import type { RefObject } from 'react';
+
+import { createContext, useContext } from 'react';
+
+type NavigationContextModel = {
+  shouldCollapse: boolean;
+  refs: {
+    wrapperRef: RefObject<HTMLDivElement>;
+    itemListRef: RefObject<HTMLDivElement>;
+  };
+};
+
+const NavigationContext = createContext<NavigationContextModel | undefined>(undefined);
+
+const useNavigationContext = () => {
+  const context = useContext(NavigationContext);
+
+  if (context === undefined) {
+    throw new Error('useNavigationContext must be used within a NavigationContext provider');
+  }
+
+  return context;
+};
+
+export { NavigationContext, useNavigationContext };
+export type { NavigationContextModel };

--- a/packages/navigation/src/legacy/NavigationItem.tsx
+++ b/packages/navigation/src/legacy/NavigationItem.tsx
@@ -1,0 +1,25 @@
+import type { NavItemProps } from './NavItem';
+import type { NavItemWithTooltipProps } from './NavItemWithTooltip';
+import type { ReactElement } from 'react';
+
+type NavigationItemProps = NavItemProps &
+  NavItemWithTooltipProps & {
+    tooltip?: boolean | ReactElement;
+  };
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const NavigationItem = (_props: NavigationItemProps) => {
+  return null;
+};
+
+NavigationItem.getCollectionNode = function* (props: NavigationItemProps) {
+  yield {
+    type: 'item',
+    props,
+    'aria-label': props.name,
+    hasChildNodes: false,
+  };
+};
+
+export { NavigationItem };
+export type { NavigationItemProps };

--- a/packages/navigation/src/legacy/NavigationList.tsx
+++ b/packages/navigation/src/legacy/NavigationList.tsx
@@ -1,0 +1,71 @@
+import type { NavProps } from './Nav';
+import type { CollectionBase } from '@react-types/shared';
+
+import { useListState } from '@react-stately/list';
+
+import { Nav } from './Nav';
+import { NavItem } from './NavItem';
+import { NavItemWithTooltip } from './NavItemWithTooltip';
+import { useNavigationContext } from './NavigationContext';
+import { NavigationMenuDropdown } from './NavigationMenuDropdown';
+import styles from './styles/Navigation.module.css';
+
+type NavigationListProps<T extends object> = CollectionBase<T> & {
+  title: string;
+  kind?: NavProps['kind'];
+};
+
+const NavigationList = <T extends object>({
+  kind = 'primary',
+  title,
+  ...rest
+}: NavigationListProps<T>) => {
+  const state = useListState(rest);
+
+  const { shouldCollapse, refs } = useNavigationContext();
+
+  return (
+    <div className={styles['NavigationList-wrapper']} ref={refs.wrapperRef}>
+      {shouldCollapse ? (
+        <NavigationMenuDropdown title={title} aria-label={title} {...rest} />
+      ) : (
+        <Nav kind={kind} ref={refs.itemListRef}>
+          {[...state.collection].map((item) =>
+            item.props.tooltip ? (
+              <NavItemWithTooltip
+                key={item.key}
+                to={item.props.to}
+                id={item.props.id}
+                name={item.props.name}
+                role={item.props.role}
+                aria-controls={item.props['aria-controls']}
+                tooltipContent={
+                  typeof item.props.tooltip === 'boolean' ? undefined : item.props.tooltip
+                }
+                tooltipOffset={item.props.tooltipOffset}
+                tooltipPlacement={item.props.tooltipPlacement}
+                onClick={item.props.onClick}
+                end={item.props.end}
+              />
+            ) : (
+              <NavItem
+                key={item.key}
+                to={item.props.to}
+                id={item.props.id}
+                name={item.props.name}
+                status={item.props.status}
+                role={item.props.role}
+                aria-controls={item.props['aria-controls']}
+                onClick={item.props.onClick}
+                end={item.props.end}
+              />
+            )
+          )}
+        </Nav>
+      )}
+    </div>
+  );
+};
+
+export { NavigationList };
+export type { NavigationListProps };

--- a/packages/navigation/src/legacy/NavigationMenuDropdown.tsx
+++ b/packages/navigation/src/legacy/NavigationMenuDropdown.tsx
@@ -1,0 +1,46 @@
+import type { CollectionBase } from '@react-types/shared';
+
+import { Chip } from '@launchpad-ui/chip';
+import { Dropdown, DropdownButton } from '@launchpad-ui/dropdown';
+import { Menu, MenuItem } from '@launchpad-ui/menu';
+import { useListState } from '@react-stately/list';
+import { NavLink } from 'react-router-dom';
+
+import { titlecase } from './utils';
+
+type NavigationMenuDropdownProps<T extends object> = CollectionBase<T> & {
+  title: string;
+};
+
+const NavigationMenuDropdown = <T extends object>(props: NavigationMenuDropdownProps<T>) => {
+  const state = useListState(props);
+
+  return (
+    <Dropdown>
+      <DropdownButton data-test-id="navigation-menu-button">{props.title}</DropdownButton>
+      <Menu>
+        {[...state.collection].map((item) => (
+          <MenuItem
+            key={item.key}
+            item={item.key}
+            component={NavLink}
+            to={item.props.to}
+            onClick={item.props.onClick}
+          >
+            <div style={{ display: 'flex', gap: 'var(--lp-spacing-300)', alignItems: 'center' }}>
+              <div>{item.props.name}</div>
+              {item.props.status ? (
+                <div>
+                  <Chip kind={item.props.status}>{titlecase(item.props.status)}</Chip>
+                </div>
+              ) : undefined}
+            </div>
+          </MenuItem>
+        ))}
+      </Menu>
+    </Dropdown>
+  );
+};
+
+export { NavigationMenuDropdown };
+export type { NavigationMenuDropdownProps };

--- a/packages/navigation/src/legacy/styles/Navigation.module.css
+++ b/packages/navigation/src/legacy/styles/Navigation.module.css
@@ -1,0 +1,173 @@
+@import '../../../../tokens/dist/media-queries.css';
+
+:root {
+  --page-gutter-width: 1rem;
+}
+
+@media (--tablet) {
+  :root {
+    --page-gutter-width: 4rem;
+  }
+}
+
+.Navigation .Nav--primary {
+  padding: 0 2.5rem;
+  background-color: var(--lp-color-bg-ui-secondary);
+  box-shadow: 0 1px 2px hsl(0 0% 0% / 0.12);
+  overflow-x: auto;
+}
+
+.Navigation--collapsed {
+  background-color: #fff;
+  box-shadow: 0 1px 2px hsl(0 0% 0% / 0.12);
+  padding: 1rem var(--page-gutter-width);
+}
+
+.Navigation--collapsed .NavigationList-wrapper {
+  padding: 1 1.4rem;
+}
+
+.Nav {
+  max-width: 100%;
+  width: 100%;
+  display: flex;
+  position: relative;
+}
+
+.Nav--secondary {
+  border-bottom: 1px solid var(--lp-color-border-ui-secondary);
+}
+
+.Nav--primary > .NavPopover-target {
+  display: flex;
+}
+
+.NavItem {
+  justify-content: flex-end;
+}
+
+.Nav--primary .NavItem {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  font-size: 1.5rem;
+  font-weight: var(--lp-font-weight-medium);
+  padding: 1rem 1.4rem;
+  border-bottom: 2px solid transparent;
+  text-decoration: none;
+  color: var(--lp-color-text-interactive-secondary);
+  position: relative;
+  border-radius: 0;
+}
+
+/* This pseudo-element renders the item name in bold to avoid shifting the other items
+ * when the font weight changes (for .is-active).
+ */
+.Nav--primary .NavItem::after {
+  font-weight: var(--lp-font-weight-bold);
+  content: attr(data-text);
+  height: 0;
+  visibility: hidden;
+  overflow: hidden;
+  user-select: none;
+  pointer-events: none;
+  padding: 0.1rem 1rem 0.2rem;
+}
+
+.Nav--primary .NavItem.is-active {
+  color: var(--lp-color-text-ui-primary);
+  border-bottom-color: var(--lp-color-text-ui-primary);
+  font-weight: var(--lp-font-weight-bold);
+}
+
+.NavItem-name {
+  padding: 0.1rem 1rem 0.2rem;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.NavItem:focus {
+  border-radius: 0;
+  box-shadow: none;
+}
+
+.Nav--secondary .NavItem {
+  display: block;
+  font-size: 1.7rem;
+  font-weight: var(--lp-font-weight-medium);
+  padding: 1rem 1.4rem 0;
+  border-bottom: 1px solid transparent;
+  text-decoration: none;
+  color: var(--lp-color-text-ui-secondary);
+  position: relative;
+  border-radius: 0;
+}
+
+.Nav--primary .NavItem:focus {
+  outline: none;
+}
+
+.NavItem:focus .NavItem-name {
+  padding: 0.1rem 1rem 0.2rem;
+  box-shadow: 0 0 0 0.2rem var(--lp-color-blue-500);
+  border-radius: 0.6rem;
+}
+
+.Nav--primary .NavItem:hover {
+  color: var(--lp-color-text-ui-primary);
+}
+
+.Nav--primary a.NavItem:hover,
+.Nav--primary a.NavItem:active {
+  color: var(--lp-color-text-ui-primary);
+  text-decoration: none;
+}
+
+.Nav--primary .NavItem:focus:not(:focus-visible) {
+  outline: unset;
+}
+
+.NavItem:focus:not(:focus-visible) .NavItem-name {
+  box-shadow: unset;
+  border-radius: unset;
+}
+
+.Nav--secondary .Nav-items {
+  gap: 1rem;
+}
+
+@media (--tablet) {
+  .Nav--secondary .Nav-items {
+    gap: 0;
+  }
+}
+
+.Nav--secondary .NavItem.is-active {
+  color: var(--lp-color-text-ui-primary);
+  border-bottom: 0.3rem solid var(--lp-color-border-interactive-secondary-active);
+  margin-bottom: -0.16rem; /* slightly larger than half to account for browser rounding */
+}
+
+.Nav--secondary .NavItem.is-active::before,
+.Nav--secondary .NavItem.is-active::after {
+  content: '';
+  position: absolute;
+  left: 50%;
+}
+
+.Nav--secondary .NavItem.is-active::after {
+  border-bottom-color: var(--lp-color-border-interactive-secondary-active);
+  bottom: -2px;
+}
+
+.NavItem-chip {
+  align-self: flex-start;
+  border-radius: 0.4rem;
+  margin-top: 0.4rem;
+  min-width: 3.5rem;
+  padding: 0.1rem 0;
+}
+
+.NavItem-tooltip {
+  text-align: center;
+}

--- a/packages/navigation/src/legacy/utils.ts
+++ b/packages/navigation/src/legacy/utils.ts
@@ -1,0 +1,28 @@
+import { useEffect, useState } from 'react';
+
+const titlecase = (str: string) => {
+  return str
+    .toString()
+    .toLowerCase()
+    .replace(/\b([a-z])/g, (ch) => ch.toUpperCase());
+};
+
+const useMediaQuery = (query: string) => {
+  const [matches, setMatches] = useState(false);
+
+  useEffect(() => {
+    const media = window.matchMedia(query);
+    if (media.matches !== matches) {
+      setMatches(media.matches);
+    }
+    const handleMediaChange = () => {
+      setMatches(media.matches);
+    };
+    media.addEventListener('change', handleMediaChange);
+    return () => media.addEventListener('change', handleMediaChange);
+  }, [matches, query]);
+
+  return matches;
+};
+
+export { titlecase, useMediaQuery };


### PR DESCRIPTION
## Summary

Adding back the legacy versions of `<Navigation />` that were changed in https://github.com/launchdarkly/launchpad-ui/pull/603

## Screenshots (if appropriate):

<!-- Are there any visual changes that would be helpful to the reviewer to see? -->

## Testing approaches

<!-- How are these changes tested? -->
