### PR TITLE
chore: minor bump in core and filter after updating to react-router-dom@6.7.0

### DIFF
--- a/.changeset/pretty-schools-study.md
+++ b/.changeset/pretty-schools-study.md
@@ -1,0 +1,6 @@
+---
+'@launchpad-ui/core': minor
+'@launchpad-ui/filter': minor
+---
+
+update to react-router-dom@6.7.0


### PR DESCRIPTION
## Summary

Tacking this on after realizing the https://github.com/launchdarkly/launchpad-ui/pull/673 incorrectly marked `core` and `filter` as patch updates (instead of minor updates to match `menu` and `navigation`).

## Screenshots (if appropriate):

<!-- Are there any visual changes that would be helpful to the reviewer to see? -->

## Testing approaches

<!-- How are these changes tested? -->
