### PR TITLE
feat(icons): add language icon component

### DIFF
--- a/.changeset/soft-boxes-know.md
+++ b/.changeset/soft-boxes-know.md
@@ -1,0 +1,6 @@
+---
+'@launchpad-ui/core': patch
+'@launchpad-ui/icons': patch
+---
+
+add "Language" icon component


### PR DESCRIPTION
## Summary

<!-- What is changing and why? -->
The "language" icon svg was added in a previous PR, but the corresponding `Language` icon component was not generated with it. This PR adds the component for the now-available icon.

## Screenshots (if appropriate):

<!-- Are there any visual changes that would be helpful to the reviewer to see? -->

## Testing approaches

<!-- How are these changes tested? -->
