### PR TITLE
feat(select): rename disabled prop and add styles

### DIFF
--- a/.changeset/selfish-bananas-leave.md
+++ b/.changeset/selfish-bananas-leave.md
@@ -1,0 +1,6 @@
+---
+'@launchpad-ui/select': patch
+'@launchpad-ui/core': patch
+---
+
+[Select] rename disabled prop and add styles

--- a/packages/select/src/MultiSelect/MultiSelect.tsx
+++ b/packages/select/src/MultiSelect/MultiSelect.tsx
@@ -31,7 +31,7 @@ const MultiSelect = <T extends object>(props: MultiSelectProps<T>) => {
     // className,
     excludeFromTabOrder,
     isClearable,
-    isDisabled,
+    disabled: isDisabled,
     isSelectableAll,
     label,
     trigger = MultiSelectTrigger,

--- a/packages/select/src/MultiSelect/useMultiSelect.ts
+++ b/packages/select/src/MultiSelect/useMultiSelect.ts
@@ -28,7 +28,7 @@ const useMultiSelect = <T extends object>(
   state: MultiSelectState<T>,
   refs: UseMultiSelectRefs
 ): SelectAria<T> => {
-  const { isDisabled, hasFilter } = props;
+  const { disabled: isDisabled, hasFilter } = props;
   const { triggerRef, listBoxRef, filterInputRef } = refs;
 
   const delegate = useMemo(
@@ -132,7 +132,7 @@ const useMultiSelect = <T extends object>(
     labelProps: {
       ...labelProps,
       onClick: () => {
-        if (!props.isDisabled) {
+        if (!props.disabled) {
           triggerRef.current?.focus();
 
           // Show the focus ring so the user knows where focus went

--- a/packages/select/src/SingleSelect/SingleSelect.tsx
+++ b/packages/select/src/SingleSelect/SingleSelect.tsx
@@ -24,7 +24,7 @@ const SingleSelect = <T extends object>(props: SingleSelectProps<T>) => {
   const {
     autoFocus,
     excludeFromTabOrder,
-    isDisabled,
+    disabled: isDisabled,
     label,
     trigger = SingleSelectTrigger,
     'data-test-id': testId = 'select',

--- a/packages/select/src/SingleSelect/useSingleSelect.ts
+++ b/packages/select/src/SingleSelect/useSingleSelect.ts
@@ -28,7 +28,7 @@ const useSingleSelect = <T extends object>(
   state: SingleSelectState<T>,
   refs: UseSingleSelectRefs
 ): SelectAria<T> => {
-  const { isDisabled, hasFilter } = props;
+  const { disabled: isDisabled, hasFilter } = props;
   const { triggerRef, listBoxRef, filterInputRef } = refs;
 
   const delegate = useMemo(
@@ -167,7 +167,7 @@ const useSingleSelect = <T extends object>(
     labelProps: {
       ...labelProps,
       onClick: () => {
-        if (!props.isDisabled) {
+        if (!props.disabled) {
           triggerRef.current?.focus();
 
           // Show the focus ring so the user knows where focus went

--- a/packages/select/src/styles/Select.module.css
+++ b/packages/select/src/styles/Select.module.css
@@ -85,6 +85,16 @@
     box-shadow: inset 0 1px 1px rgb(0 0 0 / 0.075), 0 0 0 3px rgb(0 126 255 / 0.1);
     border-color: var(--lp-color-border-field-focus);
   }
+
+  &:disabled {
+    opacity: 1;
+    background-color: var(--lp-color-bg-field-disabled);
+    border-color: var(--lp-color-border-field-disabled);
+  }
+
+  &:disabled:hover {
+    cursor: not-allowed;
+  }
 }
 
 .valueContainer {
@@ -108,6 +118,10 @@
   text-align: left;
   display: flex;
   align-items: center;
+
+  .trigger:disabled & {
+    color: var(--lp-color-text-field-disabled);
+  }
 }
 
 .indicatorsContainer {
@@ -117,6 +131,10 @@
   flex-shrink: 0;
   box-sizing: border-box;
   color: var(--lp-color-text-ui-tertiary);
+
+  .trigger:disabled & {
+    color: var(--lp-color-text-field-disabled);
+  }
 }
 
 .closeIndicatorContainer {

--- a/packages/select/src/types.ts
+++ b/packages/select/src/types.ts
@@ -35,7 +35,7 @@ type SharedSelectProps<T extends object> = CollectionBase<T> &
     excludeFromTabOrder?: boolean;
 
     /** Whether the field is disabled. */
-    isDisabled?: boolean;
+    disabled?: boolean;
 
     /** Sets the open state of the field (controlled). */
     isOpen?: boolean;


### PR DESCRIPTION
## Summary

Renaming the `isDisabled` prop to `disabled` for `SingleSelect` and `MultiSelect`, so that it's more inline with consumer / native HTML expectations. `react-aria` expects `isDisabled` for its internal hooks. 

I also added styles that were missing for disabled comboboxes.

## Screenshots (if appropriate):

disabled combobox in light mode
<img width="407" alt="disabled combobox in light mode" src="https://user-images.githubusercontent.com/109114820/222594156-53348b4d-e019-4be9-ac5c-6a4f9d55c0c2.png">


disabled combobox in light mode
<img width="407" alt="disabled combobox in dark mode" src="https://user-images.githubusercontent.com/109114820/222594277-8ca74f0e-0daf-4277-a998-d468d6b62b97.png">

