### PR TITLE
fix(button): improve IconButton icon sizing

### DIFF
--- a/.changeset/giant-parents-poke.md
+++ b/.changeset/giant-parents-poke.md
@@ -1,0 +1,6 @@
+---
+'@launchpad-ui/button': patch
+'@launchpad-ui/core': patch
+---
+
+[Button] Update `IconButton` to control icon size internally

--- a/packages/button/src/IconButton.tsx
+++ b/packages/button/src/IconButton.tsx
@@ -15,7 +15,7 @@ import './styles/Button.css';
 
 type IconButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
   kind?: 'default' | 'primary' | 'destructive' | 'minimal' | 'close';
-  icon: ReactElement<IconProps>;
+  icon: Omit<ReactElement<IconProps>, 'size'>;
   size?: 'small' | 'normal';
   'aria-label': string;
   asChild?: boolean;
@@ -50,9 +50,15 @@ const IconButtonComponent = forwardRef<HTMLButtonElement, IconButtonProps>((prop
     className
   );
 
+  const iconSize = () => {
+    if (props.size === 'small') return 'small';
+
+    return 'medium';
+  };
+
   const clonedIcon = cloneElement(icon, {
     key: 'icon',
-    size: icon.props.size || 'medium',
+    size: iconSize(),
     'aria-hidden': true,
     className: cx(icon.props.className, 'Button-icon'),
   });

--- a/packages/button/stories/IconButton.stories.tsx
+++ b/packages/button/stories/IconButton.stories.tsx
@@ -135,7 +135,7 @@ export default {
 
 type Story = StoryObj<typeof IconButton>;
 
-const icon = <Add size="medium" />;
+const icon = <Add />;
 
 export const Minimal: Story = {
   args: { icon, 'aria-label': 'Button' },
@@ -170,6 +170,15 @@ export const Close: Story = {
     icon,
     'aria-label': 'Button',
     kind: 'close',
+  },
+};
+
+export const Small: Story = {
+  args: {
+    icon,
+    size: 'small',
+    'aria-label': 'Button',
+    kind: 'default',
   },
 };
 


### PR DESCRIPTION
## Summary
Controls the icon size based on the button size within IconButton, so that we have consistency across IconButtons for which icon size is used.

<img width="197" alt="Screenshot 2023-03-09 at 5 36 00 PM" src="https://user-images.githubusercontent.com/104940219/224184704-6de93aa8-51b7-4f9c-bc50-6774d86b498c.png">
