### PR TITLE
fix(form): update form stories and make FormField use Label component

### DIFF
--- a/.changeset/long-goats-sleep.md
+++ b/.changeset/long-goats-sleep.md
@@ -1,0 +1,6 @@
+---
+'@launchpad-ui/form': patch
+'@launchpad-ui/core': patch
+---
+
+[Form] Update TextField to use LaunchPad Label component

--- a/packages/form/src/FormField.tsx
+++ b/packages/form/src/FormField.tsx
@@ -3,7 +3,7 @@ import { cx } from 'classix';
 import { FieldError } from './FieldError';
 import { FormGroup } from './FormGroup';
 import { FormHint } from './FormHint';
-import { RequiredAsterisk } from './RequiredAsterisk';
+import { Label } from './Label';
 import styles from './styles/Form.module.css';
 
 type FormFieldProps = {
@@ -49,10 +49,9 @@ const FormField = ({
       data-test-id={testId}
     >
       {label && (
-        <label htmlFor={htmlFor}>
+        <Label htmlFor={htmlFor} required={isRequired}>
           {label}
-          {isRequired && <RequiredAsterisk />}
-        </label>
+        </Label>
       )}
       {hint && <FormHint className={styles.hint}>{hint}</FormHint>}
       {children}

--- a/packages/form/stories/FormGroup.stories.tsx
+++ b/packages/form/stories/FormGroup.stories.tsx
@@ -55,4 +55,29 @@ export const Default: Story = {
       </>
     ),
   },
+  render: () => {
+    return (
+      <>
+        <p>
+          A FormGroup is a wrapper to a form section that provides vertical spacing via top and
+          bottom margin.
+        </p>
+        <p>Below are two fields each wrapped in a FormGroup.</p>
+        <FormGroup>
+          <Label htmlFor="key">
+            Key <RequiredAsterisk />
+          </Label>
+          <TextField id="key" name="key" />
+          <FormHint>Use this key in your code.</FormHint>
+        </FormGroup>
+        <FormGroup>
+          <Label htmlFor="key">
+            Key <RequiredAsterisk />
+          </Label>
+          <TextField id="key" name="key" />
+          <FormHint>Use this key in your code.</FormHint>
+        </FormGroup>
+      </>
+    );
+  },
 };

--- a/packages/form/stories/Label.stories.tsx
+++ b/packages/form/stories/Label.stories.tsx
@@ -1,6 +1,6 @@
 import type { StoryObj } from '@storybook/react';
 
-import { Label, TextField } from '../src';
+import { Label } from '../src';
 
 export default {
   component: Label,
@@ -55,11 +55,22 @@ type Story = StoryObj<typeof Label>;
 export const Default: Story = {
   args: {
     htmlFor: 'name',
-    children: (
-      <>
-        Name
-        <TextField id="name" />
-      </>
-    ),
+    children: 'Name',
+  },
+};
+
+export const WithOptional: Story = {
+  args: {
+    htmlFor: 'name',
+    children: 'Name',
+    optional: true,
+  },
+};
+
+export const WithRequired: Story = {
+  args: {
+    htmlFor: 'name',
+    children: 'Name',
+    required: true,
   },
 };

--- a/packages/form/stories/TextField.stories.tsx
+++ b/packages/form/stories/TextField.stories.tsx
@@ -1,7 +1,7 @@
 import type { StoryObj, DecoratorFn, StoryFn } from '@storybook/react';
 
 import { createWithClassesDecorator, PseudoClasses } from '../../../.storybook/utils';
-import { Label, TextField } from '../src';
+import { TextField } from '../src';
 
 import './TextArea.stories.css';
 
@@ -101,7 +101,6 @@ export const Example: Story = {
     const textFieldId = `${id} Text Field`;
     return (
       <div>
-        <Label htmlFor={textFieldId}>{textFieldId}</Label>
         <TextField id={textFieldId} {...args} />
       </div>
     );
@@ -120,7 +119,6 @@ export const NumberWithSuffix: Story = {
     const numberFieldId = `${id} Number Field`;
     return (
       <div className="Textarea-number-wrapper">
-        <Label htmlFor={numberFieldId}>{numberFieldId}</Label>
         <TextField {...args} id={numberFieldId} />
       </div>
     );


### PR DESCRIPTION
## Summary
- Use LaunchPad `Label` component in `FormField` component. Design asked us why some labels were being rendered at 16px font size, and it was because we were using `FormField` in some places, and this was using a browser native `label` element and not receiving the correct font size.
- Improve Form stories to more properly convey what the scope of each Form component actually is.