### PR TITLE
chore(deps): update framer motion from 7.6.1 to 9.0.3

### DIFF
--- a/.changeset/chilly-rice-doubt.md
+++ b/.changeset/chilly-rice-doubt.md
@@ -1,0 +1,18 @@
+---
+'@launchpad-ui/clipboard': patch
+'@launchpad-ui/markdown': patch
+'@launchpad-ui/snackbar': patch
+'@launchpad-ui/popover': patch
+'@launchpad-ui/drawer': patch
+'@launchpad-ui/modal': patch
+'@launchpad-ui/toast': patch
+'@launchpad-ui/core': patch
+---
+
+Update `framer-motion` to latest version.
+
+[Snackbar]: Update `framer-motion` dependency from `7.6.1` to `9.0.3`
+[Popover]: Update `framer-motion` dependency from `7.6.1` to `9.0.3`
+[Drawer]: Update `framer-motion` dependency from `7.6.1` to `9.0.3`
+[Modal]: Update `framer-motion` dependency from `7.6.1` to `9.0.3`
+[Toast]: Update `framer-motion` dependency from `7.6.1` to `9.0.3`

--- a/packages/drawer/package.json
+++ b/packages/drawer/package.json
@@ -40,7 +40,7 @@
     "@launchpad-ui/tokens": "workspace:~",
     "@react-aria/overlays": "3.12.1",
     "classix": "2.1.17",
