### PR TITLE
fix(chip): adjust chip size in navitem to prevent clipping

### DIFF
--- a/.changeset/beige-suits-remain.md
+++ b/.changeset/beige-suits-remain.md
@@ -1,0 +1,6 @@
+---
+'@launchpad-ui/navigation': minor
+'@launchpad-ui/core': minor
+---
+
+[NavItem] Fix clipping when using status Chip

--- a/packages/navigation/src/NavItem.tsx
+++ b/packages/navigation/src/NavItem.tsx
@@ -50,7 +50,12 @@ const NavItem = ({
         <div style={{ display: 'flex', alignItems: 'flex-end' }}>
           <span className={styles['NavItem-name']}>
             {name}
-            <Chip className={styles['NavItem-chip']} data-test-id="nav-item-chip" kind={status}>
+            <Chip
+              className={styles['NavItem-chip']}
+              size="small"
+              data-test-id="nav-item-chip"
+              kind={status}
+            >
               {titlecase(status)}
             </Chip>
           </span>


### PR DESCRIPTION
## Summary

I noticed that the Chip clips a bit when inside a NavItem. Changing the size to small for the Chip fixes the issue
## Screenshots (if appropriate):
Before:
<img width="219" alt="Screenshot 2023-03-09 at 11 58 28 AM" src="https://user-images.githubusercontent.com/14228430/224141171-96084e72-a479-4f71-9003-ea6bf7c5b943.png">
After:
<img width="217" alt="Screenshot 2023-03-09 at 11 58 47 AM" src="https://user-images.githubusercontent.com/14228430/224141189-15070867-b59f-4078-b301-3fe256bb2cb0.png">
