### PR TITLE
feat(button): update button sizes

### DIFF
--- a/.changeset/rare-moles-trade.md
+++ b/.changeset/rare-moles-trade.md
@@ -1,0 +1,8 @@
+---
+'@launchpad-ui/split-button': patch
+'@launchpad-ui/button': patch
+'@launchpad-ui/core': patch
+---
+
+[Button]: Update IconButton sizing to match button size
+[SplitButton]: Improve height definitions, and use underlying button styles where possible

--- a/packages/button/src/Button.tsx
+++ b/packages/button/src/Button.tsx
@@ -17,7 +17,7 @@ import './styles/Button.css';
 type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
   isLoading?: boolean;
   loadingText?: string | JSX.Element;
-  size?: 'tiny' | 'small' | 'normal' | 'big';
+  size?: 'tiny' | 'small' | 'medium' | 'big';
   kind?: 'default' | 'primary' | 'destructive' | 'minimal' | 'link' | 'close';
   fit?: boolean;
   disabled?: boolean;

--- a/packages/button/src/IconButton.tsx
+++ b/packages/button/src/IconButton.tsx
@@ -16,7 +16,7 @@ import './styles/Button.css';
 type IconButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
   kind?: 'default' | 'primary' | 'destructive' | 'minimal' | 'close';
   icon: Omit<ReactElement<IconProps>, 'size'>;
-  size?: 'small' | 'normal';
+  size?: 'small' | 'medium';
   'aria-label': string;
   asChild?: boolean;
   'data-test-id'?: string;
