### PR TITLE
refactor(banner): remove dismissible prop in favor of onDismiss prop

### DIFF
--- a/.changeset/big-geckos-draw.md
+++ b/.changeset/big-geckos-draw.md
@@ -1,0 +1,5 @@
+---
+'@launchpad-ui/banner': minor
+---
+
+[Banner]: Remove dismissible banner prop

--- a/packages/banner/__tests__/Banner.cy.tsx
+++ b/packages/banner/__tests__/Banner.cy.tsx
@@ -12,8 +12,9 @@ describe('Banner', () => {
   });
 
   it('can be dismissible', () => {
+    const onDismissSpy = cy.spy().as('onDismissSpy');
     cy.mount(
-      <Banner kind="info" dismissible>
+      <Banner kind="info" onDismiss={onDismissSpy}>
         An important message
       </Banner>
     );
@@ -35,7 +36,7 @@ describe('Banner', () => {
     const onDismissSpy = cy.spy().as('onDismissSpy');
     const content = 'An important message';
     cy.mount(
-      <Banner kind="info" onDismiss={onDismissSpy} dismissible>
+      <Banner kind="info" onDismiss={onDismissSpy}>
         {content}
       </Banner>
     );

--- a/packages/banner/__tests__/Banner.spec.tsx
+++ b/packages/banner/__tests__/Banner.spec.tsx
@@ -18,8 +18,9 @@ describe('Banner', () => {
   });
 
   it('can be dismissible', async () => {
+    const onDismiss = vi.fn();
     render(
-      <Banner kind="info" dismissible>
+      <Banner kind="info" onDismiss={onDismiss}>
         An important message
       </Banner>
     );
@@ -42,7 +43,7 @@ describe('Banner', () => {
     const user = userEvent.setup();
     const content = 'An important message';
     render(
-      <Banner kind="info" onDismiss={onDismiss} dismissible>
+      <Banner kind="info" onDismiss={onDismiss}>
         {content}
       </Banner>
     );

--- a/packages/banner/src/Banner.tsx
+++ b/packages/banner/src/Banner.tsx
@@ -10,7 +10,6 @@ type BannerProps = HTMLAttributes<HTMLDivElement> & {
   'data-test-id'?: string;
   kind: 'info' | 'warning' | 'error';
   onDismiss?(): void;
-  dismissible?: boolean;
   header?: ReactNode;
 };
 
@@ -19,7 +18,6 @@ const Banner = ({
   className,
   children,
   onDismiss,
-  dismissible,
   header,
   'data-test-id': testId = 'banner',
   ...rest
@@ -37,7 +35,7 @@ const Banner = ({
         {header && <h4 className={styles['Banner-heading']}>{header}</h4>}
         <div>{children}</div>
       </div>
-      {dismissible && (
+      {!!onDismiss && (
         <IconButton
           aria-label="Close banner"
           icon={<Close size="small" />}


### PR DESCRIPTION
## Summary

<!-- What is changing and why? -->
Fix bugs where `dismissible` props were passed to the banner component without an `onDismiss` function. This results in the banner _not_ being dismissed when clicked. 