### PR TITLE
fix: bump z-index values across design system

### DIFF
--- a/.changeset/four-cups-poke.md
+++ b/.changeset/four-cups-poke.md
@@ -1,0 +1,18 @@
+---
+'@launchpad-ui/drawer': patch
+'@launchpad-ui/modal': patch
+'@launchpad-ui/popover': patch
+'@launchpad-ui/snackbar': patch
+'@launchpad-ui/toast': patch
+'@launchpad-ui/tooltip': patch
+'@launchpad-ui/core': patch
+---
+
+Bump z-index values
+
+[Drawer] Increase z-index from 300 to 400
+[Modal] Increase z-index from 400 to 500
+[Popover] Increase z-index from 500 to 600
+[Snackbar] Increase z-index from 700 to 800
+[Toast] Increase z-index from 700 to 800
+[Tooltip] Increase z-index from 600 to 700

--- a/packages/drawer/src/styles/Drawer.module.css
+++ b/packages/drawer/src/styles/Drawer.module.css
@@ -15,7 +15,7 @@
 }
 
 .drawer {
-  z-index: var(--lp-z-index-300);
+  z-index: var(--lp-z-index-400);
   position: fixed;
   top: 0;
   right: 0;

--- a/packages/modal/src/styles/Modal.module.css
+++ b/packages/modal/src/styles/Modal.module.css
@@ -5,7 +5,7 @@
 }
 
 .overlayContainer {
-  z-index: var(--lp-z-index-400);
+  z-index: var(--lp-z-index-500);
   position: fixed;
   inset: 0;
   transform: translateZ(0);

--- a/packages/popover/src/styles/Popover.module.css
+++ b/packages/popover/src/styles/Popover.module.css
@@ -3,7 +3,7 @@
 }
 
 .Popover {
-  z-index: var(--lp-z-index-500);
+  z-index: var(--lp-z-index-600);
   position: absolute;
 }
 

--- a/packages/snackbar/src/styles/SnackbarCenter.module.css
+++ b/packages/snackbar/src/styles/SnackbarCenter.module.css
@@ -4,7 +4,7 @@
   right: 2rem;
   bottom: auto;
   left: auto;
-  z-index: var(--lp-z-index-700);
+  z-index: var(--lp-z-index-800);
 }
 
 .SnackbarCenter-item:not(:first-child) {

--- a/packages/toast/src/styles/ToastCenter.module.css
+++ b/packages/toast/src/styles/ToastCenter.module.css
@@ -5,7 +5,7 @@
   transform: translateX(-50%);
   right: auto;
   top: auto;
-  z-index: var(--lp-z-index-700);
+  z-index: var(--lp-z-index-800);
 }
 
 .ToastCenter-item {

--- a/packages/tooltip/src/styles/Tooltip.module.css
+++ b/packages/tooltip/src/styles/Tooltip.module.css
@@ -1,5 +1,5 @@
 .Tooltip {
-  z-index: var(--lp-z-index-600);
+  z-index: var(--lp-z-index-700);
 }
 
 [class^='_Popover-content_'].Tooltip-popover-content {


### PR DESCRIPTION
## Summary
Currently, we have z-index levels 100 through 900. LaunchPad occupies 300 through 700. In our main app, this only leaves levels 100 and 200 for app-level z-indexing. This isn't enough, since we have three levels of z-indexing that need to be considered. Since we technically still have levels 800 and 900 unassigned, the solution presented in this PR is to bump all z-indexes in LaunchPad by +100, so that we have 1 extra z-index level available in the consumer app levels.

Here is the impetus for this fix (where both the banner container and the app sidebar use z-index-100, and neither should be bumped to 200 since topbar currently occupies that value):
<img width="1009" alt="Screen Shot 2023-01-27 at 2 25 34 PM" src="https://user-images.githubusercontent.com/104940219/215190303-a3bc3d99-efdd-41f3-9b48-d9fd08f4e388.png">
