### PR TITLE
Update CODEOWNERS to be frontend only

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @launchdarkly/team-core-product
+* @launchdarkly/team-core-product-frontend


### PR DESCRIPTION
## Summary

<!-- What is changing and why? -->
Use the frontend team within the core group as codeowners since the current codeowner group is far too broad.

## Screenshots (if appropriate): N/A

<!-- Are there any visual changes that would be helpful to the reviewer to see? -->

## Testing approaches
N/A
<!-- How are these changes tested? -->
