### PR TITLE
refactor(select): expose SelectItem and SelectSection

### DIFF
--- a/.changeset/tough-birds-agree.md
+++ b/.changeset/tough-birds-agree.md
@@ -1,0 +1,6 @@
+---
+'@launchpad-ui/select': patch
+'@launchpad-ui/core': patch
+---
+
+[Select] Expose `SelectItem` and `SelectSection` components

--- a/packages/select/src/MultiSelect/MultiSelect.tsx
+++ b/packages/select/src/MultiSelect/MultiSelect.tsx
@@ -40,7 +40,7 @@ const MultiSelect = <T extends object>(props: MultiSelectProps<T>) => {
   const filterInputRef = useRef<HTMLInputElement>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
   const popoverRef = useRef<HTMLDivElement>(null);
-  const listBoxRef = useRef<HTMLUListElement>(null);
+  const listBoxRef = useRef<HTMLDivElement>(null);
 
   const state = useMultiSelectState(props);
 

--- a/packages/select/src/SelectItem.tsx
+++ b/packages/select/src/SelectItem.tsx
@@ -8,7 +8,7 @@ type SelectItemProps<T extends object, P extends ElementType> = ItemProps<T> & {
   [key: string]: any;
 };
 
-const SelectItem = <T extends object, P extends ElementType = 'li'>(
+const SelectItem = <T extends object, P extends ElementType = 'div'>(
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   _props: SelectItemProps<T, P> & Omit<ComponentPropsWithoutRef<P>, keyof SelectItemProps<T, P>>
 ) => {

--- a/packages/select/src/SelectItem.tsx
+++ b/packages/select/src/SelectItem.tsx
@@ -1,0 +1,44 @@
+import type { SharedSelectState } from './types';
+import type { ItemProps } from '@react-types/shared';
+import type { ComponentPropsWithoutRef, ElementType } from 'react';
+
+type SelectItemProps<T extends object, P extends ElementType> = ItemProps<T> & {
+  as?: P;
+  onClick?: (_e: MouseEvent, state: SharedSelectState) => void;
+  [key: string]: any;
+};
+
+const SelectItem = <T extends object, P extends ElementType = 'li'>(
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  _props: SelectItemProps<T, P> & Omit<ComponentPropsWithoutRef<P>, keyof SelectItemProps<T, P>>
+) => {
+  return null;
+};
+
+SelectItem.getCollectionNode = function* getCollectionNode<T extends object>(
+  props: ItemProps<T>,
+  context: any
+) {
+  const rendered = props.title || props.children;
+  const textValue =
+    props.textValue || (typeof rendered === 'string' ? rendered : '') || props['aria-label'] || '';
+
+  // suppressTextValueWarning is used in components like Tabs, which don't have type to select support.
+  if (!textValue && !context?.suppressTextValueWarning) {
+    console.warn(
+      '<SelectItem> with non-plain text contents is unsupported by type to select for accessibility. Please add a `textValue` prop.'
+    );
+  }
+
+  yield {
+    type: 'item',
+    props: props,
+    rendered,
+    textValue,
+    'aria-label': props['aria-label'],
+    hasChildNodes: false,
+  };
+};
+
+export { SelectItem };
+export type { SelectItemProps };

--- a/packages/select/src/SelectItem.tsx
+++ b/packages/select/src/SelectItem.tsx
@@ -5,7 +5,6 @@ import type { ComponentPropsWithoutRef, ElementType } from 'react';
 type SelectItemProps<T extends object, P extends ElementType> = ItemProps<T> & {
   as?: P;
   onClick?: (_e: MouseEvent, state: SharedSelectState) => void;
-  [key: string]: any;
 };
 
 const SelectItem = <T extends object, P extends ElementType = 'div'>(

--- a/packages/select/src/SelectListBox.tsx
+++ b/packages/select/src/SelectListBox.tsx
@@ -1,10 +1,12 @@
 /* eslint-disable @typescript-eslint/no-use-before-define */
 import type { MultiSelectState } from './MultiSelect';
+import type { MultiSelectListState } from './MultiSelect/useMultiSelectListState';
+import type { SelectItemProps } from './SelectItem';
 import type { SingleSelectState } from './SingleSelect';
 import type { AriaListBoxOptions } from '@react-aria/listbox';
-import type { ListState } from '@react-stately/list';
+import type { SingleSelectListState } from '@react-stately/list';
 import type { Node } from '@react-types/shared';
-import type { InputHTMLAttributes, RefObject } from 'react';
+import type { ElementType, InputHTMLAttributes, RefObject } from 'react';
 
 import { Search } from '@launchpad-ui/icons';
 import { getItemId, useListBox, useListBoxSection, useOption } from '@react-aria/listbox';
@@ -22,16 +24,6 @@ type SelectListBoxProps<T extends object> = AriaListBoxOptions<T> & {
   state: SingleSelectState<T> | MultiSelectState<T>;
   filterInputProps: InputHTMLAttributes<HTMLInputElement>;
   hasFilter?: boolean;
-};
-
-type SelectListBoxSectionProps<T extends object> = {
-  section: Node<T>;
-  state: ListState<T>;
-};
-
-type SelectListBoxOptionProps<T extends object> = {
-  item: Node<T>;
-  state: ListState<T>;
 };
 
 const SelectListBox = <T extends object>(props: SelectListBoxProps<T>) => {
@@ -102,7 +94,14 @@ const SelectListBox = <T extends object>(props: SelectListBoxProps<T>) => {
   );
 };
 
-const Section = <T extends object>({ section, state }: SelectListBoxSectionProps<T>) => {
+type SectionProps<T extends object> = {
+  section: Omit<Node<T>, 'props'> & {
+    props?: SelectItemProps<T, ElementType>;
+  };
+  state: SingleSelectListState<T> | MultiSelectListState<T>;
+};
+
+const Section = <T extends object>({ section, state }: SectionProps<T>) => {
   const { itemProps, headingProps, groupProps } = useListBoxSection({
     heading: section.rendered,
     'aria-label': section['aria-label'],
@@ -126,7 +125,14 @@ const Section = <T extends object>({ section, state }: SelectListBoxSectionProps
   );
 };
 
-const Option = <T extends object>({ item, state }: SelectListBoxOptionProps<T>) => {
+type OptionProps<T extends object> = {
+  item: Omit<Node<T>, 'props'> & {
+    props?: SelectItemProps<T, ElementType>;
+  };
+  state: SingleSelectListState<T> | MultiSelectListState<T>;
+};
+
+const Option = <T extends object>({ item, state }: OptionProps<T>) => {
   const ref = useRef<HTMLLIElement>(null);
   const { optionProps, isDisabled, isSelected, isFocused } = useOption(
     {
@@ -136,9 +142,12 @@ const Option = <T extends object>({ item, state }: SelectListBoxOptionProps<T>) 
     ref
   );
 
+  const { as: Component = 'li', ...itemProps } = item.props || {};
+
   return (
-    <li
+    <Component
       {...optionProps}
+      {...itemProps}
       ref={ref}
       className={cx(
         styles.option,
@@ -151,7 +160,7 @@ const Option = <T extends object>({ item, state }: SelectListBoxOptionProps<T>) 
         <input type="checkbox" disabled={isDisabled} checked={isSelected} readOnly />
       )}
       {typeof item.rendered === 'string' ? <span>{item.rendered}</span> : item.rendered}
-    </li>
+    </Component>
   );
 };
 

--- a/packages/select/src/SelectListBox.tsx
+++ b/packages/select/src/SelectListBox.tsx
@@ -19,7 +19,7 @@ import { useRef } from 'react';
 import styles from './styles/Select.module.css';
 
 type SelectListBoxProps<T extends object> = AriaListBoxOptions<T> & {
-  listBoxRef?: RefObject<HTMLUListElement>;
+  listBoxRef?: RefObject<HTMLDivElement>;
   filterInputRef?: RefObject<HTMLInputElement>;
   state: SingleSelectState<T> | MultiSelectState<T>;
   filterInputProps: InputHTMLAttributes<HTMLInputElement>;
@@ -29,7 +29,7 @@ type SelectListBoxProps<T extends object> = AriaListBoxOptions<T> & {
 const SelectListBox = <T extends object>(props: SelectListBoxProps<T>) => {
   const { state, hasFilter } = props;
 
-  const listBoxRef = useObjectRef<HTMLUListElement>(props.listBoxRef);
+  const listBoxRef = useObjectRef<HTMLDivElement>(props.listBoxRef);
 
   const filterInputRef = useObjectRef<HTMLInputElement>(props.filterInputRef);
 
@@ -75,7 +75,7 @@ const SelectListBox = <T extends object>(props: SelectListBoxProps<T>) => {
         </div>
       )}
 
-      <ul
+      <div
         {...listBoxProps}
         ref={listBoxRef}
         role="listbox"
@@ -89,7 +89,7 @@ const SelectListBox = <T extends object>(props: SelectListBoxProps<T>) => {
             <Option key={item.key} item={item} state={state} />
           )
         )}
-      </ul>
+      </div>
     </div>
   );
 };
@@ -142,7 +142,7 @@ const Option = <T extends object>({ item, state }: OptionProps<T>) => {
     ref
   );
 
-  const { as: Component = 'li', ...itemProps } = item.props || {};
+  const { as: Component = 'div', ...itemProps } = item.props || {};
 
   return (
     <Component

--- a/packages/select/src/SelectSection.tsx
+++ b/packages/select/src/SelectSection.tsx
@@ -1,0 +1,54 @@
+import type { PartialNode } from '@react-stately/collections';
+import type { SectionProps } from '@react-types/shared';
+
+import { Children } from 'react';
+
+type SelectSectionProps<T extends object> = SectionProps<T>;
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const Section = <T extends object>(_: SelectSectionProps<T>) => {
+  return null;
+};
+
+Section.getCollectionNode = function* getCollectionNode<T>(
+  props: SectionProps<T>
+): Generator<PartialNode<T>> {
+  const { children, title, items } = props;
+  yield {
+    type: 'section',
+    props: props,
+    hasChildNodes: true,
+    rendered: title,
+    'aria-label': props['aria-label'],
+    *childNodes() {
+      if (typeof children === 'function') {
+        if (!items) {
+          throw new Error('props.children was a function but props.items is missing');
+        }
+
+        for (const item of items) {
+          yield {
+            type: 'item',
+            value: item,
+            renderer: children,
+          };
+        }
+      } else {
+        const items: PartialNode<T>[] = [];
+        Children.forEach(children, (child) => {
+          items.push({
+            type: 'item',
+            element: child,
+          });
+        });
+
+        yield* items;
+      }
+    },
+  };
+};
+
+// We don't want getCollectionNode to show up in the type definition
+const _Section = Section as <T extends object>(props: SelectSectionProps<T>) => JSX.Element | null;
+export { _Section as SelectSection };
+export type { SelectSectionProps };

--- a/packages/select/src/SingleSelect/SingleSelect.tsx
+++ b/packages/select/src/SingleSelect/SingleSelect.tsx
@@ -32,7 +32,7 @@ const SingleSelect = <T extends object>(props: SingleSelectProps<T>) => {
   const filterInputRef = useRef<HTMLInputElement>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
   const popoverRef = useRef<HTMLDivElement>(null);
-  const listBoxRef = useRef<HTMLUListElement>(null);
+  const listBoxRef = useRef<HTMLDivElement>(null);
 
   const state = useSingleSelectState(props);
 

--- a/packages/select/src/__tests__/MultiSelect.cy.tsx
+++ b/packages/select/src/__tests__/MultiSelect.cy.tsx
@@ -1,6 +1,4 @@
-import { Item } from '@react-stately/collections';
-
-import { MultiSelect } from '../';
+import { MultiSelect, SelectItem } from '../';
 
 import { FRUIT } from './constants';
 
@@ -9,7 +7,7 @@ describe('Select', () => {
     beforeEach(() => {
       cy.mount(
         <MultiSelect label="Fruit" items={FRUIT}>
-          {(item) => <Item>{item.name}</Item>}
+          {(item) => <SelectItem>{item.name}</SelectItem>}
         </MultiSelect>
       );
     });

--- a/packages/select/src/__tests__/MultiSelect.spec.tsx
+++ b/packages/select/src/__tests__/MultiSelect.spec.tsx
@@ -1,7 +1,6 @@
-import { Item } from '@react-stately/collections';
 import { it, expect, describe } from 'vitest';
 
-import { MultiSelectTrigger, MultiSelect } from '../';
+import { MultiSelectTrigger, MultiSelect, SelectItem } from '../';
 import { render, screen, userEvent } from '../../../../test/utils';
 
 import { FRUIT } from './constants';
@@ -12,7 +11,7 @@ describe('Select', () => {
     it('renders', () => {
       render(
         <MultiSelect label="Fruit" items={FRUIT}>
-          {(item) => <Item>{item.name}</Item>}
+          {(item) => <SelectItem>{item.name}</SelectItem>}
         </MultiSelect>
       );
       expect(screen.getByTestId('select')).toBeVisible();
@@ -23,7 +22,7 @@ describe('Select', () => {
 
       render(
         <MultiSelect label="Fruit" items={FRUIT}>
-          {(item) => <Item>{item.name}</Item>}
+          {(item) => <SelectItem>{item.name}</SelectItem>}
         </MultiSelect>
       );
 
@@ -42,7 +41,7 @@ describe('Select', () => {
 
       render(
         <MultiSelect label="Fruit" isClearable items={FRUIT}>
-          {(item) => <Item>{item.name}</Item>}
+          {(item) => <SelectItem>{item.name}</SelectItem>}
         </MultiSelect>
       );
 
@@ -65,7 +64,7 @@ describe('Select', () => {
 
       render(
         <MultiSelect label="Fruit" isSelectableAll items={FRUIT}>
-          {(item) => <Item>{item.name}</Item>}
+          {(item) => <SelectItem>{item.name}</SelectItem>}
         </MultiSelect>
       );
 
@@ -92,7 +91,7 @@ describe('Select', () => {
           )}
           items={FRUIT}
         >
-          {(item) => <Item>{item.name}</Item>}
+          {(item) => <SelectItem>{item.name}</SelectItem>}
         </MultiSelect>
       );
 
@@ -109,7 +108,7 @@ describe('Select', () => {
     it('renders', () => {
       render(
         <MultiSelect label="Fruit" trigger={CustomMultiSelectTrigger} items={FRUIT}>
-          {(item) => <Item>{item.name}</Item>}
+          {(item) => <SelectItem>{item.name}</SelectItem>}
         </MultiSelect>
       );
 
@@ -121,7 +120,7 @@ describe('Select', () => {
 
       render(
         <MultiSelect label="Fruit" trigger={CustomMultiSelectTrigger} items={FRUIT}>
-          {(item) => <Item>{item.name}</Item>}
+          {(item) => <SelectItem>{item.name}</SelectItem>}
         </MultiSelect>
       );
 
@@ -138,7 +137,7 @@ describe('Select', () => {
 
       render(
         <MultiSelect label="Fruit" trigger={CustomMultiSelectTrigger} items={FRUIT}>
-          {(item) => <Item>{item.name}</Item>}
+          {(item) => <SelectItem>{item.name}</SelectItem>}
         </MultiSelect>
       );
 

--- a/packages/select/src/__tests__/SingleSelect.cy.tsx
+++ b/packages/select/src/__tests__/SingleSelect.cy.tsx
@@ -1,6 +1,4 @@
-import { Item } from '@react-stately/collections';
-
-import { SingleSelect } from '../';
+import { SelectItem, SingleSelect } from '../';
 
 import { FRUIT } from './constants';
 
@@ -9,7 +7,7 @@ describe('Select', () => {
     beforeEach(() => {
       cy.mount(
         <SingleSelect label="Fruit" items={FRUIT}>
-          {(item) => <Item>{item.name}</Item>}
+          {(item) => <SelectItem>{item.name}</SelectItem>}
         </SingleSelect>
       );
     });

--- a/packages/select/src/__tests__/SingleSelect.spec.tsx
+++ b/packages/select/src/__tests__/SingleSelect.spec.tsx
@@ -1,7 +1,6 @@
-import { Item } from '@react-stately/collections';
 import { it, expect, describe } from 'vitest';
 
-import { SingleSelect, SingleSelectTrigger } from '..';
+import { SelectItem, SingleSelect, SingleSelectTrigger } from '..';
 import { render, screen, userEvent } from '../../../../test/utils';
 
 import { FRUIT } from './constants';
@@ -12,7 +11,7 @@ describe('Select', () => {
     it('renders', () => {
       render(
         <SingleSelect label="Fruit" items={FRUIT}>
-          {(item) => <Item>{item.name}</Item>}
+          {(item) => <SelectItem>{item.name}</SelectItem>}
         </SingleSelect>
       );
       expect(screen.getByTestId('select')).toBeVisible();
@@ -22,7 +21,7 @@ describe('Select', () => {
       const user = userEvent.setup();
       render(
         <SingleSelect label="Fruit" items={FRUIT}>
-          {(item) => <Item>{item.name}</Item>}
+          {(item) => <SelectItem>{item.name}</SelectItem>}
         </SingleSelect>
       );
       await user.click(screen.getByTestId('select-trigger'));
@@ -35,7 +34,7 @@ describe('Select', () => {
 
       render(
         <SingleSelect label="Fruit" items={FRUIT}>
-          {(item) => <Item>{item.name}</Item>}
+          {(item) => <SelectItem>{item.name}</SelectItem>}
         </SingleSelect>
       );
 
@@ -58,7 +57,7 @@ describe('Select', () => {
           )}
           items={FRUIT}
         >
-          {(item) => <Item>{item.name}</Item>}
+          {(item) => <SelectItem>{item.name}</SelectItem>}
         </SingleSelect>
       );
 
@@ -74,7 +73,7 @@ describe('Select', () => {
     it('renders', () => {
       render(
         <SingleSelect label="Fruit" trigger={CustomSingleSelectTrigger} items={FRUIT}>
-          {(item) => <Item>{item.name}</Item>}
+          {(item) => <SelectItem>{item.name}</SelectItem>}
         </SingleSelect>
       );
 
@@ -86,13 +85,35 @@ describe('Select', () => {
 
       render(
         <SingleSelect label="Fruit" trigger={CustomSingleSelectTrigger} items={FRUIT}>
-          {(item) => <Item>{item.name}</Item>}
+          {(item) => <SelectItem>{item.name}</SelectItem>}
         </SingleSelect>
       );
 
       await user.click(screen.getByTestId('custom-trigger'));
       await user.click(screen.getAllByRole('option')[0]);
       expect(screen.getByTestId('custom-trigger')).toHaveTextContent(FRUIT[0].name);
+    });
+  });
+
+  describe('with select item rendered as something other than li', () => {
+    it('renders', async () => {
+      const user = userEvent.setup();
+
+      render(
+        <SingleSelect label="Fruit" items={FRUIT}>
+          {(item) => (
+            <SelectItem as="a" href="/">
+              {item.name}
+            </SelectItem>
+          )}
+        </SingleSelect>
+      );
+
+      await user.click(screen.getByTestId('select-trigger'));
+
+      screen.getAllByRole('option').forEach((option) => {
+        expect(option).toHaveAttribute('href');
+      });
     });
   });
 });

--- a/packages/select/src/index.ts
+++ b/packages/select/src/index.ts
@@ -4,6 +4,10 @@ export type {
   SingleSelectTriggerProps,
   SingleSelectState,
 } from './SingleSelect';
+export type { SelectItemProps } from './SelectItem';
+export type { SelectSectionProps } from './SelectSection';
 
 export { MultiSelect, MultiSelectTrigger } from './MultiSelect';
 export { SingleSelect, SingleSelectTrigger } from './SingleSelect';
+export { SelectItem } from './SelectItem';
+export { SelectSection } from './SelectSection';

--- a/packages/select/src/styles/Select.module.css
+++ b/packages/select/src/styles/Select.module.css
@@ -33,6 +33,9 @@
   cursor: pointer;
   list-style-type: none;
   margin: 0;
+  width: 100%;
+  display: block;
+  text-decoration: none;
 
   &.isSelected {
     background-color: rgb(64 91 255 / 0.05);

--- a/packages/select/stories/MultiSelect.stories.tsx
+++ b/packages/select/stories/MultiSelect.stories.tsx
@@ -2,10 +2,9 @@ import type { StoryObj } from '@storybook/react';
 import type { Key } from 'react';
 
 import { Chip } from '@launchpad-ui/chip';
-import { Item } from '@react-stately/collections';
 import { useState } from 'react';
 
-import { MultiSelectTrigger, MultiSelect } from '../src';
+import { MultiSelectTrigger, MultiSelect, SelectItem } from '../src';
 import { FRUIT } from '../src/__tests__/constants';
 import { CustomMultiSelectTrigger } from '../src/__tests__/examples';
 
@@ -34,7 +33,7 @@ export const Basic: Story = {
         isSelectableAll
         isClearable
       >
-        {(item) => <Item>{item.name}</Item>}
+        {(item) => <SelectItem>{item.name}</SelectItem>}
       </MultiSelect>
     );
   },
@@ -50,7 +49,7 @@ export const Filterable: Story = {
         hasFilter
         onSelectionChange={(keys) => console.log(Array.from(keys))}
       >
-        {(item) => <Item>{item.name}</Item>}
+        {(item) => <SelectItem>{item.name}</SelectItem>}
       </MultiSelect>
     );
   },
@@ -74,7 +73,7 @@ export const WithCustomTrigger: Story = {
           onSelectionChange={(keys) => console.log(Array.from(keys))}
           trigger={CustomMultiSelectTrigger}
         >
-          {(item) => <Item textValue={item.name}>{item.name}</Item>}
+          {(item) => <SelectItem textValue={item.name}>{item.name}</SelectItem>}
         </MultiSelect>
       </>
     );
@@ -104,9 +103,9 @@ export const MultiSelectWithCustomSelectedRender: Story = {
         )}
       >
         {(item) => (
-          <Item textValue={item.name}>
+          <SelectItem textValue={item.name}>
             {item.name} <Chip>ID: {item.id}</Chip>
-          </Item>
+          </SelectItem>
         )}
       </MultiSelect>
     );
@@ -137,7 +136,7 @@ export const MultiSelectWithSelectAll: Story = {
           </MultiSelectTrigger>
         )}
       >
-        {(item) => <Item textValue={item.name}>{item.name}</Item>}
+        {(item) => <SelectItem textValue={item.name}>{item.name}</SelectItem>}
       </MultiSelect>
     );
   },
@@ -156,7 +155,7 @@ export const WithControlledSelectedKeys: Story = {
           selectedKeys={selectedKeys}
           onSelectionChange={(keys) => setSelectedKeys(keys)}
         >
-          {(item) => <Item textValue={item.name}>{item.name}</Item>}
+          {(item) => <SelectItem textValue={item.name}>{item.name}</SelectItem>}
         </MultiSelect>
       );
     };
@@ -170,7 +169,7 @@ export const WithUncontrolledItems: Story = {
   render: () => {
     return (
       <MultiSelect label="Fruit" defaultItems={FRUIT}>
-        {(item) => <Item textValue={item.name}>{item.name}</Item>}
+        {(item) => <SelectItem textValue={item.name}>{item.name}</SelectItem>}
       </MultiSelect>
     );
   },

--- a/packages/select/stories/SingleSelect.stories.tsx
+++ b/packages/select/stories/SingleSelect.stories.tsx
@@ -2,10 +2,9 @@ import type { StoryObj } from '@storybook/react';
 import type { Key } from 'react';
 
 import { Chip } from '@launchpad-ui/chip';
-import { Item, Section } from '@react-stately/collections';
 import { useMemo, useState } from 'react';
 
-import { SingleSelect, SingleSelectTrigger } from '../src';
+import { SingleSelect, SingleSelectTrigger, SelectItem, SelectSection } from '../src';
 import { FRUIT, SECTIONED_ITEMS } from '../src/__tests__/constants';
 import { CustomSingleSelectTrigger } from '../src/__tests__/examples';
 
@@ -32,7 +31,7 @@ export const Basic: Story = {
           defaultItems={FRUIT}
           onSelectionChange={(key) => console.log(key)}
         >
-          {(item) => <Item textValue={item.name}>{item.name}</Item>}
+          {(item) => <SelectItem textValue={item.name}>{item.name}</SelectItem>}
         </SingleSelect>
       );
     };
@@ -53,7 +52,7 @@ export const WithUncontrolledSelectedKey: Story = {
           items={FRUIT}
           onSelectionChange={(key) => setSelectedKey(key)}
         >
-          {(item) => <Item textValue={item.name}>{item.name}</Item>}
+          {(item) => <SelectItem textValue={item.name}>{item.name}</SelectItem>}
         </SingleSelect>
       );
     };
@@ -68,7 +67,7 @@ export const WithControlledSelectedKey: Story = {
     const Component = () => {
       return (
         <SingleSelect label="Fruit" defaultSelectedKey={FRUIT[2].id} items={FRUIT}>
-          {(item) => <Item textValue={item.name}>{item.name}</Item>}
+          {(item) => <SelectItem textValue={item.name}>{item.name}</SelectItem>}
         </SingleSelect>
       );
     };
@@ -88,7 +87,7 @@ export const WithControlledFilterable: Story = {
           defaultItems={FRUIT}
           onSelectionChange={(key) => console.log(key)}
         >
-          {(item) => <Item textValue={item.name}>{item.name}</Item>}
+          {(item) => <SelectItem textValue={item.name}>{item.name}</SelectItem>}
         </SingleSelect>
       );
     };
@@ -117,7 +116,7 @@ export const WithUncontrolledFilterable: Story = {
           filterValue={filterValue}
           onSelectionChange={(key) => console.log(key)}
         >
-          {(item) => <Item textValue={item.name}>{item.name}</Item>}
+          {(item) => <SelectItem textValue={item.name}>{item.name}</SelectItem>}
         </SingleSelect>
       );
     };
@@ -146,9 +145,9 @@ export const WithCustomSelectedRender: Story = {
         )}
       >
         {(item) => (
-          <Item textValue={item.name}>
+          <SelectItem textValue={item.name}>
             {item.name} <Chip>ID: {item.id}</Chip>
-          </Item>
+          </SelectItem>
         )}
       </SingleSelect>
     );
@@ -165,7 +164,7 @@ export const WithCustomTrigger: Story = {
         onSelectionChange={(key) => console.log(key)}
         trigger={CustomSingleSelectTrigger}
       >
-        {(item) => <Item textValue={item.name}>{item.name}</Item>}
+        {(item) => <SelectItem textValue={item.name}>{item.name}</SelectItem>}
       </SingleSelect>
     );
   },
@@ -179,17 +178,37 @@ export const SingleSelectWithSections: Story = {
         label="Produce"
         defaultItems={SECTIONED_ITEMS}
         hasFilter
-        // isOpen
         onSelectionChange={(key) => console.log(key)}
       >
         {(section) => (
-          <Section key={section.name} title={section.name} items={section.items}>
+          <SelectSection key={section.name} title={section.name} items={section.items}>
             {(item) => (
-              <Item textValue={item.name}>
+              <SelectItem textValue={item.name}>
                 {item.name} <Chip>ID: {item.id}</Chip>
-              </Item>
+              </SelectItem>
             )}
-          </Section>
+          </SelectSection>
+        )}
+      </SingleSelect>
+    );
+  },
+  parameters: { docs: { disable: false } },
+};
+
+export const WithSelectItemRenderedAs: Story = {
+  render: () => {
+    return (
+      <SingleSelect
+        label="Produce"
+        defaultItems={FRUIT}
+        hasFilter
+        isOpen
+        onSelectionChange={(key) => console.log(key)}
+      >
+        {(item) => (
+          <SelectItem as="a" href="/" textValue={item.name}>
+            {item.name} <Chip>ID: {item.id}</Chip>
+          </SelectItem>
         )}
       </SingleSelect>
     );

--- a/packages/select/stories/SingleSelect.stories.tsx
+++ b/packages/select/stories/SingleSelect.stories.tsx
@@ -206,7 +206,7 @@ export const WithSelectItemRenderedAs: Story = {
         onSelectionChange={(key) => console.log(key)}
       >
         {(item) => (
-          <SelectItem as="a" href="/" textValue={item.name}>
+          <SelectItem as="a" href="#" textValue={item.name}>
             {item.name} <Chip>ID: {item.id}</Chip>
           </SelectItem>
         )}


### PR DESCRIPTION
## Summary
Based on some conversation with the team, we decided not to require consumers to use `react-stately`s `Item` and `Section` components directly, and instead expose named components through LaunchPad. These components in this case are `SelectItem` and `SelectSection`. 

I also added the `as` prop to `SelectItem`, which allows us to render selected items as links if needed, like in the case of the refactored Navigation component in this PR: https://github.com/launchdarkly/launchpad-ui/pull/696/files#diff-622d77675b453717536c6747bff490028f4b3ab94fd52c74f38dec365d91c1ffR23