### PR TITLE
feat(tags): improve darkmode styles and IconButton style

### DIFF
--- a/.changeset/unlucky-ears-bake.md
+++ b/.changeset/unlucky-ears-bake.md
@@ -1,0 +1,6 @@
+---
+'@launchpad-ui/tag': patch
+'@launchpad-ui/core': patch
+---
+
+[TagGroup] Update darkmode styles

--- a/packages/tag/src/styles/Tag.module.css
+++ b/packages/tag/src/styles/Tag.module.css
@@ -53,6 +53,11 @@ a.tag,
   &:focus {
     text-decoration: underline;
   }
+
+  [data-theme='dark'] & {
+    color: var(--lp-color-cyan-500);
+    background-color: hsla(190.1 90.2% 60% / 0.2);
+  }
 }
 
 .isFocusVisible {
@@ -84,9 +89,9 @@ a.tag,
 }
 
 .removeButton {
-  border-radius: 100px;
-  width: 2.2rem;
-  height: 2.2rem;
+  border-radius: 0.6rem;
+  width: 2rem;
+  height: 2rem;
   margin: 0;
   display: flex;
   padding: 0;
@@ -95,6 +100,7 @@ a.tag,
   justify-content: center;
   background-color: transparent;
   cursor: pointer;
+  color: var(--lp-color-text-ui-secondary);
 
   &:hover {
     background-color: var(--lp-color-bg-interactive-tertiary-hover);
@@ -105,8 +111,9 @@ a.tag,
   }
 
   .tiny & {
-    width: 1.8rem;
-    height: 1.8rem;
+    border-radius: 0.3rem;
+    width: 1.6rem;
+    height: 1.6rem;
   }
 }
 


### PR DESCRIPTION
## Summary
To test: look at chromatic storybook build (will link once it's ready)
- Look at darkmode for link styles and removable styles
- Align remove button with IconButton styles (no longer circular)