### PR TITLE
fix: update button styles to match Figma

### DIFF
--- a/.changeset/rich-ways-remember.md
+++ b/.changeset/rich-ways-remember.md
@@ -1,0 +1,7 @@
+---
+'@launchpad-ui/split-button': patch
+'@launchpad-ui/button': patch
+'@launchpad-ui/core': patch
+---
+
+[Button] Adjust sizing to match design system guidelines

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -23,6 +23,8 @@ jobs:
 
       - name: Publish to Chromatic
         uses: chromaui/action@v1
+        env:
+          NODE_OPTIONS: '--max_old_space_size=4096'
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           buildScriptName: 'storybook:build'

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -28,4 +28,5 @@ jobs:
           buildScriptName: 'storybook:build'
           exitOnceUploaded: true
           onlyChanged: true
+          exitZeroOnChanges: true
           externals: packages/(icons/icons|tokens/src)/**

--- a/packages/button/src/Button.tsx
+++ b/packages/button/src/Button.tsx
@@ -21,7 +21,7 @@ type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
   kind?: 'default' | 'primary' | 'destructive' | 'minimal' | 'link' | 'close';
   fit?: boolean;
   disabled?: boolean;
-  icon?: ReactElement<IconProps>;
+  icon?: ReactElement<Omit<IconProps, 'size'>>;
   renderIconFirst?: boolean;
   asChild?: boolean;
   'data-test-id'?: string;
@@ -58,11 +58,21 @@ const ButtonComponent = forwardRef<HTMLButtonElement, ButtonProps>((props, ref) 
     className
   );
 
+  const getIconSize = () => {
+    let iconSize: IconProps['size'] = 'small';
+
+    if (size === 'big') {
+      iconSize = 'medium';
+    }
+
+    return iconSize;
+  };
+
   const renderIcon =
     icon &&
-    cloneElement(icon, {
+    cloneElement(icon as ReactElement<IconProps>, {
       key: 'icon',
-      size: icon.props.size || 'small',
+      size: getIconSize(),
       'aria-hidden': true,
       className: cx(icon.props.className, 'Button-icon'),
     });

--- a/packages/button/src/styles/Button.css
+++ b/packages/button/src/styles/Button.css
@@ -8,7 +8,6 @@
   margin: 0;
   font-family: var(--lp-font-family-base);
   font-weight: var(--Button-font-weight);
-  letter-spacing: 0.05em;
   text-align: center;
   text-decoration: none;
   text-transform: var(--Button-text-transform);
@@ -18,7 +17,7 @@
   border-radius: var(--Button-border-radius-default);
   font-size: var(--Button-font-size-default);
   line-height: var(--Button-line-height-default);
-  padding: 0.5rem 0.8rem;
+  padding: 0.8rem;
   cursor: default;
   user-select: none;
   appearance: none;
@@ -37,14 +36,14 @@
   border-radius: var(--Button-border-radius-small);
   font-size: var(--Button-font-size-small);
   line-height: var(--Button-line-height-small);
-  padding: 0.3rem 0.7rem;
+  padding: 0.4rem 0.8rem;
   min-height: 2.5rem;
 }
 
 .Button--big {
   font-size: var(--Button-font-size-large);
   line-height: var(--Button-line-height-large);
-  padding: 1rem 1.4rem;
+  padding: 0.8rem 1.2rem;
   min-height: 4rem;
 }
 

--- a/packages/button/src/styles/Button.css
+++ b/packages/button/src/styles/Button.css
@@ -17,7 +17,7 @@
   border-radius: var(--Button-border-radius-default);
   font-size: var(--Button-font-size-default);
   line-height: var(--Button-line-height-default);
-  padding: 0.8rem;
+  padding: 0.7rem 0.8rem;
   cursor: default;
   user-select: none;
   appearance: none;
@@ -36,14 +36,14 @@
   border-radius: var(--Button-border-radius-small);
   font-size: var(--Button-font-size-small);
   line-height: var(--Button-line-height-small);
-  padding: 0.4rem 0.8rem;
+  padding: 0.3rem 0.8rem;
   min-height: 2.5rem;
 }
 
 .Button--big {
   font-size: var(--Button-font-size-large);
   line-height: var(--Button-line-height-large);
-  padding: 0.8rem 1.2rem;
+  padding: 0.7rem 1.2rem;
   min-height: 4rem;
 }
 

--- a/packages/button/src/styles/ButtonVariables.css
+++ b/packages/button/src/styles/ButtonVariables.css
@@ -20,7 +20,7 @@
   --Button-font-size-large: 1.6rem;
   --Button-font-weight: var(--lp-font-weight-medium);
   --Button-line-height-default: 114%;
-  --Button-line-height-small: 144%;
+  --Button-line-height-small: 114%;
   --Button-line-height-large: 150%;
   --Button-border-radius-default: 0.6rem;
   --Button-border-radius-small: var(--lp-border-radius-regular);

--- a/packages/button/src/styles/ButtonVariables.css
+++ b/packages/button/src/styles/ButtonVariables.css
@@ -15,13 +15,13 @@
 
   /* End Remaining Legacy Tokens */
 
