### PR TITLE
feat: left-align CopyToClipboard text

### DIFF
--- a/.changeset/neat-boxes-fail.md
+++ b/.changeset/neat-boxes-fail.md
@@ -1,0 +1,6 @@
+---
+'@launchpad-ui/clipboard': patch
+'@launchpad-ui/core': patch
+---
+
+left-align CopyToClipboard text

--- a/packages/clipboard/src/styles/CopyCodeButton.module.css
+++ b/packages/clipboard/src/styles/CopyCodeButton.module.css
@@ -2,6 +2,7 @@
   border-radius: 20px;
   font-family: var(--lp-font-family-monospace);
   font-size: 87.5%;
+  text-align: left;
   margin: 0;
   background-color: var(--lp-color-gray-100);
   padding: 0.4rem 0.8rem;


### PR DESCRIPTION
## Summary

Left-align the `CopyToClipboard` button text. In most cases this produces no visual difference, but it helps for the cases where longer text values are supplied and the content wraps to multiple lines.

## Screenshots (if appropriate):

**Before**:
<img width="416" alt="Screenshot 2023-03-03 at 2 20 25 PM" src="https://user-images.githubusercontent.com/109103953/222821069-1610b5da-df2d-4902-a40a-19a9ebc4fc2f.png">

**After**:
<img width="416" alt="Screenshot 2023-03-03 at 2 20 13 PM" src="https://user-images.githubusercontent.com/109103953/222821115-39fa8131-5f55-4d1f-927e-a65f30a14b0a.png">


<!-- Are there any visual changes that would be helpful to the reviewer to see? -->

## Testing approaches

<!-- How are these changes tested? -->
