### PR TITLE
feat(IconButton): add squared shape to IconButton

### DIFF
--- a/.changeset/shiny-islands-compete.md
+++ b/.changeset/shiny-islands-compete.md
@@ -1,0 +1,6 @@
+---
+'@launchpad-ui/button': minor
+'@launchpad-ui/core': minor
+---
+
+[IconButton]: Add squared IconButton

--- a/packages/button/src/IconButton.tsx
+++ b/packages/button/src/IconButton.tsx
@@ -15,6 +15,7 @@ import './styles/Button.css';
 
 type IconButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
   kind?: 'default' | 'primary' | 'destructive' | 'minimal' | 'close';
+  shape?: 'circle' | 'square';
   icon: ReactElement<IconProps>;
   size?: 'small' | 'normal';
   'aria-label': string;
@@ -29,6 +30,7 @@ const IconButtonComponent = forwardRef<HTMLButtonElement, IconButtonProps>((prop
     className,
     size = 'normal',
     kind = 'minimal',
+    shape = 'circle',
     disabled = false,
     asChild = false,
     onKeyDown,
@@ -47,6 +49,7 @@ const IconButtonComponent = forwardRef<HTMLButtonElement, IconButtonProps>((prop
     `Button--${kind}`,
     disabled && 'Button--disabled',
     size && `Button--${size}`,
+    shape && `Button--${shape}`,
     className
   );
 

--- a/packages/button/src/styles/Button.css
+++ b/packages/button/src/styles/Button.css
@@ -395,6 +395,8 @@
   fill: var(--Button-icon-color-fill-disabled);
 }
 
+/* ------- ICON ------- */
+
 .Button.Button--icon {
   padding: 0;
   line-height: 1;
@@ -408,5 +410,14 @@
 .Button.Button--icon.Button--small {
   height: 2.2rem;
   width: 2.2rem;
+}
+
+.Button.Button--icon.Button--square {
+  border-radius: var(--Button-border-radius-default);
+}
+
+.Button.Button--icon.Button--square.Button--normal {
+  height: 3.2rem;
+  width: 3.2rem;
 }
 /* stylelint-enable no-descending-specificity */

--- a/packages/button/stories/IconButton.stories.tsx
+++ b/packages/button/stories/IconButton.stories.tsx
@@ -182,3 +182,12 @@ export const AsAnchorChild: Story = {
     kind: 'destructive',
   },
 };
+
+export const Square: Story = {
+  args: {
+    icon,
+    'aria-label': 'Button',
+    kind: 'default',
+    shape: 'square',
+  },
+};


### PR DESCRIPTION
## Summary

Adding a `shape` parameter to Icon button with two modes: `circle` and `square` - the New Flag Creation UX added a use case of an icon contained within a squared off button. I originally began just styling the Icon Button to look the way I want it to, but it was recommended that it become a pattern in Launchpad:

Figma: https://www.figma.com/file/tfMGicaVSFHOChrbToE4EX/Flag-creation?node-id=2560%3A18251&t=smAt3MIUQPqBeG3K-0

Gonfalon PR Context: https://github.com/launchdarkly/gonfalon/pull/25540/commits/ee1dba01016d34381ccf32663640326803482443#r1124587959

**NOTE:** Whoever reviews this PR should merge it - I don't have access.

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/70972175/222814264-279cdbdf-db1e-4c6b-8a4d-0a37d9f8e282.png)

## Testing approaches

Added Storybook case for this - see screenshot