-    "framer-motion": "7.6.1"
+    "framer-motion": "9.0.3"
   },
   "peerDependencies": {
     "react": "18.2.0",

--- a/packages/modal/package.json
+++ b/packages/modal/package.json
@@ -39,7 +39,7 @@
     "@launchpad-ui/tokens": "workspace:~",
     "@react-aria/overlays": "3.12.1",
     "classix": "2.1.17",
-    "framer-motion": "7.6.1"
+    "framer-motion": "9.0.3"
   },
   "peerDependencies": {
     "react": "18.2.0",

--- a/packages/popover/package.json
+++ b/packages/popover/package.json
@@ -38,7 +38,7 @@
     "@launchpad-ui/overlay": "workspace:~",
     "@launchpad-ui/tokens": "workspace:~",
     "classix": "2.1.17",
-    "framer-motion": "7.6.1"
+    "framer-motion": "9.0.3"
   },
   "peerDependencies": {
     "react": "18.2.0",

--- a/packages/snackbar/package.json
+++ b/packages/snackbar/package.json
@@ -36,7 +36,7 @@
     "@launchpad-ui/icons": "workspace:~",
     "@launchpad-ui/tokens": "workspace:~",
     "classix": "2.1.17",
-    "framer-motion": "7.6.1"
+    "framer-motion": "9.0.3"
   },
   "peerDependencies": {
     "react": "18.2.0",

--- a/packages/toast/package.json
+++ b/packages/toast/package.json
@@ -35,7 +35,7 @@
     "@launchpad-ui/icons": "workspace:~",
     "@launchpad-ui/tokens": "workspace:~",
     "classix": "2.1.17",
-    "framer-motion": "7.6.1"
+    "framer-motion": "9.0.3"
   },
   "peerDependencies": {
     "react": "18.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -459,7 +459,7 @@ importers:
       '@launchpad-ui/tokens': workspace:~
       '@react-aria/overlays': 3.12.1
       classix: 2.1.17
-      framer-motion: 7.6.1
+      framer-motion: 9.0.3
       react: 18.2.0
       react-dom: 18.2.0
     dependencies:
@@ -471,7 +471,7 @@ importers:
       '@launchpad-ui/tokens': link:../tokens
       '@react-aria/overlays': 3.12.1_biqbaboplfbrettd7655fr4n2y
       classix: 2.1.17
-      framer-motion: 7.6.1_biqbaboplfbrettd7655fr4n2y
+      framer-motion: 9.0.3_biqbaboplfbrettd7655fr4n2y
     devDependencies:
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
@@ -624,7 +624,7 @@ importers:
       '@launchpad-ui/tokens': workspace:~
       '@react-aria/overlays': 3.12.1
       classix: 2.1.17
-      framer-motion: 7.6.1
+      framer-motion: 9.0.3
       react: 18.2.0
       react-dom: 18.2.0
     dependencies:
@@ -635,7 +635,7 @@ importers:
       '@launchpad-ui/tokens': link:../tokens
       '@react-aria/overlays': 3.12.1_biqbaboplfbrettd7655fr4n2y
       classix: 2.1.17
-      framer-motion: 7.6.1_biqbaboplfbrettd7655fr4n2y
+      framer-motion: 9.0.3_biqbaboplfbrettd7655fr4n2y
     devDependencies:
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
@@ -713,7 +713,7 @@ importers:
       '@launchpad-ui/overlay': workspace:~
       '@launchpad-ui/tokens': workspace:~
       classix: 2.1.17
-      framer-motion: 7.6.1
+      framer-motion: 9.0.3
       react: 18.2.0
       react-dom: 18.2.0
     dependencies:
@@ -723,7 +723,7 @@ importers:
       '@launchpad-ui/overlay': link:../overlay
       '@launchpad-ui/tokens': link:../tokens
       classix: 2.1.17
-      framer-motion: 7.6.1_biqbaboplfbrettd7655fr4n2y
+      framer-motion: 9.0.3_biqbaboplfbrettd7655fr4n2y
     devDependencies:
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
@@ -858,7 +858,7 @@ importers:
       '@launchpad-ui/icons': workspace:~
       '@launchpad-ui/tokens': workspace:~
       classix: 2.1.17
-      framer-motion: 7.6.1
+      framer-motion: 9.0.3
       react: 18.2.0
       react-dom: 18.2.0
     dependencies:
@@ -866,7 +866,7 @@ importers:
       '@launchpad-ui/icons': link:../icons
       '@launchpad-ui/tokens': link:../tokens
       classix: 2.1.17
-      framer-motion: 7.6.1_biqbaboplfbrettd7655fr4n2y
+      framer-motion: 9.0.3_biqbaboplfbrettd7655fr4n2y
     devDependencies:
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
@@ -933,14 +933,14 @@ importers:
       '@launchpad-ui/icons': workspace:~
       '@launchpad-ui/tokens': workspace:~
       classix: 2.1.17
-      framer-motion: 7.6.1
+      framer-motion: 9.0.3
       react: 18.2.0
       react-dom: 18.2.0
     dependencies:
       '@launchpad-ui/icons': link:../icons
       '@launchpad-ui/tokens': link:../tokens
       classix: 2.1.17
-      framer-motion: 7.6.1_biqbaboplfbrettd7655fr4n2y
+      framer-motion: 9.0.3_biqbaboplfbrettd7655fr4n2y
     devDependencies:
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
@@ -3854,25 +3854,25 @@ packages:
       '@motionone/easing': 10.15.1
       '@motionone/types': 10.15.1
       '@motionone/utils': 10.15.1
-      tslib: 2.4.0
+      tslib: 2.5.0
     dev: false
 
-  /@motionone/dom/10.13.1:
-    resolution: {integrity: sha512-zjfX+AGMIt/fIqd/SL1Lj93S6AiJsEA3oc5M9VkUr+Gz+juRmYN1vfvZd6MvEkSqEjwPQgcjN7rGZHrDB9APfQ==}
+  /@motionone/dom/10.15.5:
+    resolution: {integrity: sha512-Xc5avlgyh3xukU9tydh9+8mB8+2zAq+WlLsC3eEIp7Ax7DnXgY7Bj/iv0a4X2R9z9ZFZiaXK3BO0xMYHKbAAdA==}
     dependencies:
       '@motionone/animation': 10.15.1
       '@motionone/generators': 10.15.1
       '@motionone/types': 10.15.1
       '@motionone/utils': 10.15.1
       hey-listen: 1.0.8
-      tslib: 2.4.0
+      tslib: 2.5.0
     dev: false
 
   /@motionone/easing/10.15.1:
     resolution: {integrity: sha512-6hIHBSV+ZVehf9dcKZLT7p5PEKHGhDwky2k8RKkmOvUoYP3S+dXsKupyZpqx5apjd9f+php4vXk4LuS+ADsrWw==}
     dependencies:
       '@motionone/utils': 10.15.1
-      tslib: 2.4.0
+      tslib: 2.5.0
     dev: false
 
   /@motionone/generators/10.15.1:
@@ -3880,7 +3880,7 @@ packages:
     dependencies:
       '@motionone/types': 10.15.1
       '@motionone/utils': 10.15.1
-      tslib: 2.4.0
+      tslib: 2.5.0
     dev: false
 
   /@motionone/types/10.15.1:
@@ -3892,7 +3892,7 @@ packages:
     dependencies:
       '@motionone/types': 10.15.1
       hey-listen: 1.0.8
-      tslib: 2.4.0
+      tslib: 2.5.0
     dev: false
 
   /@nicolo-ribaudo/eslint-scope-5-internals/5.1.1-v1:
@@ -10884,28 +10884,19 @@ packages:
     resolution: {integrity: sha512-MhLuK+2gUcnZe8ZHlaaINnQLl0xRIGRfcGk2yl8xoQAfHrSsL3rYu6FCmBdkdbhc9EPlwyGHewaRsvwRMJtAlA==}
     dev: true
 
-  /framer-motion/7.6.1_biqbaboplfbrettd7655fr4n2y:
-    resolution: {integrity: sha512-8US03IWJKrLoSb81l5OahNzB9Sv7Jo1RhIwUoTG/25BRUdO9lOqq/klsdZqNmNG0ua9IEJJQ8hkYpETJ4N6VSw==}
+  /framer-motion/9.0.3_biqbaboplfbrettd7655fr4n2y:
+    resolution: {integrity: sha512-QcMWXcwvBmInzFpkIgtLx8VQ/+H9+EhiHVgnx6zsOWTGmcvzFqkrw6SLTZn5fKejCaf3RznqkshhxXipBpe9ig==}
     peerDependencies:
       react: ^18.0.0 || 18
       react-dom: ^18.0.0 || 18
     dependencies:
-      '@motionone/dom': 10.13.1
-      framesync: 6.1.2
+      '@motionone/dom': 10.15.5
       hey-listen: 1.0.8
-      popmotion: 11.0.5
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
-      style-value-types: 5.1.2
-      tslib: 2.4.0
+      tslib: 2.5.0
     optionalDependencies:
       '@emotion/is-prop-valid': 0.8.8
-    dev: false
-
-  /framesync/6.1.2:
-    resolution: {integrity: sha512-jBTqhX6KaQVDyus8muwZbBeGGP0XgujBRbQ7gM7BRdS3CadCZIHiawyzYLnafYcvZIh5j8WE7cxZKFn7dXhu9g==}
-    dependencies:
-      tslib: 2.4.0
     dev: false
 
   /fresh/0.5.2:
@@ -14869,15 +14860,6 @@ packages:
       '@babel/runtime': 7.20.13
     dev: true
 
-  /popmotion/11.0.5:
-    resolution: {integrity: sha512-la8gPM1WYeFznb/JqF4GiTkRRPZsfaj2+kCxqQgr2MJylMmIKUwBfWW8Wa5fml/8gmtlD5yI01MP1QCZPWmppA==}
-    dependencies:
-      framesync: 6.1.2
-      hey-listen: 1.0.8
-      style-value-types: 5.1.2
-      tslib: 2.4.0
-    dev: false
-
   /postcss-attribute-case-insensitive/6.0.2_postcss@8.4.21:
     resolution: {integrity: sha512-IRuCwwAAQbgaLhxQdQcIIK0dCVXg3XDUnzgKD8iwdiYdwU4rMWRWyl/W9/0nA4ihVpq5pyALiHB2veBJ0292pw==}
     engines: {node: ^14 || ^16 || >=18}
@@ -16978,13 +16960,6 @@ packages:
       inline-style-parser: 0.1.1
     dev: true
 
-  /style-value-types/5.1.2:
-    resolution: {integrity: sha512-Vs9fNreYF9j6W2VvuDTP7kepALi7sk0xtk2Tu8Yxi9UoajJdEVpNpCov0HsLTqXvNGKX+Uv09pkozVITi1jf3Q==}
-    dependencies:
-      hey-listen: 1.0.8
-      tslib: 2.4.0
-    dev: false
-
   /stylelint-config-prettier/9.0.4_stylelint@14.16.1:
     resolution: {integrity: sha512-38nIGTGpFOiK5LjJ8Ma1yUgpKENxoKSOhbDNSemY7Ep0VsJoXIW9Iq/2hSt699oB9tReynfWicTAoIHiq8Rvbg==}
     engines: {node: '>= 12'}
@@ -17465,10 +17440,6 @@ packages:
   /tslib/1.14.1:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
     dev: true
-
-  /tslib/2.4.0:
-    resolution: {integrity: sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==}
-    dev: false
 
   /tslib/2.5.0:
     resolution: {integrity: sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==}


### PR DESCRIPTION
## Summary
Followed along with the [upgrade guide for framer-motion](https://www.framer.com/motion/guide-upgrade/) to determine that we can safely update framer-motion to 9.0.3 from 7.6.1. Let's release this as a standalone version upgrade to LaunchPad so if something does pop up in Gonfalon, we can revert this in isolation. Gonfalon _also_ imports `framer-motion`, and I tested there that upgrading to 9.0.3 does not result in any test failures.