### PR TITLE
fix(alert): add break-word property to alert content

### DIFF
--- a/.changeset/silver-spiders-itch.md
+++ b/.changeset/silver-spiders-itch.md
@@ -1,0 +1,6 @@
+---
+'@launchpad-ui/alert': patch
+'@launchpad-ui/core': patch
+---
+
+[Alert] Add `word-break: break-word` to alert content container

--- a/packages/alert/src/styles/Alert.module.css
+++ b/packages/alert/src/styles/Alert.module.css
@@ -107,6 +107,7 @@
 .Alert-content {
   flex-grow: 1;
   max-width: 70rem;
+  word-break: break-word;
 }
 
 .Alert-close {


### PR DESCRIPTION
## Summary
Adds break-word property to alert content to avoid content flowing outside alert container by default.