### PR TITLE
fix(tab-list): remove bg color

### DIFF
--- a/.changeset/smart-rockets-attack.md
+++ b/.changeset/smart-rockets-attack.md
@@ -1,0 +1,6 @@
+---
+'@launchpad-ui/tab-list': patch
+'@launchpad-ui/core': patch
+---
+
+[TabList]: Remove background color

--- a/packages/tab-list/src/styles/TabList.module.css
+++ b/packages/tab-list/src/styles/TabList.module.css
@@ -1,7 +1,6 @@
 .TabList-list {
   display: flex;
   flex-direction: row;
-  background-color: var(--lp-color-bg-ui-primary);
   border-bottom: 1px solid var(--lp-color-border-ui-primary);
 }
 


### PR DESCRIPTION
## Summary
A few weeks ago, @kwatkins-ld and I removed the background color of the Navigation component so that it is more unopinionated about the background color of parent elements. Looking at the TabList in darkmode, it appears we should do the same thing.
<img width="638" alt="Screenshot 2023-03-10 at 10 19 49 AM" src="https://user-images.githubusercontent.com/104940219/224368180-dc1da775-3677-425a-9b00-9f00e63a3a4e.png">
