### PR TITLE
feat(drawer): add cancel icon toggle to Drawer

### DIFF
--- a/.changeset/poor-cooks-sniff.md
+++ b/.changeset/poor-cooks-sniff.md
@@ -1,0 +1,6 @@
+---
+'@launchpad-ui/drawer': minor
+'@launchpad-ui/core': minor
+---
+
+Add cancel icon toggle prop to Drawer

--- a/packages/drawer/__tests__/Drawer.spec.tsx
+++ b/packages/drawer/__tests__/Drawer.spec.tsx
@@ -13,6 +13,7 @@ describe('Drawer', () => {
       </Drawer>
     );
     expect(await screen.findByRole('dialog')).toBeInTheDocument();
+    expect(await screen.findByTestId('drawer-close-button')).toBeInTheDocument();
   });
 
   it('calls onCancel when escape key is pressed', async () => {

--- a/packages/drawer/__tests__/Drawer.spec.tsx
+++ b/packages/drawer/__tests__/Drawer.spec.tsx
@@ -28,4 +28,14 @@ describe('Drawer', () => {
 
     expect(spy).toHaveBeenCalledTimes(1);
   });
+
+  it('hides cancel button when hideCancel is passed in', async () => {
+    render(
+      <Drawer hideCancel>
+        <DrawerHeader>Drawer</DrawerHeader>
+      </Drawer>
+    );
+
+    expect(screen.queryByTestId('drawer-close-button')).not.toBeInTheDocument();
+  });
 });

--- a/packages/drawer/src/Drawer.tsx
+++ b/packages/drawer/src/Drawer.tsx
@@ -50,7 +50,7 @@ const Drawer = ({
   onCancel,
   size = 'small',
   'data-test-id': testId = 'drawer',
-  hideCancel = true,
+  hideCancel = false,
 }: DrawerProps) => {
   const ref = useRef<HTMLDivElement>(null);
 

--- a/packages/drawer/src/Drawer.tsx
+++ b/packages/drawer/src/Drawer.tsx
@@ -41,6 +41,7 @@ type DrawerProps = {
   onCancel?(): void;
   'data-test-id'?: string;
   size?: 'small' | 'medium' | 'large' | 'xLarge' | 'full';
+  hideCancel?: boolean;
 };
 
 const Drawer = ({
@@ -49,6 +50,7 @@ const Drawer = ({
   onCancel,
   size = 'small',
   'data-test-id': testId = 'drawer',
+  hideCancel = true,
 }: DrawerProps) => {
   const ref = useRef<HTMLDivElement>(null);
 
@@ -111,13 +113,15 @@ const Drawer = ({
                 className={styles.content}
                 tabIndex={-1}
               >
-                <IconButton
-                  aria-label="close"
-                  icon={<Close size="medium" />}
-                  className={styles.closeButton}
-                  onClick={onCancel}
-                  data-test-id="drawer-close-button"
-                />
+                {!hideCancel && (
+                  <IconButton
+                    aria-label="close"
+                    icon={<Close size="medium" />}
+                    className={styles.closeButton}
+                    onClick={onCancel}
+                    data-test-id="drawer-close-button"
+                  />
+                )}
                 <Suspense fallback={<Progress />}>{children}</Suspense>
               </m.div>
             </FocusTrap>


### PR DESCRIPTION
## Summary

In the New Flag Creation Experience I had to add this CSS hack to make the cancel icon go away in Drawer:

```
.entity-creation__drawer > div > div > .IconButton {
  display: none;
}
```

We did this because this Drawer had several bits of custom UI for breaking out of it, and the icon was occupying space in the header of the drawer.

![image](https://user-images.githubusercontent.com/70972175/217373381-782cd2e8-9feb-4e0e-8edf-8a5db220983d.png)

To avoid doing such hacks in the future, Squonk wanted to add a toggle to the `Drawer`. It's a boolean flag that controls whether the `IconButton` appears in the DOM or not.

## Screenshots (if appropriate):

<!-- Are there any visual changes that would be helpful to the reviewer to see? -->

## Testing approaches

Added unit test coverage.
