### PR TITLE
feat(tokens): remove root from token variables

### DIFF
--- a/.changeset/fast-carrots-rhyme.md
+++ b/.changeset/fast-carrots-rhyme.md
@@ -1,0 +1,6 @@
+---
+'@launchpad-ui/tokens': patch
+'@launchpad-ui/core': patch
+---
+
+Remove :root from token variables

--- a/packages/tokens/sd.config.js
+++ b/packages/tokens/sd.config.js
@@ -139,7 +139,7 @@ StyleDictionary.registerFormat({
 
     const darkColorCSSVariables = `[data-theme='dark'] {\n${darkTokens}\n}\n`;
 
-    const defaultColorCSSVariables = `:root, [data-theme='default'] {\n${defaultTokens}\n}\n`;
+    const defaultColorCSSVariables = `[data-theme='default'] {\n${defaultTokens}\n}\n`;
 
     return `${fileHeader({
       file,


### PR DESCRIPTION
This was actually causing issues with the ability to nest themes, so I figured out a way to support data-theme in the Chromatic build of the main LD app. Now we can remove this.