### PR TITLE
fix(copy-to-clipboard): add button type to default copy button

### DIFF
--- a/.changeset/curly-ligers-yawn.md
+++ b/.changeset/curly-ligers-yawn.md
@@ -1,0 +1,6 @@
+---
+'@launchpad-ui/clipboard': patch
+'@launchpad-ui/core': patch
+---
+
+[CopyToClipboard] Add type='button' to default copy code button

--- a/packages/clipboard/src/CopyCodeButton.tsx
+++ b/packages/clipboard/src/CopyCodeButton.tsx
@@ -16,6 +16,7 @@ const CopyCodeButton = forwardRef<HTMLButtonElement, CopyCodeButtonProps>(
       <button
         ref={ref}
         data-test-id={testId}
+        type="button"
         className={cx(styles['CopyCodeButton'], className)}
         {...rest}
       >


### PR DESCRIPTION
## Summary
The default copy button's `type` attribute defaults to `submit`, which potentially triggers unwanted form submissions.