### PR TITLE
feat(chip): Update sizing, deprecate `kind=label` and `size=legacy` and `subtle`

### DIFF
--- a/.changeset/happy-nails-love.md
+++ b/.changeset/happy-nails-love.md
@@ -3,4 +3,9 @@
 '@launchpad-ui/core': patch
 ---
 
-[Chip] Update default styles
+[Chip]
+
+- Deprecate `label` variant
+- Remove `legacy` variant, design decided to reduce padding back to 24px total height, making legacy unnecessary.
+- Deprecate `subtle` variants
+- Update normal and small sizing

--- a/.changeset/happy-nails-love.md
+++ b/.changeset/happy-nails-love.md
@@ -1,0 +1,6 @@
+---
+'@launchpad-ui/chip': patch
+'@launchpad-ui/core': patch
+---
+
+[Chip] Update default styles

--- a/packages/chip/src/Chip.tsx
+++ b/packages/chip/src/Chip.tsx
@@ -5,15 +5,13 @@ import { cx } from 'classix';
 import styles from './styles/Chip.module.css';
 
 type ChipProps = HTMLAttributes<HTMLSpanElement> & {
-  kind?: 'success' | 'warning' | 'info' | 'label' | 'new' | 'beta' | 'federal';
-  subtle?: boolean;
-  size?: 'normal' | 'small' | 'legacy';
+  kind?: 'success' | 'warning' | 'info' | 'new' | 'beta' | 'federal';
+  size?: 'normal' | 'small';
   'data-test-id'?: string;
 };
 
 const Chip = ({
   kind,
-  subtle = false,
   onClick,
   onKeyDown,
   className,
@@ -29,7 +27,6 @@ const Chip = ({
     kind && styles[`Chip--${kind}`],
     styles[`Chip--${size}`],
     className,
-    subtle && styles['Chip--subtle'],
     isInteractive && styles['Chip--clickable']
   );
 

--- a/packages/chip/src/styles/Chip.module.css
+++ b/packages/chip/src/styles/Chip.module.css
@@ -4,23 +4,14 @@
   --lp-component-chip-color-text-info: var(--lp-color-blue-600);
   --lp-component-chip-color-bg-warning: var(--lp-color-system-yellow-200);
   --lp-component-chip-color-text-warning: var(--lp-color-system-yellow-900);
-  --lp-component-chip-color-bg-error: var(--lp-color-system-red-200);
-  --lp-component-chip-color-text-error: var(--lp-color-system-red-900);
   --lp-component-chip-color-bg-success: var(--lp-color-system-green-200);
   --lp-component-chip-color-text-success: var(--lp-color-system-green-900);
-  --lp-component-chip-color-bg-inactive: var(--lp-color-gray-200);
-  --lp-component-chip-color-text-inactive: var(--lp-color-gray-600);
-  --lp-component-chip-color-bg-label: var(--lp-color-gray-100);
-  --lp-component-chip-color-text-label: var(--lp-color-gray-800);
   --lp-component-chip-color-bg-beta: var(--lp-color-purple-200);
   --lp-component-chip-color-text-beta: var(--lp-color-purple-600);
   --lp-component-chip-color-bg-federal: var(--lp-color-yellow-500);
   --lp-component-chip-color-text-federal: var(--lp-color-black);
-  --lp-component-chip-color-bg-default: var(--lp-color-white-100);
+  --lp-component-chip-color-bg-default: var(--lp-color-gray-100);
   --lp-component-chip-color-text-default: var(--lp-color-gray-800);
-  --lp-component-chip-color-shadow-hover: 0 2px 8px -1px hsl(0 0% 0% / 0.04),
-    0 2px 4px 0 hsl(0 0% 0% / 0.08), 0 1px 2px 0 hsl(0 0% 0% / 0.14);
-  --lp-component-chip-color-border: var(--lp-color-gray-600);
 }
 
 [data-theme='dark'] {
@@ -28,12 +19,8 @@
   --lp-component-chip-color-text-info: var(--lp-color-blue-300);
   --lp-component-chip-color-bg-warning: #3c351f;
   --lp-component-chip-color-text-warning: var(--lp-color-system-yellow-500);
-  --lp-component-chip-color-bg-error: #360914;
-  --lp-component-chip-color-text-error: var(--lp-color-pink-500);
   --lp-component-chip-color-bg-success: #143929;
   --lp-component-chip-color-text-success: var(--lp-color-system-green-500);
-  --lp-component-chip-color-bg-inactive: #313232;
-  --lp-component-chip-color-text-inactive: var(--lp-color-gray-300);
   --lp-component-chip-color-bg-label: var(--lp-color-black-100);
   --lp-component-chip-color-text-label: var(--lp-color-gray-100);
   --lp-component-chip-color-bg-beta: #30213a;
@@ -42,14 +29,11 @@
   --lp-component-chip-color-text-federal: var(--lp-color-yellow-500);
   --lp-component-chip-color-bg-default: var(--lp-color-black-100);
   --lp-component-chip-color-text-default: var(--lp-color-gray-100);
-  --lp-component-chip-color-border: var(--lp-color-gray-500);
-  --lp-component-chip-color-bg-hover: var(--lp-color-gray-800);
 }
 
 .Chip {
   display: inline-flex;
-  font-weight: var(--lp-font-weight-medium);
-  border: 1px solid var(--lp-component-chip-color-border);
+  font-weight: var(--lp-font-weight-semibold);
   border-radius: 0.2rem;
   vertical-align: bottom;
   text-align: center;
@@ -65,92 +49,44 @@
 .Chip--normal {
   font-size: 1.4rem;
   line-height: 1.4;
-  padding: 0.3125rem 0.6rem;
-  min-height: 2.8rem;
-}
-
-.Chip--legacy {
-  font-size: 1.1rem;
-  line-height: 1.4;
-  padding: 0.325rem;
+  padding: 0.215rem 0.6rem;
   min-height: 2.4rem;
 }
 
 .Chip.Chip--small {
   font-size: 1.2rem;
   line-height: 1.33;
-  padding: 0.1rem 0.4rem;
+  padding: 0.2rem 0.4rem;
   min-height: 2rem;
 }
 
-.Chip--subtle {
-  background: var(--lp-color-bg-ui-primary);
-}
-
 .Chip--info {
-  border-color: var(--lp-component-chip-color-text-info);
-  color: var(--lp-component-chip-color-text-info);
-}
-
-.Chip--info:not(.Chip--subtle) {
   background-color: var(--lp-component-chip-color-bg-info);
-  border-color: var(--lp-component-chip-color-bg-info);
   color: var(--lp-component-chip-color-text-info);
 }
 
 .Chip--new {
-  border-color: var(--lp-component-chip-color-text-success);
-  color: var(--lp-component-chip-color-text-success);
-}
-
-.Chip--new:not(.Chip--subtle) {
   background-color: var(--lp-component-chip-color-bg-success);
-  border-color: var(--lp-component-chip-color-bg-success);
   color: var(--lp-component-chip-color-text-success);
 }
 
 .Chip--beta {
-  border-color: var(--lp-component-chip-color-text-beta);
-  color: var(--lp-component-chip-color-text-beta);
-}
-
-.Chip--beta:not(.Chip--subtle) {
   background-color: var(--lp-component-chip-color-bg-beta);
-  border-color: var(--lp-component-chip-color-bg-beta);
   color: var(--lp-component-chip-color-text-beta);
 }
 
 .Chip--success {
-  border-color: var(--lp-component-chip-color-text-success);
-  color: var(--lp-component-chip-color-text-success);
-}
-
-.Chip--success:not(.Chip--subtle) {
   background-color: var(--lp-component-chip-color-bg-success);
-  border-color: transparent;
   color: var(--lp-component-chip-color-text-success);
 }
 
 .Chip--warning {
-  border-color: var(--lp-component-chip-color-text-warning);
-  color: var(--lp-component-chip-color-text-warning);
-}
-
-.Chip--warning:not(.Chip--subtle) {
   background-color: var(--lp-component-chip-color-bg-warning);
-  border-color: var(--lp-component-chip-color-bg-warning);
   color: var(--lp-component-chip-color-text-warning);
-}
-
-.Chip--label {
-  background-color: var(--lp-component-chip-color-bg-label);
-  border-color: var(--lp-component-chip-color-bg-label);
-  color: var(--lp-component-chip-color-text-label);
 }
 
 .Chip--federal {
   background-color: var(--lp-component-chip-color-bg-federal);
-  border-color: var(--lp-component-chip-color-bg-federal);
   color: var(--lp-component-chip-color-text-federal);
 }
 

--- a/packages/chip/stories/Chip.stories.tsx
+++ b/packages/chip/stories/Chip.stories.tsx
@@ -22,11 +22,6 @@ export default {
         category: 'Presentation',
       },
     },
-    subtle: {
-      table: {
-        category: 'Presentation',
-      },
-    },
     children: {
       table: {
         category: 'Content',
@@ -47,8 +42,6 @@ export const Warning: Story = { args: { children: 'Warning Chip', kind: 'warning
 
 export const Info: Story = { args: { children: 'Info Chip', kind: 'info' } };
 
-export const Label: Story = { args: { children: 'Label Chip', kind: 'label' } };
-
 export const New: Story = { args: { children: 'New Chip', kind: 'new' } };
 
 export const Federal: Story = { args: { children: 'Federal Chip', kind: 'federal' } };
@@ -56,37 +49,3 @@ export const Federal: Story = { args: { children: 'Federal Chip', kind: 'federal
 export const Beta: Story = { args: { children: 'Beta Chip', kind: 'beta' } };
 
 export const Small: Story = { args: { children: 'Small Chip', size: 'small', kind: 'success' } };
-
-export const Medium: Story = { args: { children: 'Medium Chip', size: 'medium', kind: 'success' } };
-
-export const Interactive: Story = {
-  args: {
-    children: 'Interactive Chip',
-    onClick: () => {
-      alert('Chip clicked');
-    },
-  },
-};
-
-export const DefaultSubtle: Story = {
-  args: { children: 'Example Chip', subtle: true },
-};
-
-export const SuccessSubtle: Story = {
-  args: { children: 'Success Chip', kind: 'success', subtle: true },
-};
-
-export const WarningSubtle: Story = {
-  args: { children: 'Warning Chip', kind: 'warning', subtle: true },
-};
-export const InfoSubtle: Story = { args: { children: 'Info Chip', kind: 'info', subtle: true } };
-
-export const LabelSubtle: Story = { args: { children: 'Label Chip', kind: 'label', subtle: true } };
-
-export const NewSubtle: Story = { args: { children: 'New Chip', kind: 'new', subtle: true } };
-
-export const FederalSubtle: Story = {
-  args: { children: 'Federal Chip', kind: 'federal', subtle: true },
-};
-
-export const BetaSubtle: Story = { args: { children: 'Beta Chip', kind: 'beta', subtle: true } };


### PR DESCRIPTION
## Summary
- Deprecate `label` variant
- Remove `legacy` variant, design decided to reduce padding back to 24px total height, making legacy unnecessary.
- Deprecate `subtle` variants
- Update normal and small sizing