### PR TITLE
feat(chip): add size variants and deprecate unused variants

### DIFF
--- a/.changeset/afraid-penguins-change.md
+++ b/.changeset/afraid-penguins-change.md
@@ -1,0 +1,6 @@
+---
+'@launchpad-ui/chip': patch
+'@launchpad-ui/core': patch
+---
+
+[Chip] Add size variants and deprecate unused variants

--- a/packages/chip/src/Chip.tsx
+++ b/packages/chip/src/Chip.tsx
@@ -7,7 +7,7 @@ import styles from './styles/Chip.module.css';
 type ChipProps = HTMLAttributes<HTMLSpanElement> & {
   kind?: 'success' | 'warning' | 'info' | 'label' | 'new' | 'beta' | 'federal';
   subtle?: boolean;
-  size?: 'normal' | 'small' | 'medium';
+  size?: 'normal' | 'small' | 'legacy';
   'data-test-id'?: string;
 };
 

--- a/packages/chip/src/Chip.tsx
+++ b/packages/chip/src/Chip.tsx
@@ -5,27 +5,20 @@ import { cx } from 'classix';
 import styles from './styles/Chip.module.css';
 
 type ChipProps = HTMLAttributes<HTMLSpanElement> & {
-  kind?:
-    | 'default'
-    | 'success'
-    | 'warning'
-    | 'inactive'
-    | 'info'
-    | 'label'
-    | 'new'
-    | 'beta'
-    | 'federal';
+  kind?: 'success' | 'warning' | 'info' | 'label' | 'new' | 'beta' | 'federal';
   subtle?: boolean;
+  size?: 'normal' | 'small' | 'medium';
   'data-test-id'?: string;
 };
 
 const Chip = ({
-  kind = 'default',
+  kind,
   subtle = false,
   onClick,
   onKeyDown,
   className,
   children,
+  size = 'normal',
   'data-test-id': testId = 'chip',
   ...rest
 }: ChipProps) => {
@@ -33,7 +26,8 @@ const Chip = ({
 
   const classes = cx(
     styles.Chip,
-    styles[`Chip--${kind}`],
+    kind && styles[`Chip--${kind}`],
+    styles[`Chip--${size}`],
     className,
     subtle && styles['Chip--subtle'],
     isInteractive && styles['Chip--clickable']

--- a/packages/chip/src/styles/Chip.module.css
+++ b/packages/chip/src/styles/Chip.module.css
@@ -69,7 +69,7 @@
   min-height: 2.8rem;
 }
 
-.Chip--medium {
+.Chip--legacy {
   font-size: 1.1rem;
   line-height: 1.4;
   padding: 0.325rem;

--- a/packages/chip/src/styles/Chip.module.css
+++ b/packages/chip/src/styles/Chip.module.css
@@ -156,7 +156,6 @@
 
 .Chip--clickable:hover {
   cursor: pointer;
-  box-shadow: var(--lp-component-chip-color-shadow-hover);
 }
 
 .Chip--clickable:focus {
@@ -164,4 +163,9 @@
   box-shadow: 0 0 0 1px var(--lp-color-bg-ui-primary),
     0 0 0 2px var(--lp-color-shadow-interactive-focus);
   z-index: 2;
+}
+
+.Chip :global([class*='_icon_']) {
+  margin-right: 0.2rem;
+  vertical-align: top;
 }

--- a/packages/chip/src/styles/Chip.module.css
+++ b/packages/chip/src/styles/Chip.module.css
@@ -18,8 +18,8 @@
   --lp-component-chip-color-text-federal: var(--lp-color-black);
   --lp-component-chip-color-bg-default: var(--lp-color-white-100);
   --lp-component-chip-color-text-default: var(--lp-color-gray-800);
-  --lp-component-chip-color-bg-hover: var(--lp-color-gray-100);
-  --lp-component-chip-border-radius: 0.2rem;
+  --lp-component-chip-color-shadow-hover: 0 2px 8px -1px hsl(0 0% 0% / 0.04),
+    0 2px 4px 0 hsl(0 0% 0% / 0.08), 0 1px 2px 0 hsl(0 0% 0% / 0.14);
   --lp-component-chip-color-border: var(--lp-color-gray-600);
 }
 
@@ -42,34 +42,49 @@
   --lp-component-chip-color-text-federal: var(--lp-color-yellow-500);
   --lp-component-chip-color-bg-default: var(--lp-color-black-100);
   --lp-component-chip-color-text-default: var(--lp-color-gray-100);
-  --lp-component-chip-border-radius: 0.2rem;
   --lp-component-chip-color-border: var(--lp-color-gray-500);
   --lp-component-chip-color-bg-hover: var(--lp-color-gray-800);
 }
 
 .Chip {
-  display: inline-block;
-  font-weight: var(--lp-font-weight-semibold);
+  display: inline-flex;
+  font-weight: var(--lp-font-weight-medium);
   border: 1px solid var(--lp-component-chip-color-border);
-  border-radius: var(--lp-component-chip-border-radius);
+  border-radius: 0.2rem;
   vertical-align: bottom;
   text-align: center;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
   max-width: 100%;
+  color: var(--lp-component-chip-color-text-default);
+  background-color: var(--lp-component-chip-color-bg-default);
+  transition: all 0.1s ease-in-out;
+}
+
+.Chip--normal {
+  font-size: 1.4rem;
+  line-height: 1.4;
+  padding: 0.3125rem 1rem;
+  min-height: 2.8rem;
+}
+
+.Chip--medium {
   font-size: 1.1rem;
   line-height: 1.4;
-  padding: 0.3em;
+  padding: 0.325rem;
+  min-height: 2.4rem;
+}
+
+.Chip.Chip--small {
+  font-size: 1.2rem;
+  line-height: 1.33;
+  padding: 0.1rem 0.7rem;
+  min-height: 2rem;
 }
 
 .Chip--subtle {
   background: var(--lp-color-bg-ui-primary);
-}
-
-.Chip--default {
-  color: var(--lp-component-chip-color-text-default);
-  background-color: var(--lp-component-chip-color-bg-default);
 }
 
 .Chip--info {
@@ -127,42 +142,21 @@
   color: var(--lp-component-chip-color-text-warning);
 }
 
-.Chip--error {
-  border-color: var(--lp-component-chip-color-text-error);
-  color: var(--lp-component-chip-color-text-error);
-}
-
-.Chip--error:not(.Chip--subtle) {
-  background-color: var(--lp-component-chip-color-bg-error);
-  border-color: var(--lp-component-chip-color-bg-error);
-  color: var(--lp-component-chip-color-text-error);
-}
-
-.Chip--inactive {
-  border-color: var(--lp-component-chip-color-bg-inactive);
-  color: var(--lp-component-chip-color-text-inactive);
-}
-
-.Chip--inactive:not(.Chip--subtle) {
-  background-color: var(--lp-component-chip-color-bg-inactive);
-  color: var(--lp-component-chip-color-text-inactive);
-  border: 1px solid var(--lp-component-chip-color-bg-inactive);
-}
-
 .Chip--label {
   background-color: var(--lp-component-chip-color-bg-label);
   border-color: var(--lp-component-chip-color-bg-label);
   color: var(--lp-component-chip-color-text-label);
 }
 
-.Chip :global([class*='_icon_']) {
-  margin-right: 0.2rem;
-  vertical-align: top;
+.Chip--federal {
+  background-color: var(--lp-component-chip-color-bg-federal);
+  border-color: var(--lp-component-chip-color-bg-federal);
+  color: var(--lp-component-chip-color-text-federal);
 }
 
 .Chip--clickable:hover {
   cursor: pointer;
-  background: var(--lp-component-chip-color-bg-hover);
+  box-shadow: var(--lp-component-chip-color-shadow-hover);
 }
 
 .Chip--clickable:focus {
@@ -170,10 +164,4 @@
   box-shadow: 0 0 0 1px var(--lp-color-bg-ui-primary),
     0 0 0 2px var(--lp-color-shadow-interactive-focus);
   z-index: 2;
-}
-
-.Chip--federal {
-  background-color: var(--lp-component-chip-color-bg-federal);
-  border-color: var(--lp-component-chip-color-bg-federal);
-  color: var(--lp-component-chip-color-text-federal);
 }

--- a/packages/chip/src/styles/Chip.module.css
+++ b/packages/chip/src/styles/Chip.module.css
@@ -65,7 +65,7 @@
 .Chip--normal {
   font-size: 1.4rem;
   line-height: 1.4;
-  padding: 0.3125rem 1rem;
+  padding: 0.3125rem 0.6rem;
   min-height: 2.8rem;
 }
 
@@ -79,7 +79,7 @@
 .Chip.Chip--small {
   font-size: 1.2rem;
   line-height: 1.33;
-  padding: 0.1rem 0.7rem;
+  padding: 0.1rem 0.4rem;
   min-height: 2rem;
 }
 

--- a/packages/chip/stories/Chip.stories.tsx
+++ b/packages/chip/stories/Chip.stories.tsx
@@ -32,30 +32,18 @@ export default {
         category: 'Content',
       },
     },
-    onClick: {
-      table: {
-        category: 'Functions',
-      },
-    },
-    onKeyDown: {
-      table: {
-        category: 'Functions',
-      },
-    },
   },
 };
 
 type Story = StoryObj<typeof Chip>;
 
-export const Default: Story = { args: { children: 'Example Chip', kind: 'default' } };
+export const Default: Story = {
+  args: { children: 'Default Chip' },
+};
 
 export const Success: Story = { args: { children: 'Success Chip', kind: 'success' } };
 
 export const Warning: Story = { args: { children: 'Warning Chip', kind: 'warning' } };
-
-export const Inactive: Story = {
-  args: { children: 'Inactive Chip', kind: 'inactive' },
-};
 
 export const Info: Story = { args: { children: 'Info Chip', kind: 'info' } };
 
@@ -67,8 +55,21 @@ export const Federal: Story = { args: { children: 'Federal Chip', kind: 'federal
 
 export const Beta: Story = { args: { children: 'Beta Chip', kind: 'beta' } };
 
+export const Small: Story = { args: { children: 'Small Chip', size: 'small', kind: 'success' } };
+
+export const Medium: Story = { args: { children: 'Medium Chip', size: 'medium', kind: 'success' } };
+
+export const Interactive: Story = {
+  args: {
+    children: 'Interactive Chip',
+    onClick: () => {
+      alert('Chip clicked');
+    },
+  },
+};
+
 export const DefaultSubtle: Story = {
-  args: { children: 'Example Chip', kind: 'default', subtle: true },
+  args: { children: 'Example Chip', subtle: true },
 };
 
 export const SuccessSubtle: Story = {


### PR DESCRIPTION
## Summary
Adds new size variants:
- `small`: 20px height
- `normal`: 28px height
- `legacy`: 24px height (**this is the legacy size, we should not use moving forward after we feature flag migrate the sizing change**)

Also removes interactive styling since we do not want to encourage making chips interactive.
