### PR TITLE
feat(Button): add minimal primary theme

### DIFF
--- a/.changeset/olive-clocks-study.md
+++ b/.changeset/olive-clocks-study.md
@@ -1,0 +1,6 @@
+---
+'@launchpad-ui/button': minor
+'@launchpad-ui/core': minor
+---
+
+[Button]: add minimal primary theme to button

--- a/packages/button/src/Button.tsx
+++ b/packages/button/src/Button.tsx
@@ -18,7 +18,7 @@ type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
   isLoading?: boolean;
   loadingText?: string | JSX.Element;
   size?: 'tiny' | 'small' | 'normal' | 'big';
-  kind?: 'default' | 'primary' | 'destructive' | 'minimal' | 'link' | 'close';
+  kind?: 'default' | 'primary' | 'destructive' | 'minimal' | 'link' | 'close' | 'minimal-primary';
   fit?: boolean;
   disabled?: boolean;
   icon?: ReactElement<Omit<IconProps, 'size'>>;

--- a/packages/button/src/styles/Button.css
+++ b/packages/button/src/styles/Button.css
@@ -196,6 +196,31 @@
   color: var(--lp-color-text-interactive-disabled);
 }
 
+/* ------- MINIMAL PRIMARY ------- */
+.Button.Button--minimal-primary {
+  background-color: var(--lp-color-bg-interactive-tertiary);
+  color: var(--lp-color-text-interactive);
+  font-weight: var(--lp-font-weight-medium);
+  border: none;
+  font-size: var(--lp-font-size-200);
+}
+
+.Button.Button--minimal-primary:hover,
+.Button--minimal-primary:focus-visible {
+  background-color: var(--lp-color-bg-interactive-tertiary-hover);
+}
+
+.Button.Button--minimal-primary:active {
+  background-color: var(--lp-color-bg-interactive-tertiary-active);
+}
+
+.Button.Button--minimal-primary[disabled],
+.Button.Button--minimal-primary[disabled]:hover {
+  background-color: var(--lp-color-bg-interactive-tertiary);
+  border: none;
+  color: var(--lp-color-text-interactive-disabled);
+}
+
 /* ------- CLOSE ICON BUTTON ------- */
 
 .Button.Button--close {

--- a/packages/button/stories/Button.stories.tsx
+++ b/packages/button/stories/Button.stories.tsx
@@ -171,6 +171,10 @@ export const Minimal: Story = { args: { children: 'Minimal', kind: 'minimal' } }
 
 export const Primary: Story = { args: { children: 'Primary', kind: 'primary' } };
 
+export const MinimalPrimary: Story = {
+  args: { children: 'Minimal Primary', kind: 'minimal-primary' },
+};
+
 export const Destructive: Story = {
   args: { children: 'Destructive', kind: 'destructive' },
 };


### PR DESCRIPTION
## Summary

Adding a new theme for buttons - a minimal button with blue text referred to as `minimal primary` since I didn't have a better name for it.

Extra context on this change can be found in this Figma design: https://www.figma.com/file/tfMGicaVSFHOChrbToE4EX/Flag-creation?node-id=2560%3A18251&t=smAt3MIUQPqBeG3K-0

And this Gonfalon PR: https://github.com/launchdarkly/gonfalon/pull/25540/files#r1124587767

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/70972175/222810925-345bc920-c085-4afc-9d0b-e3b7f6646451.png)

## Testing approaches

Added to Storybook.