@@ -27,7 +27,7 @@ const IconButtonComponent = forwardRef<HTMLButtonElement, IconButtonProps>((prop
     icon,
     children,
     className,
-    size = 'normal',
+    size = 'medium',
     kind = 'minimal',
     disabled = false,
     asChild = false,

--- a/packages/button/src/styles/Button.css
+++ b/packages/button/src/styles/Button.css
@@ -37,7 +37,7 @@
   font-size: var(--Button-font-size-small);
   line-height: var(--Button-line-height-small);
   padding: 0.3rem 0.8rem;
-  min-height: 2.5rem;
+  min-height: 2.4rem;
 }
 
 .Button--big {
@@ -382,14 +382,14 @@
   padding: 0;
   line-height: 1;
   border-radius: 50%;
-  height: 2.5rem;
-  width: 2.5rem;
+  height: 3.2rem;
+  width: 3.2rem;
   min-height: auto;
   flex-shrink: 0;
 }
 
 .Button.Button--icon.Button--small {
-  height: 2.2rem;
-  width: 2.2rem;
+  height: 2.4rem;
+  width: 2.4rem;
 }
 /* stylelint-enable no-descending-specificity */

--- a/packages/split-button/src/context.ts
+++ b/packages/split-button/src/context.ts
@@ -11,7 +11,7 @@ type SplitButtonContextState = {
 const SplitButtonContext = createContext<SplitButtonContextState>({
   disabled: false,
   kind: 'default',
-  size: 'normal',
+  size: 'medium',
 });
 
 export { SplitButtonContext };

--- a/packages/split-button/src/styles/SplitButton.css
+++ b/packages/split-button/src/styles/SplitButton.css
@@ -1,51 +1,35 @@
-.SplitButton {
-  --SplitButton-color-border-primary: var(--lp-color-border-interactive-primary);
-  --SplitButton-focus-margin: -0.5rem;
-  --SplitButton-focus-radius: 1rem;
-  --SplitButton-focus-radius-small: 0.6rem;
-  --SplitButton-drop-border-left: 1px;
-  --SplitButton-drop-line-height: 1.7;
-  --SplitButton-drop-margin: 0.1rem;
-  --SplitButton-drop-padding: 0.7rem 0;
-  --SplitButton-drop-padding-small: 0.2rem 0 0.3rem;
-  --SplitButton-popoverTarget-line-height: 1;
-  --SplitButton-border-focus-color: var(--lp-color-shadow-interactive-focus);
-  --SplitButton-box-shadow-focus: 0 0 0 2px var(--lp-color-shadow-interactive-primary),
+:root {
+  --lp-component-splitbutton--color-border-primary: var(--lp-color-border-interactive-primary);
+  --lp-component-splitbutton-color-shadow-focus: 0 0 0 2px
+      var(--lp-color-shadow-interactive-primary),
     0 0 0 4px var(--lp-color-shadow-interactive-focus);
-  --SplitButton-box-shadow-active: none;
-  --SplitButton-drop-width: 3.4rem;
+}
 
+.SplitButton {
   align-items: flex-start;
   display: flex;
-  line-height: var(--SplitButton-popoverTarget-line-height);
+  line-height: 1;
   isolation: isolate;
 
   & .Button--default.SplitButton-main {
-    --SplitButton-color-border-primary: var(--lp-color-border-ui-primary);
+    --lp-component-splitbutton--color-border-primary: var(--lp-color-border-ui-primary);
   }
 
   & .Button--primary.SplitButton-drop {
-    margin-left: var(--SplitButton-drop-margin);
-    width: var(--SplitButton-drop-width);
+    margin-left: 0.1rem;
   }
 }
 
 .SplitButton-drop.Button {
-  border-left-width: var(--SplitButton-drop-border-left);
+  border-left-width: 1px;
   border-top-left-radius: 0;
   border-bottom-left-radius: 0;
-  padding: var(--SplitButton-drop-padding);
+  padding: 0 0.8rem;
   margin-left: -0.1rem;
-  width: calc(var(--SplitButton-drop-width) + 0.2rem);
 }
 
 .SplitButton-drop.Button > span {
   line-height: 1;
-}
-
-.SplitButton-main.Button,
-.SplitButton-drop.Button {
-  min-height: 2.5rem;
 }
 
 .SplitButton-main.Button {
@@ -54,7 +38,7 @@
 }
 
 .SplitButton-main.Button:not([disabled]) {
-  border-right: 1px solid var(--SplitButton-color-border-primary);
+  border-right: 1px solid var(--lp-component-splitbutton--color-border-primary);
 }
 
 .SplitButton :nth-child(1):focus-within {
@@ -76,21 +60,21 @@
 .SplitButton-main.Button:focus-visible {
   border-top-right-radius: 0;
   border-bottom-right-radius: 0;
-  box-shadow: var(--SplitButton-box-shadow-focus);
+  box-shadow: var(--lp-component-splitbutton-color-shadow-focus);
 }
 
 .SplitButton-drop.Button--small {
-  padding: var(--SplitButton-drop-padding-small);
+  padding: 0 0.4rem;
 }
 
 .SplitButton-drop.Button:focus-visible {
-  box-shadow: var(--SplitButton-box-shadow-focus);
+  box-shadow: var(--lp-component-splitbutton-color-shadow-focus);
   border-top-left-radius: 0;
   border-bottom-left-radius: 0;
-  border-left-width: var(--SplitButton-drop-border-left);
+  border-left-width: 1px;
 }
 
 .SplitButton-main.Button:active,
 .SplitButton-drop.Button:active {
-  box-shadow: var(--SplitButton-box-shadow-active);
+  box-shadow: none;
 }

--- a/packages/split-button/stories/SplitButton.stories.tsx
+++ b/packages/split-button/stories/SplitButton.stories.tsx
@@ -4,7 +4,6 @@ import type { ReactElement } from 'react';
 
 import { Person } from '@launchpad-ui/icons';
 import { Menu, MenuItem } from '@launchpad-ui/menu';
-import { Tooltip } from '@launchpad-ui/tooltip';
 import { Fragment, useState } from 'react';
 
 import {
@@ -30,17 +29,13 @@ const SplitButtonExample = ({ icon, ...props }: SplitButtonStoryProps) => {
 
   return (
     <SplitButton {...props}>
-      <Tooltip content={!props.disabled ? 'Main tooltip' : ''}>
-        <SplitButtonMainButton icon={icon}>{!icon && 'Save changes'}</SplitButtonMainButton>
-      </Tooltip>
+      <SplitButtonMainButton icon={icon}>{!icon && 'Save changes'}</SplitButtonMainButton>
       <SplitButtonDropdown
         isOpen={open}
         onInteraction={() => setOpen(!open)}
         onSelect={handleSelect}
       >
-        <Tooltip content={!props.disabled ? 'Dropdown tooltip' : ''}>
-          <SplitButtonDropdownButton />
-        </Tooltip>
+        <SplitButtonDropdownButton />
         <Menu>
           <MenuItem item={{ key: 'Saved changes' }}>Save changes</MenuItem>
           <MenuItem item={{ key: 'Saved with comment' }}>Save with comment</MenuItem>
@@ -228,7 +223,7 @@ const SplitButtonArgs = {
   ),
 };
 
-export const Example: Story = {
+export const Basic: Story = {
   args: {
     ...SplitButtonArgs,
     kind: 'default',
@@ -242,7 +237,7 @@ export const Primary: Story = {
   },
 };
 
-export const DefaultSmall: Story = {
+export const BasicSmall: Story = {
   args: {
     ...SplitButtonArgs,
     kind: 'default',


### PR DESCRIPTION
## Summary
Renames `normal` to `medium` to go with the other t-shirt sizing values.

Improves button sizing so that IconButton and Button share the exact same heights for `small` and `medium` sizes. This makes putting them alongside one another look much more visually correct
<img width="310" alt="Screenshot 2023-03-13 at 11 02 23 PM" src="https://user-images.githubusercontent.com/104940219/224890119-fc1200ce-1b21-40bf-bb82-f76d193616ab.png">

Also refactors the SplitButton to remove unused css variables and improve naming for those that are there.
