### PR TITLE
feat(alert): support uncontrolled handling of the dismiss prop

### DIFF
--- a/.changeset/thick-dots-change.md
+++ b/.changeset/thick-dots-change.md
@@ -1,0 +1,6 @@
+---
+'@launchpad-ui/alert': patch
+'@launchpad-ui/core': patch
+---
+
+[Alert] Support uncontrolled handling of the `dismissed` prop

--- a/packages/alert/package.json
+++ b/packages/alert/package.json
@@ -35,6 +35,7 @@
     "@launchpad-ui/button": "workspace:~",
     "@launchpad-ui/icons": "workspace:~",
     "@launchpad-ui/tokens": "workspace:~",
+    "@react-stately/utils": "3.6.0",
     "classix": "2.1.17"
   },
   "peerDependencies": {

--- a/packages/alert/src/Alert.tsx
+++ b/packages/alert/src/Alert.tsx
@@ -2,8 +2,8 @@ import type { HTMLAttributes, ReactNode } from 'react';
 
 import { IconButton } from '@launchpad-ui/button';
 import { Close, StatusIcon } from '@launchpad-ui/icons';
+import { useControlledState } from '@react-stately/utils';
 import { cx } from 'classix';
-import { useState } from 'react';
 
 import styles from './styles/Alert.module.css';
 
@@ -48,6 +48,11 @@ type AlertProps = HTMLAttributes<HTMLDivElement> & {
   onDismiss?(): void;
 
   /**
+   * Controlled dismissed handler
+   */
+  dismissed?: boolean;
+
+  /**
    * When true no icon is rendered
    */
   noIcon?: boolean;
@@ -70,7 +75,9 @@ const Alert = ({
   'data-test-id': testId = 'alert',
   ...rest
 }: AlertProps) => {
-  const [dismissed, setDismissed] = useState(false);
+  const [dismissed, setDismissed] = useControlledState(!!rest.dismissed, false, (val) =>
+    val && onDismiss ? onDismiss() : null
+  );
 
   const defaultClasses = `${styles.Alert} ${styles[`Alert--${kind}`]}`;
   const sizeClass = size === 'small' && styles[`Alert--${size}`];

--- a/packages/alert/stories/Alert.stories.tsx
+++ b/packages/alert/stories/Alert.stories.tsx
@@ -1,6 +1,7 @@
 import type { StoryObj } from '@storybook/react';
 
 import { Button, ButtonGroup } from '@launchpad-ui/button';
+import { useState } from 'react';
 
 import { Alert } from '../src';
 
@@ -174,5 +175,32 @@ export const WithContent: Story = {
     ),
     header: 'My title',
     dismissible: true,
+  },
+};
+
+export const WithControlledDismissed: Story = {
+  render: () => {
+    const Component = () => {
+      const [dismissed, setDismissed] = useState(false);
+
+      return (
+        <Alert
+          dismissible={true}
+          dismissed={dismissed}
+          onDismiss={() => {
+            setDismissed(true);
+
+            setTimeout(() => {
+              setDismissed(false);
+            }, 1500);
+          }}
+        >
+          With the parent handling dismiss behavior. In this example, the parent resets the{' '}
+          <code>dismissed</code> value after 3 seconds.
+        </Alert>
+      );
+    };
+
+    return <Component />;
   },
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -268,6 +268,7 @@ importers:
       '@launchpad-ui/button': workspace:~
       '@launchpad-ui/icons': workspace:~
       '@launchpad-ui/tokens': workspace:~
+      '@react-stately/utils': 3.6.0
       classix: 2.1.17
       react: 18.2.0
       react-dom: 18.2.0
@@ -275,6 +276,7 @@ importers:
       '@launchpad-ui/button': link:../button
       '@launchpad-ui/icons': link:../icons
       '@launchpad-ui/tokens': link:../tokens
+      '@react-stately/utils': 3.6.0_react@18.2.0
       classix: 2.1.17
     devDependencies:
       react: 18.2.0
@@ -5355,7 +5357,7 @@ packages:
       '@storybook/csf-plugin': 7.0.0-beta.60
       '@storybook/csf-tools': 7.0.0-beta.60
       '@storybook/global': 5.0.0
-      '@storybook/mdx2-csf': 1.0.0-next.5
+      '@storybook/mdx2-csf': 1.0.0-next.6
       '@storybook/node-logger': 7.0.0-beta.60
       '@storybook/postinstall': 7.0.0-beta.60
       '@storybook/preview-api': 7.0.0-beta.60
@@ -5685,7 +5687,7 @@ packages:
       '@storybook/client-logger': 7.0.0-beta.60
       '@storybook/core-common': 7.0.0-beta.60
       '@storybook/csf-plugin': 7.0.0-beta.60
-      '@storybook/mdx2-csf': 1.0.0-next.5
+      '@storybook/mdx2-csf': 1.0.0-next.6
       '@storybook/node-logger': 7.0.0-beta.60
       '@storybook/preview': 7.0.0-beta.60
       '@storybook/preview-api': 7.0.0-beta.60
@@ -6070,8 +6072,8 @@ packages:
     resolution: {integrity: sha512-XcAAYnd9oHvkG4ieSiCbNJvqAYNh7zO1LYQ2cx2GdDL+Wr40SaUk6VG1/E8s/ETF4QgI6CvQbbg74VaaO2MbBA==}
     dev: true
 
-  /@storybook/mdx2-csf/1.0.0-next.5:
-    resolution: {integrity: sha512-02w0sgGZaK1agT050yCVhJ+o4rLHANWvLKWjQjeAsYbjneLC5ITt+3GDB4jRiWwJboZ8dHW1fGSK1Vg5fA34aQ==}
+  /@storybook/mdx2-csf/1.0.0-next.6:
+    resolution: {integrity: sha512-m6plojocU/rmrqWd26yvm8D+oHZPZ6PtSSFmZIgpNDEPVmc8s4fBD6LXOAB5MiPI5f8KLUr2HVhOMZ97o5pDTw==}
     dev: true
 
   /@storybook/node-logger/7.0.0-beta.60:


### PR DESCRIPTION
## Summary
One of our team members has requested that they have the ability to show/hide Alerts from the consumer. This change implements a controlled/uncontrolled state management solution using `react-stately`'s `useControlledState` hook, which is in use elsewhere across the design system.