### PR TITLE
chore(chip): remove large variant and size prop

### DIFF
--- a/.changeset/curly-shrimps-breathe.md
+++ b/.changeset/curly-shrimps-breathe.md
@@ -1,0 +1,6 @@
+---
+'@launchpad-ui/chip': minor
+'@launchpad-ui/core': minor
+---
+
+[Chip]: Remove `large` variant and `size` prop from component

--- a/packages/chip/src/Chip.tsx
+++ b/packages/chip/src/Chip.tsx
@@ -15,14 +15,12 @@ type ChipProps = HTMLAttributes<HTMLSpanElement> & {
     | 'new'
     | 'beta'
     | 'federal';
-  size?: 'normal' | 'large';
   subtle?: boolean;
   'data-test-id'?: string;
 };
 
 const Chip = ({
   kind = 'default',
-  size = 'normal',
   subtle = false,
   onClick,
   onKeyDown,
@@ -36,7 +34,6 @@ const Chip = ({
   const classes = cx(
     styles.Chip,
     styles[`Chip--${kind}`],
-    styles[`Chip--${size}`],
     className,
     subtle && styles['Chip--subtle'],
     isInteractive && styles['Chip--clickable']

--- a/packages/chip/src/styles/Chip.module.css
+++ b/packages/chip/src/styles/Chip.module.css
@@ -50,8 +50,6 @@
 .Chip {
   display: inline-block;
   font-weight: var(--lp-font-weight-semibold);
-  font-size: 1.1rem;
-  line-height: 1.2;
   border: 1px solid var(--lp-component-chip-color-border);
   border-radius: var(--lp-component-chip-border-radius);
   vertical-align: bottom;
@@ -60,18 +58,9 @@
   overflow: hidden;
   text-overflow: ellipsis;
   max-width: 100%;
-}
-
-.Chip--normal {
   font-size: 1.1rem;
   line-height: 1.4;
   padding: 0.3em;
-}
-
-.Chip--large {
-  font-size: 1.3rem;
-  line-height: 1.6;
-  padding: 0.5em;
 }
 
 .Chip--subtle {

--- a/packages/chip/stories/Chip.stories.tsx
+++ b/packages/chip/stories/Chip.stories.tsx
@@ -22,11 +22,6 @@ export default {
         category: 'Presentation',
       },
     },
-    size: {
-      table: {
-        category: 'Presentation',
-      },
-    },
     subtle: {
       table: {
         category: 'Presentation',
@@ -66,8 +61,6 @@ export const Info: Story = { args: { children: 'Info Chip', kind: 'info' } };
 
 export const Label: Story = { args: { children: 'Label Chip', kind: 'label' } };
 
-export const Large: Story = { args: { children: 'Large Chip', size: 'large' } };
-
 export const New: Story = { args: { children: 'New Chip', kind: 'new' } };
 
 export const Federal: Story = { args: { children: 'Federal Chip', kind: 'federal' } };
@@ -88,8 +81,6 @@ export const WarningSubtle: Story = {
 export const InfoSubtle: Story = { args: { children: 'Info Chip', kind: 'info', subtle: true } };
 
 export const LabelSubtle: Story = { args: { children: 'Label Chip', kind: 'label', subtle: true } };
-
-export const LargeSubtle: Story = { args: { children: 'Large Chip', size: 'large', subtle: true } };
 
 export const NewSubtle: Story = { args: { children: 'New Chip', kind: 'new', subtle: true } };
 


### PR DESCRIPTION
## Summary
I noticed the LaunchDarkly app doesn't use the large variant chip, so we can deprecate it. With this change, the `size` prop is now irrelevant as well.