-  --Button-font-size-default: 1.2rem;
-  --Button-font-size-small: 1.1rem;
-  --Button-font-size-large: 1.7rem;
-  --Button-font-weight: var(--lp-font-weight-bold);
-  --Button-line-height-default: 1.6667; /* 20px */
-  --Button-line-height-small: 1.5455; /* 17px */
-  --Button-line-height-large: 1.111; /* 20px */
+  --Button-font-size-default: 1.4rem;
+  --Button-font-size-small: 1.4rem;
+  --Button-font-size-large: 1.6rem;
+  --Button-font-weight: var(--lp-font-weight-medium);
+  --Button-line-height-default: 114%;
+  --Button-line-height-small: 144%;
+  --Button-line-height-large: 150%;
   --Button-border-radius-default: 0.6rem;
   --Button-border-radius-small: var(--lp-border-radius-regular);
   --Button-border-radius-link: 1px;

--- a/packages/button/stories/Button.stories.tsx
+++ b/packages/button/stories/Button.stories.tsx
@@ -181,23 +181,35 @@ export const AsAnchorChild: Story = {
   args: {
     children: <a href="/">Anchor tag</a>,
     asChild: true,
-    icon: <Add size="medium" />,
+    icon: <Add />,
     kind: 'destructive',
   },
 };
 
 export const WithIcon: Story = {
-  args: { children: 'With icon', icon: <Add size="medium" /> },
+  args: { children: 'With icon', icon: <Add /> },
 };
 
 export const WithIconPrimary: Story = {
-  args: { children: 'With icon', icon: <Add size="medium" />, kind: 'primary' },
+  args: { children: 'With icon', icon: <Add />, kind: 'primary' },
+};
+
+export const BigButtonWithIcon: Story = {
+  args: { children: 'Click me', icon: <Add />, kind: 'primary', size: 'big' },
+};
+
+export const SmallButtonWithIcon: Story = {
+  args: { children: 'Click me', icon: <Add />, kind: 'primary', size: 'small' },
+};
+
+export const TinyButtonWithIcon: Story = {
+  args: { children: 'Click me', icon: <Add />, kind: 'primary', size: 'tiny' },
 };
 
 export const WithIconDestructive: Story = {
   args: {
     children: 'With icon',
-    icon: <Add size="medium" />,
+    icon: <Add />,
     kind: 'destructive',
   },
 };

--- a/packages/button/stories/Button.stories.tsx
+++ b/packages/button/stories/Button.stories.tsx
@@ -2,7 +2,7 @@ import type { StoryObj, DecoratorFn } from '@storybook/react';
 
 import { Fragment } from 'react';
 
-import { Add } from '../../icons/src';
+import { Add, ExpandMore } from '../../icons/src';
 import { Button } from '../src';
 
 import './Button.stories.css';
@@ -191,7 +191,7 @@ export const WithIcon: Story = {
 };
 
 export const WithIconPrimary: Story = {
-  args: { children: 'With icon', icon: <Add />, kind: 'primary' },
+  args: { children: 'With icon', icon: <ExpandMore />, kind: 'primary' },
 };
 
 export const BigButtonWithIcon: Story = {

--- a/packages/split-button/src/styles/SplitButton.css
+++ b/packages/split-button/src/styles/SplitButton.css
@@ -6,7 +6,7 @@
   --SplitButton-drop-border-left: 1px;
   --SplitButton-drop-line-height: 1.7;
   --SplitButton-drop-margin: 0.1rem;
-  --SplitButton-drop-padding: 0.4rem 0 0.6rem;
+  --SplitButton-drop-padding: 0.7rem 0;
   --SplitButton-drop-padding-small: 0.2rem 0 0.3rem;
   --SplitButton-popoverTarget-line-height: 1;
   --SplitButton-border-focus-color: var(--lp-color-shadow-interactive-focus);

--- a/packages/split-button/src/styles/SplitButton.css
+++ b/packages/split-button/src/styles/SplitButton.css
@@ -25,6 +25,10 @@
   width: calc(var(--SplitButton-drop-width) + 0.2rem);
 }
 
+.SplitButton-drop.Button > span {
+  line-height: 1;
+}
+
 .SplitButton {
   align-items: flex-start;
   display: flex;


### PR DESCRIPTION
## Summary

I updated the button styles to match Figma.

## Screenshots (if appropriate):

![Screenshot 2023-02-15 at 4 15 19 PM](https://user-images.githubusercontent.com/329075/219225152-e7ce7085-20cd-4590-a10f-382d971cb5f9.png)

## Testing approaches

I just tested visually.

One thing to note is that I _think_ Launchpad isn't loading Inter, which makes developing in Launchpad tough since the font will always be different. I installed Inter locally while making these changes which I think fixed it, but it's hard for me to know for sure since Inter and the fallback font (apple system font? SF Pro?) are pretty similar. So if we could Inter in Storybook while developing it would help us stay closer to how everything is styled in gonfalon.
