### PR TITLE
refactor(button): switch from circular IconButton to rounded

### DIFF
--- a/.changeset/moody-gifts-lay.md
+++ b/.changeset/moody-gifts-lay.md
@@ -1,6 +1,10 @@
 ---
 '@launchpad-ui/button': patch
+'@launchpad-ui/pagination': patch
+'@launchpad-ui/modal': patch
 '@launchpad-ui/core': patch
 ---
 
-[Button] Switch from circular IconButton to rounded
+[Button]: Switch from circular IconButton to rounded
+[Modal]: Update close button size to small
+[Pagination]: Update PaginationButton IconButton size to small

--- a/.changeset/moody-gifts-lay.md
+++ b/.changeset/moody-gifts-lay.md
@@ -1,0 +1,6 @@
+---
+'@launchpad-ui/button': patch
+'@launchpad-ui/core': patch
+---
+
+[Button] Switch from circular IconButton to rounded

--- a/packages/button/src/styles/Button.css
+++ b/packages/button/src/styles/Button.css
@@ -381,7 +381,6 @@
 .Button.Button--icon {
   padding: 0;
   line-height: 1;
-  border-radius: 50%;
   height: 3.2rem;
   width: 3.2rem;
   min-height: auto;

--- a/packages/modal/src/ModalHeader.tsx
+++ b/packages/modal/src/ModalHeader.tsx
@@ -39,6 +39,7 @@ const ModalHeader = ({
         {withCloseButton && (
           <IconButton
             aria-label="close"
+            size="small"
             icon={<Close size="medium" />}
             className={styles.closeButton}
             onClick={onCancel}

--- a/packages/pagination/src/PaginationButton.tsx
+++ b/packages/pagination/src/PaginationButton.tsx
@@ -56,9 +56,10 @@ const PaginationButton = ({
     <IconButton
       disabled={disabled}
       className={classes}
+      size="small"
       data-test-id={testId}
       onClick={() => onClick(kind)}
-      icon={<Icon size="small" />}
+      icon={<Icon />}
       aria-label={label}
     />
   );


### PR DESCRIPTION
## Summary
We recently had a contribution spec approved to switch from round IconButtons to border-radius: 0.6rem. This aligns better with buttons so that they can sit next to eachother.