### PR TITLE
feat: new `action` prop for tags, improve `tiny` button styles, and rename `default` button kind to `basic`

### DIFF
--- a/.changeset/young-dolls-fix.md
+++ b/.changeset/young-dolls-fix.md
@@ -1,0 +1,10 @@
+---
+'@launchpad-ui/collapsible': patch
+'@launchpad-ui/button': patch
+'@launchpad-ui/alert': patch
+'@launchpad-ui/tag': patch
+'@launchpad-ui/core': patch
+---
+
+[Button]: Rename `default` kind to `basic` and rename size variants for `ButtonGroup`
+[Tag]: Remove `onAction` and `actionLabel` props in favor of a new `action` prop which accepts a render element

--- a/packages/alert/stories/Alert.stories.tsx
+++ b/packages/alert/stories/Alert.stories.tsx
@@ -168,7 +168,7 @@ export const WithContent: Story = {
           <li>This is item two of a list</li>
         </ul>
         <ButtonGroup>
-          <Button kind="default">Label</Button>
+          <Button>Label</Button>
           <Button kind="minimal">Label</Button>
         </ButtonGroup>
       </>

--- a/packages/button/src/Button.tsx
+++ b/packages/button/src/Button.tsx
@@ -18,7 +18,7 @@ type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
   isLoading?: boolean;
   loadingText?: string | JSX.Element;
   size?: 'tiny' | 'small' | 'medium' | 'big';
-  kind?: 'default' | 'primary' | 'destructive' | 'minimal' | 'link' | 'close';
+  kind?: 'basic' | 'primary' | 'destructive' | 'minimal' | 'link' | 'close';
   fit?: boolean;
   disabled?: boolean;
   icon?: ReactElement<Omit<IconProps, 'size'>>;
@@ -34,7 +34,7 @@ const ButtonComponent = forwardRef<HTMLButtonElement, ButtonProps>((props, ref) 
     className,
     size,
     fit,
-    kind = 'default',
+    kind = 'basic',
     isLoading = false,
     loadingText,
     renderIconFirst = false,

--- a/packages/button/src/ButtonGroup.tsx
+++ b/packages/button/src/ButtonGroup.tsx
@@ -5,12 +5,12 @@ import { cx } from 'classix';
 import './styles/ButtonGroup.css';
 
 type ButtonGroupProps = HTMLAttributes<HTMLDivElement> & {
-  spacing?: 'compact' | 'normal' | 'large';
+  spacing?: 'small' | 'medium' | 'large';
   'data-test-id'?: string;
 };
 
 const ButtonGroup = ({
-  spacing = 'normal',
+  spacing = 'medium',
   className,
   children,
   'data-test-id': testId = 'button-group',

--- a/packages/button/src/IconButton.tsx
+++ b/packages/button/src/IconButton.tsx
@@ -14,7 +14,7 @@ import { isValidElement, cloneElement, forwardRef, memo } from 'react';
 import './styles/Button.css';
 
 type IconButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
-  kind?: 'default' | 'primary' | 'destructive' | 'minimal' | 'close';
+  kind?: 'basic' | 'primary' | 'destructive' | 'minimal' | 'close';
   icon: Omit<ReactElement<IconProps>, 'size'>;
   size?: 'small' | 'medium';
   'aria-label': string;

--- a/packages/button/src/styles/Button.css
+++ b/packages/button/src/styles/Button.css
@@ -13,10 +13,10 @@
   text-transform: var(--Button-text-transform);
   vertical-align: initial;
   white-space: nowrap;
-  border: var(--Button-border-default);
-  border-radius: var(--Button-border-radius-default);
-  font-size: var(--Button-font-size-default);
-  line-height: var(--Button-line-height-default);
+  border: var(--Button-border-basic);
+  border-radius: var(--Button-border-radius-basic);
+  font-size: var(--Button-font-size-basic);
+  line-height: var(--Button-line-height-basic);
   padding: 0.7rem 0.8rem;
   cursor: default;
   user-select: none;
@@ -26,10 +26,10 @@
 
 .Button--tiny {
   border-radius: var(--Button-border-radius-small);
-  font-size: var(--Button-font-size-small);
+  font-size: var(--lp-font-size-100);
   line-height: var(--Button-line-height-small);
-  padding: 0 0.4rem;
-  min-height: 1.9rem;
+  padding: 0.1rem 0.4rem;
+  min-height: 2rem;
 }
 
 .Button--small {
@@ -70,7 +70,7 @@
 
 .Button:focus-visible,
 .Dropdown-trigger:focus-visible .Button--menu {
-  border-radius: var(--Button-border-radius-default);
+  border-radius: var(--Button-border-radius-basic);
   box-shadow: var(--Button-box-shadow-focus);
   outline: 0;
   z-index: 2;
@@ -83,39 +83,39 @@
 
 /* ------- BUTTON VARIANTS -------  */
 
-/* ------- DEFAULT ------- */
+/* ------- BASIC ------- */
 
-.Button--default {
-  background-color: var(--lp-component-button-color-bg-default);
-  border-color: var(--Button-color-border-default);
-  color: var(--Button-color-text-default);
+.Button--basic {
+  background-color: var(--lp-component-button-color-bg-basic);
+  border-color: var(--Button-color-border-basic);
+  color: var(--Button-color-text-basic);
 }
 
-.Button--default .Button-icon {
-  fill: var(--Button-icon-color-fill-default);
+.Button--basic .Button-icon {
+  fill: var(--Button-icon-color-fill-basic);
 }
 
-.Button--icon.Button--default .Button-icon {
+.Button--icon.Button--basic .Button-icon {
   background-color: transparent;
-  color: var(--Button-icon-color-text-default);
+  color: var(--Button-icon-color-text-basic);
 }
 
-.Button--default:hover,
-.Button--icon.Button--default:hover {
-  background-color: var(--Button-color-background-default-hover);
-  color: var(--Button-color-text-default-hover);
+.Button--basic:hover,
+.Button--icon.Button--basic:hover {
+  background-color: var(--Button-color-background-basic-hover);
+  color: var(--Button-color-text-basic-hover);
   box-shadow: var(--Button-box-shadow-hover);
 }
 
-.Button--default:focus-visible {
-  background-color: var(--Button-color-background-default-focus);
+.Button--basic:focus-visible {
+  background-color: var(--Button-color-background-basic-focus);
 }
 
-.Button--icon.Button--default:active,
-.Button--default:active {
-  background-color: var(--Button-color-background-default-active);
+.Button--icon.Button--basic:active,
+.Button--basic:active {
+  background-color: var(--Button-color-background-basic-active);
   box-shadow: var(--Button-box-shadow-active);
-  color: var(--Button-color-text-default-active);
+  color: var(--Button-color-text-basic-active);
 }
 
 /* ------- PRIMARY, ICON, SUBMIT, MINIMAL ------- */
@@ -312,7 +312,7 @@
   line-height: 1; /* 1 */
   border-color: transparent;
   background-color: transparent;
-  color: var(--Button-color-link-default);
+  color: var(--Button-color-link-basic);
   cursor: pointer;
   min-height: auto;
 }

--- a/packages/button/src/styles/ButtonVariables.css
+++ b/packages/button/src/styles/ButtonVariables.css
@@ -1,6 +1,6 @@
 :root,
 [data-theme='default'] {
-  --lp-component-button-color-bg-default: var(--lp-color-bg-interactive-secondary);
+  --lp-component-button-color-bg-basic: var(--lp-color-bg-interactive-secondary);
   --lp-component-button-color-border-destructive: var(--lp-color-border-interactive-destructive);
   --lp-component-button-color-bg-destructive-hover: var(
     --lp-color-bg-interactive-destructive-hover
@@ -14,7 +14,7 @@
 }
 
 [data-theme='dark'] {
-  --lp-component-button-color-bg-default: transparent;
+  --lp-component-button-color-bg-basic: transparent;
   --lp-component-button-color-border-destructive: var(--lp-color-system-red-600);
   --lp-component-button-color-bg-destructive-hover: var(--lp-color-system-red-900);
   --lp-component-button-color-bg-destructive-focus: var(--lp-color-system-red-900);
@@ -24,62 +24,61 @@
 .Button,
 .ButtonGroup {
   /* Remaining Legacy Tokens */
-  --Button-border-default: 1px solid transparent;
-  --Button-box-shadow-default-active: none;
-  --Button-color-boxShadow-1-default-active: var(--lp-color-white);
-  --Button-color-boxShadow-2-default-active: hsl(231.5 100% 62.5% / 0.1);
-  --Button-color-boxShadow-1-default-withIcon-focus: var(--lp-color-shadow-interactive-focus);
-  --Button-color-boxShadow-2-default-withIcon-focus: hsl(231.5 100% 62.5% / 0.1);
-  --Button-box-shadow-withIcon-focus: 0 0 0 1px
-      var(--Button-color-boxShadow-1-default-withIcon-focus),
-    0 0 0 4px var(--Button-color-boxShadow-2-default-withIcon-focus);
+  --Button-border-basic: 1px solid transparent;
+  --Button-box-shadow-basic-active: none;
+  --Button-color-boxShadow-1-basic-active: var(--lp-color-white);
+  --Button-color-boxShadow-2-basic-active: hsl(231.5 100% 62.5% / 0.1);
+  --Button-color-boxShadow-1-basic-withIcon-focus: var(--lp-color-shadow-interactive-focus);
+  --Button-color-boxShadow-2-basic-withIcon-focus: hsl(231.5 100% 62.5% / 0.1);
+  --Button-box-shadow-withIcon-focus: 0 0 0 1px var(--Button-color-boxShadow-1-basic-withIcon-focus),
+    0 0 0 4px var(--Button-color-boxShadow-2-basic-withIcon-focus);
   --Button-color-text-destructive-focus: var(--lp-color-white);
   --Button-color-background-disabled-withIcon: var(--lp-color-white);
   --Button-color-border-disabled-withIcon: transparent;
 
   /* End Remaining Legacy Tokens */
 
-  --Button-font-size-default: 1.4rem;
+  --Button-font-size-basic: 1.4rem;
   --Button-font-size-small: 1.4rem;
   --Button-font-size-large: 1.6rem;
   --Button-font-weight: var(--lp-font-weight-medium);
-  --Button-line-height-default: 114%;
+  --Button-line-height-basic: 114%;
   --Button-line-height-small: 114%;
   --Button-line-height-large: 150%;
-  --Button-border-radius-default: 0.6rem;
+  --Button-border-radius-basic: 0.6rem;
   --Button-border-radius-small: var(--lp-border-radius-regular);
   --Button-border-radius-link: 1px;
   --Button-border-radius-withIcon: 50%;
   --Button-text-transform: none;
 
-  /* ------- DEFAULT ------- */
-  --Button-color-background-default-hover: var(--lp-color-bg-interactive-secondary-hover);
-  --Button-color-background-default-focus: var(--lp-color-bg-interactive-secondary-focus);
-  --Button-color-background-default-active: var(--lp-color-bg-interactive-secondary-active);
-  --Button-color-border-default: var(--lp-color-border-interactive-secondary);
+  /* ------- basic ------- */
+  --Button-color-background-basic-hover: var(--lp-color-bg-interactive-secondary-hover);
+  --Button-color-background-basic-focus: var(--lp-color-bg-interactive-secondary-focus);
+  --Button-color-background-basic-active: var(--lp-color-bg-interactive-secondary-active);
+  --Button-color-border-basic: var(--lp-color-border-interactive-secondary);
 
-  /* named for hover state for default, primary, destructive */
+  /* named for hover state for basic, primary, destructive */
   --Button-box-shadow-hover: 0 2px 8px -1px hsl(0 0% 0% / 0.04), 0 2px 4px 0 hsl(0 0% 0% / 0.08),
     0 1px 2px 0 hsl(0 0% 0% / 0.14);
-  --Button-color-boxShadow-1-default-focus: var(--lp-color-bg-ui-primary);
-  --Button-color-boxShadow-2-default-focus: var(--lp-color-shadow-interactive-focus);
+  --Button-color-boxShadow-1-basic-focus: var(--lp-color-bg-ui-primary);
+  --Button-color-boxShadow-2-basic-focus: var(--lp-color-shadow-interactive-focus);
 
-  /* named for focus state for default, primary, destructive */
-  --Button-box-shadow-focus: 0 0 0 2px var(--Button-color-boxShadow-1-default-focus),
-    0 0 0 4px var(--Button-color-boxShadow-2-default-focus);
+  /* named for focus state for basic, primary, destructive */
+  --Button-box-shadow-focus: 0 0 0 2px var(--Button-color-boxShadow-1-basic-focus),
+    0 0 0 4px var(--Button-color-boxShadow-2-basic-focus);
 
-  /* named for active state for default, primary, destructive */
+  /* named for active state for basic, primary, destructive */
   --Button-box-shadow-active: none;
   --Button-box-shadow-link-hover: none;
-  --Button-box-shadow-link-focus: 0 0 0 2px var(--Button-color-boxShadow-1-default-focus),
-    0 0 0 4px var(--Button-color-boxShadow-2-default-focus);
+  --Button-box-shadow-link-focus: 0 0 0 2px var(--Button-color-boxShadow-1-basic-focus),
+    0 0 0 4px var(--Button-color-boxShadow-2-basic-focus);
   --Button-box-shadow-link-active: none;
-  --Button-color-link-default: var(--lp-color-text-interactive);
+  --Button-color-link-basic: var(--lp-color-text-interactive);
   --Button-color-link-active: var(--lp-color-text-interactive-active);
-  --Button-color-text-default: var(--lp-color-text-ui-primary);
-  --Button-color-text-default-hover: var(--lp-color-text-ui-primary);
-  --Button-color-text-default-focus: var(--lp-color-text-ui-primary);
-  --Button-color-text-default-active: var(--lp-color-text-ui-primary);
+  --Button-color-text-basic: var(--lp-color-text-ui-primary);
+  --Button-color-text-basic-hover: var(--lp-color-text-ui-primary);
+  --Button-color-text-basic-focus: var(--lp-color-text-ui-primary);
+  --Button-color-text-basic-active: var(--lp-color-text-ui-primary);
 
   /* ------- PRIMARY ------- */
   --Button-color-background-primary: var(--lp-color-bg-interactive-primary);
@@ -149,10 +148,10 @@
 
   /* ------- BUTTON ICONS ------- */
 
-  /* BUTTON ICON DEFAULT */
-  --Button-icon-color-default: var(--lp-color-text-ui-primary);
-  --Button-icon-color-fill-default: var(--lp-color-text-ui-primary);
-  --Button-icon-color-text-default: var(--lp-color-text-ui-primary);
+  /* BUTTON ICON basic */
+  --Button-icon-color-basic: var(--lp-color-text-ui-primary);
+  --Button-icon-color-fill-basic: var(--lp-color-text-ui-primary);
+  --Button-icon-color-text-basic: var(--lp-color-text-ui-primary);
 
   /* BUTTON ICON PRIMARY */
   --Button-icon-color-fill-primary: var(--lp-color-fill-interactive-primary);

--- a/packages/button/stories/ButtonGroup.stories.tsx
+++ b/packages/button/stories/ButtonGroup.stories.tsx
@@ -21,7 +21,7 @@ const buttonTemplateWithStates: DecoratorFn = (storyComponent, context) => {
         {ButtonLabels[ButtonLabels.length - 1 >= index ? index : ButtonLabels.length - 1]}
       </span>
       <ButtonGroup {...storyArgs}>
-        <Button kind="default" className={className}>
+        <Button kind="basic" className={className}>
           First
         </Button>
         <Button kind="primary">Second</Button>
@@ -36,7 +36,7 @@ const buttonTemplateWithStates: DecoratorFn = (storyComponent, context) => {
       {PseudoStateButtons}
       <span className="Button-state-label">Disabled</span>
       <ButtonGroup {...storyArgs}>
-        <Button kind="default" disabled>
+        <Button kind="basic" disabled>
           First
         </Button>
         <Button kind="primary">Second</Button>

--- a/packages/collapsible/src/CollapsibleTrigger.tsx
+++ b/packages/collapsible/src/CollapsibleTrigger.tsx
@@ -22,7 +22,6 @@ const CollapsibleTrigger = (props: CollapsibleTriggerProps) => {
     <Button
       icon={icon}
       renderIconFirst
-      kind="default"
       onClick={toggleOpen}
       data-test-id="collapsible-trigger"
       {...triggerProps}

--- a/packages/tag/src/Tag.tsx
+++ b/packages/tag/src/Tag.tsx
@@ -1,3 +1,4 @@
+import type { TagGroupProps } from './TagGroup';
 import type { TagItemProps } from './TagItem';
 import type { TagGroupState } from '@react-stately/tag';
 import type { Node } from '@react-types/shared';
@@ -20,10 +21,11 @@ type TagProps<T extends object> = ReactAriaTagProps<T> & {
     props?: TagItemProps<T, ElementType>;
   };
   state: TagGroupState<T>;
+  size: TagGroupProps<T>['size'];
 };
 
 const Tag = <T extends object>(props: TagProps<T>) => {
-  const { children, allowsRemoving, item, state, onRemove } = props;
+  const { children, allowsRemoving, item, state, onRemove, size } = props;
 
   const { hoverProps, isHovered } = useHover({});
   const { isFocused, isFocusVisible, focusProps } = useFocusRing({ within: true });
@@ -51,7 +53,8 @@ const Tag = <T extends object>(props: TagProps<T>) => {
         styles.tag,
         isFocusVisible && styles.isFocusVisible,
         isHovered && styles.isHovered,
-        !allowsRemoving && styles.isReadOnly
+        !allowsRemoving && styles.isReadOnly,
+        size === 'small' && styles.small
       )}
       ref={ref}
       data-test-id="tag"

--- a/packages/tag/src/TagGroup.tsx
+++ b/packages/tag/src/TagGroup.tsx
@@ -20,6 +20,8 @@ type TagGroupProps<T extends object> = AriaTagGroupProps<T> & {
   hideActionWhenEmpty?: boolean;
 
   'data-test-id'?: string;
+
+  size?: 'small' | 'medium';
 };
 
 const TagGroup = <T extends object>(props: TagGroupProps<T>) => {
@@ -31,6 +33,7 @@ const TagGroup = <T extends object>(props: TagGroupProps<T>) => {
     action,
     hideActionWhenEmpty,
     'data-test-id': testId = 'tag-group',
+    size = 'medium',
   } = props;
   const containerRef = useRef<HTMLDivElement>(null);
   const tagsRef = useRef<HTMLDivElement>(null);
@@ -145,7 +148,7 @@ const TagGroup = <T extends object>(props: TagGroupProps<T>) => {
   const isEmpty = state.collection.size === 0;
   const showCustomAction = !(hideActionWhenEmpty && isEmpty) && !!action;
   const showActions = tagState.showCollapseButton || showCustomAction;
-  const customAction = showCustomAction && action({ state });
+  const customAction = showCustomAction && action({ state, size });
 
   const collapseLabel = isCollapsed ? `Show all (${state.collection.size})` : 'Show less';
 
@@ -161,6 +164,7 @@ const TagGroup = <T extends object>(props: TagGroupProps<T>) => {
               state={state}
               allowsRemoving={allowsRemoving}
               onRemove={onRemove}
+              size={size}
             >
               {item.rendered}
             </Tag>
@@ -178,7 +182,7 @@ const TagGroup = <T extends object>(props: TagGroupProps<T>) => {
             <>
               {tagState.showCollapseButton && (
                 <Button
-                  size="small"
+                  size={size === 'small' ? 'tiny' : 'small'}
                   kind="minimal"
                   data-test-id="tag-group-collapse-action-btn"
                   onClick={handlePressCollapse}

--- a/packages/tag/src/TagGroupClearAction.tsx
+++ b/packages/tag/src/TagGroupClearAction.tsx
@@ -2,11 +2,15 @@ import type { TagGroupActionProps } from './types';
 
 import { Button } from '@launchpad-ui/button';
 
-const TagGroupClearAction = <T extends object>(props: TagGroupActionProps<T>) => {
+const TagGroupClearAction = <T extends object>({
+  size,
+  state: _state,
+  ...props
+}: TagGroupActionProps<T>) => {
   return (
     <Button
       {...props}
-      size="small"
+      size={size === 'small' ? 'tiny' : 'small'}
       kind="minimal"
       data-test-id="tag-group-action-btn"
       aria-label="Clear"

--- a/packages/tag/src/TagGroupClearAction.tsx
+++ b/packages/tag/src/TagGroupClearAction.tsx
@@ -1,0 +1,19 @@
+import type { TagGroupActionProps } from './types';
+
+import { Button } from '@launchpad-ui/button';
+
+const TagGroupClearAction = <T extends object>(props: TagGroupActionProps<T>) => {
+  return (
+    <Button
+      {...props}
+      size="small"
+      kind="minimal"
+      data-test-id="tag-group-action-btn"
+      aria-label="Clear"
+    >
+      Clear
+    </Button>
+  );
+};
+
+export { TagGroupClearAction };

--- a/packages/tag/src/index.ts
+++ b/packages/tag/src/index.ts
@@ -1,4 +1,6 @@
 export type { TagGroupProps } from './TagGroup';
+export type { TagGroupActionProps } from './types';
 
 export { TagGroup } from './TagGroup';
 export { TagItem } from './TagItem';
+export { TagGroupClearAction } from './TagGroupClearAction';

--- a/packages/tag/src/styles/Tag.module.css
+++ b/packages/tag/src/styles/Tag.module.css
@@ -19,7 +19,7 @@
   border: 1px solid var(--lp-component-tag-color-border);
   border-radius: var(--lp-border-radius-regular);
   font-size: var(--lp-font-size-200);
-  line-height: 1;
+  line-height: var(--lp-font-size-200);
   padding: 0 0.4rem 0 0.6rem;
   height: 2.4rem;
   max-width: 100%;
@@ -28,6 +28,13 @@
   box-sizing: border-box;
   cursor: default;
   display: inline-grid;
+}
+
+.tag.small {
+  font-size: var(--lp-font-size-100);
+  line-height: 1.25;
+  height: 20px;
+  margin-bottom: 0.2rem;
 }
 
 a.tag {
@@ -64,6 +71,10 @@ a.tag {
 
 .tagContent {
   padding: 0.4rem 0.2rem 0.4rem 0;
+
+  .small & {
+    padding: 0.15rem 0.2rem 0.15rem 0;
+  }
 }
 
 .removeButton {
@@ -86,6 +97,11 @@ a.tag {
   &:focus-within {
     outline: none;
   }
+
+  .small & {
+    width: 1.8rem;
+    height: 1.8rem;
+  }
 }
 
 .tagGroupContainer {
@@ -95,12 +111,17 @@ a.tag {
 
 .tagGroup {
   display: inline;
+  line-height: 1;
+  vertical-align: top;
 }
 
 .tagGroupActions {
   display: inline;
+  vertical-align: top;
+  margin-bottom: 0.4rem;
+  line-height: 1;
 
-  & button {
-    margin-bottom: 0.4rem;
+  .small & {
+    margin-bottom: 0.2rem;
   }
 }

--- a/packages/tag/src/styles/Tag.module.css
+++ b/packages/tag/src/styles/Tag.module.css
@@ -99,8 +99,8 @@ a.tag {
 
 .tagGroupActions {
   display: inline;
-}
 
-.tagGroupAction {
-  margin-bottom: 0.4rem;
+  & button {
+    margin-bottom: 0.4rem;
+  }
 }

--- a/packages/tag/src/types.ts
+++ b/packages/tag/src/types.ts
@@ -1,0 +1,11 @@
+import type { ButtonProps } from '@launchpad-ui/button';
+import type { TagGroupState } from '@react-stately/tag';
+
+type TagGroupActionProps<T extends object> = Omit<
+  ButtonProps,
+  'size' | 'kind' | 'aria-label' | 'data-test-id' | 'children'
+> & {
+  state?: TagGroupState<T>;
+};
+
+export type { TagGroupActionProps };

--- a/packages/tag/src/types.ts
+++ b/packages/tag/src/types.ts
@@ -1,3 +1,4 @@
+import type { TagGroupProps } from './TagGroup';
 import type { ButtonProps } from '@launchpad-ui/button';
 import type { TagGroupState } from '@react-stately/tag';
 
@@ -6,6 +7,7 @@ type TagGroupActionProps<T extends object> = Omit<
   'size' | 'kind' | 'aria-label' | 'data-test-id' | 'children'
 > & {
   state?: TagGroupState<T>;
+  size: TagGroupProps<T>['size'];
 };
 
 export type { TagGroupActionProps };

--- a/packages/tag/stories/Tag.stories.tsx
+++ b/packages/tag/stories/Tag.stories.tsx
@@ -1,11 +1,11 @@
 import type { StoryObj } from '@storybook/react';
 
-import { Close, Edit, Star } from '@launchpad-ui/icons';
+import { IconButton } from '@launchpad-ui/button';
+import { Edit, Star } from '@launchpad-ui/icons';
 import { useState } from 'react';
 
 import { MOCK_TAGS } from '../__tests__/constants';
 import { TagGroup, TagGroupClearAction, TagItem } from '../src';
-import { IconButton } from '@launchpad-ui/button';
 
 export default {
   component: TagGroup,
@@ -27,13 +27,46 @@ export const ReadOnly: Story = {
   },
 };
 
-export const RemovableTags: Story = {
+export const ReadOnlySmall: Story = {
+  render: () => {
+    return (
+      <TagGroup size="small" items={MOCK_TAGS}>
+        {(item) => <TagItem>{item.name}</TagItem>}
+      </TagGroup>
+    );
+  },
+};
+
+export const Removable: Story = {
   render: () => {
     const Component = () => {
       const [items, setItems] = useState(MOCK_TAGS);
 
       return (
         <TagGroup
+          allowsRemoving
+          onRemove={(key) => {
+            setItems((prevItems) => prevItems.filter((item) => key !== item.id));
+          }}
+          items={items}
+        >
+          {(item) => <TagItem>{item.name}</TagItem>}
+        </TagGroup>
+      );
+    };
+
+    return <Component />;
+  },
+};
+
+export const RemovableSmall: Story = {
+  render: () => {
+    const Component = () => {
+      const [items, setItems] = useState(MOCK_TAGS);
+
+      return (
+        <TagGroup
+          size="small"
           allowsRemoving
           onRemove={(key) => {
             setItems((prevItems) => prevItems.filter((item) => key !== item.id));
@@ -62,7 +95,32 @@ export const WithClearAction: Story = {
           }}
           hideActionWhenEmpty
           items={items}
-          action={() => <TagGroupClearAction onClick={() => setItems([])} />}
+          action={(props) => <TagGroupClearAction {...props} onClick={() => setItems([])} />}
+        >
+          {(item) => <TagItem>{item.name}</TagItem>}
+        </TagGroup>
+      );
+    };
+
+    return <Component />;
+  },
+};
+
+export const WithClearActionSmall: Story = {
+  render: () => {
+    const Component = () => {
+      const [items, setItems] = useState(MOCK_TAGS);
+
+      return (
+        <TagGroup
+          allowsRemoving
+          onRemove={(key) => {
+            setItems((prevItems) => prevItems.filter((item) => key !== item.id));
+          }}
+          size="small"
+          hideActionWhenEmpty
+          items={items}
+          action={(props) => <TagGroupClearAction {...props} onClick={() => setItems([])} />}
         >
           {(item) => <TagItem>{item.name}</TagItem>}
         </TagGroup>
@@ -86,8 +144,9 @@ export const WithCustomAction: Story = {
           }}
           hideActionWhenEmpty
           items={items}
-          action={() => (
+          action={(props) => (
             <IconButton
+              {...props}
               aria-label="Clear"
               size="small"
               icon={<Edit />}
@@ -109,6 +168,18 @@ export const WithMaxRows: Story = {
     return (
       <div style={{ maxWidth: 290, border: '1px solid #efefef', padding: '1rem' }}>
         <TagGroup maxRows={2} items={MOCK_TAGS}>
+          {(item) => <TagItem>{item.name}</TagItem>}
+        </TagGroup>
+      </div>
+    );
+  },
+};
+
+export const WithMaxRowsSmall: Story = {
+  render: () => {
+    return (
+      <div style={{ maxWidth: 290, border: '1px solid #efefef', padding: '1rem' }}>
+        <TagGroup maxRows={2} items={MOCK_TAGS} size="small">
           {(item) => <TagItem>{item.name}</TagItem>}
         </TagGroup>
       </div>

--- a/packages/tag/stories/Tag.stories.tsx
+++ b/packages/tag/stories/Tag.stories.tsx
@@ -1,10 +1,11 @@
 import type { StoryObj } from '@storybook/react';
 
-import { Star } from '@launchpad-ui/icons';
+import { Close, Edit, Star } from '@launchpad-ui/icons';
 import { useState } from 'react';
 
 import { MOCK_TAGS } from '../__tests__/constants';
-import { TagGroup, TagItem } from '../src';
+import { TagGroup, TagGroupClearAction, TagItem } from '../src';
+import { IconButton } from '@launchpad-ui/button';
 
 export default {
   component: TagGroup,
@@ -59,9 +60,40 @@ export const WithClearAction: Story = {
           onRemove={(key) => {
             setItems((prevItems) => prevItems.filter((item) => key !== item.id));
           }}
+          hideActionWhenEmpty
           items={items}
-          actionLabel="Clear"
-          onAction={() => alert('Clear action pressed.')}
+          action={() => <TagGroupClearAction onClick={() => setItems([])} />}
+        >
+          {(item) => <TagItem>{item.name}</TagItem>}
+        </TagGroup>
+      );
+    };
+
+    return <Component />;
+  },
+};
+
+export const WithCustomAction: Story = {
+  render: () => {
+    const Component = () => {
+      const [items, setItems] = useState(MOCK_TAGS);
+
+      return (
+        <TagGroup
+          allowsRemoving
+          onRemove={(key) => {
+            setItems((prevItems) => prevItems.filter((item) => key !== item.id));
+          }}
+          hideActionWhenEmpty
+          items={items}
+          action={() => (
+            <IconButton
+              aria-label="Clear"
+              size="small"
+              icon={<Edit />}
+              onClick={() => setItems([])}
+            />
+          )}
         >
           {(item) => <TagItem>{item.name}</TagItem>}
         </TagGroup>


### PR DESCRIPTION
## Summary
[Button]:
- Rename `default` kind to `basic`
- rename size variants for `ButtonGroup`
- Change height of tiny button to 20px to match tiny tags

[Tag]:
- Remove `onAction` and `actionLabel` props in favor of a new `action` prop which accepts a render element
- Improve styles and add stories
