### PR TITLE
feat(form): replace error text with icon

### DIFF
--- a/.changeset/unlucky-shirts-sit.md
+++ b/.changeset/unlucky-shirts-sit.md
@@ -1,0 +1,6 @@
+---
+'@launchpad-ui/form': patch
+'@launchpad-ui/core': patch
+---
+
+[Form] Replace field "Error" text with an error icon

--- a/apps/remix/app/routes/components/form.tsx
+++ b/apps/remix/app/routes/components/form.tsx
@@ -22,7 +22,7 @@ export default function Index() {
         label="Email"
         name="Email"
         htmlFor="Email"
-        errorMessage="Oops, you entered an incorrect email."
+        errorMessage="Oops, you entered an incorrect email"
         isInvalid={true}
       >
         <TextField id="Email" value="testing@launchdarkly.com" />

--- a/packages/form/__tests__/Form.cy.tsx
+++ b/packages/form/__tests__/Form.cy.tsx
@@ -24,7 +24,7 @@ const createComponent = (props?: FormProps) => (
       label="Email"
       name="Email"
       htmlFor="Email"
-      errorMessage="Oops, you entered an incorrect email."
+      errorMessage="Oops, you entered an incorrect email"
       isInvalid={true}
     >
       <TextField id="Email" value="testing@launchdarkly.com" />

--- a/packages/form/src/FieldError.tsx
+++ b/packages/form/src/FieldError.tsx
@@ -1,6 +1,7 @@
 import type { FieldPath } from './utils';
 import type { HTMLAttributes } from 'react';
 
+import { AlertRhombus } from '@launchpad-ui/icons';
 import { cx } from 'classix';
 
 import styles from './styles/Form.module.css';
@@ -29,9 +30,10 @@ const FieldError = ({
       className={cx(styles.fieldError, className)}
       aria-live="polite"
       data-test-id={testId}
+      aria-label="Error"
       id={createFieldErrorId(name)}
     >
-      {`Error - ${errorMessage}`}
+      <AlertRhombus size="small" /> {errorMessage}
     </span>
   );
 };

--- a/packages/form/src/styles/Form.module.css
+++ b/packages/form/src/styles/Form.module.css
@@ -138,6 +138,10 @@ select.formInput {
 .fieldError {
   color: var(--lp-color-text-feedback-error);
   font-size: 1.3rem;
+
+  & svg {
+    transform: translateY(-1px);
+  }
 }
 
 /* The margin for .formGroup and the min-height of .form-fieldError

--- a/packages/form/stories/FormField.stories.tsx
+++ b/packages/form/stories/FormField.stories.tsx
@@ -70,7 +70,7 @@ export const WithError: Story = {
     label: 'Email',
     name: 'Email',
     htmlFor: 'Email',
-    errorMessage: 'Oops, you entered an incorrect email.',
+    errorMessage: 'Oops, you entered an incorrect email',
     isInvalid: true,
     children: <TextField id="Email" value="testing@launchdarkly.com" />,
   },
@@ -82,7 +82,7 @@ export const WithHint: Story = {
     label: 'Email',
     name: 'Email',
     htmlFor: 'Email',
-    hint: 'Must be a valid email.',
+    hint: 'Must be a valid email',
     children: <TextField id="Email" value="testing@launchdarkly.com" />,
   },
 };


### PR DESCRIPTION
Before:
<img width="367" alt="Screenshot 2023-03-16 at 10 55 55 AM" src="https://user-images.githubusercontent.com/104940219/225677882-c5848bc3-01a4-4545-ac94-764c85736411.png">

After:
<img width="412" alt="Screenshot 2023-03-16 at 10 49 31 AM" src="https://user-images.githubusercontent.com/104940219/225677670-31616f6c-7c8d-456a-99f1-ef25455753cc.png">
