### PR TITLE
chore: update renovate to only update range deps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,6 +13,7 @@
       "enabled": false
     }
   ],
+  "updatePinnedDependencies": false,
   "rangeStrategy": "bump",
-  "ignoreDeps": ["react-router-dom"]
+  "ignoreDeps": ["react-router-dom", ""]
 }


### PR DESCRIPTION
We have several packages set to pinned dependency versions, and it makes sense to update these manually where possible instead of having renovate bot suggest we update them. These versions are also matched to ones in the downstream consumer app to minimize bundle size.