### PR TITLE
feat: update interactive disabled text color

### DIFF
--- a/.changeset/mean-pandas-shake.md
+++ b/.changeset/mean-pandas-shake.md
@@ -1,0 +1,7 @@
+---
+'@launchpad-ui/button': patch
+'@launchpad-ui/tokens': patch
+'@launchpad-ui/core': patch
+---
+
+Update disabled text button color to be lighter

--- a/packages/button/src/styles/Button.css
+++ b/packages/button/src/styles/Button.css
@@ -338,15 +338,6 @@
   text-decoration: underline;
 }
 
-.Button--link[disabled] {
-  color: var(--Button-color-link-disabled);
-  text-decoration: none;
-}
-
-.Button--link[disabled]:hover {
-  color: var(--Button-color-link-disabled-hover);
-}
-
 /* ------- DISABLED ------- */
 
 .Button[disabled] {
@@ -376,6 +367,17 @@
 
 .Button[disabled] .Button-icon {
   fill: var(--Button-icon-color-fill-disabled);
+}
+
+.Button--link[disabled] {
+  background-color: transparent;
+  border-color: transparent;
+  color: var(--Button-color-link-disabled);
+  text-decoration: none;
+}
+
+.Button--link[disabled]:hover {
+  color: var(--Button-color-link-disabled-hover);
 }
 
 .Button.Button--icon {

--- a/packages/tokens/src/color-aliases.yaml
+++ b/packages/tokens/src/color-aliases.yaml
@@ -238,8 +238,8 @@ color:
         value: '{ color.system.red.700.value }'
         dark: '{ color.white. .value }'
       disabled:
-        value: '{ color.gray.700.value }'
-        dark: '{ color.gray.500.value }'
+        value: '{ color.gray.500.value }'
+        dark: '{ color.gray.700.value }'
     ui:
       primary:
         ' ':


### PR DESCRIPTION
## Summary

The disabled state of the minimal button variant doesn’t look very inactive. I’m proposing we make the text color a lighter gray (gray-500 in default mode, gray-700 in dark mode) so it more clearly looks disabled.

To do this, I updated the `--lp-color-text-interactive-disabled` variable. This also updates the disabled style for text links, and disabled tabs list. In both situations, I think it's appropriate that these are updated and all match.

More detail here: https://launchdarkly.atlassian.net/wiki/spaces/ENG/pages/2392949075/Minimal+button+disabled+state

## Screenshots (if appropriate):

### Minimal button before 

Last button is the disabled one.

![Screenshot 2023-03-31 at 10 33 14 AM](https://user-images.githubusercontent.com/329075/229191811-31df5307-8fe4-474d-aebc-0ac0be4e3cd4.png)

![Screenshot 2023-03-31 at 10 33 45 AM](https://user-images.githubusercontent.com/329075/229192158-22227bc1-e416-427c-b36d-4c87f4c79a52.png)

### Minimal button after 

Last button is the disabled one.

![Screenshot 2023-03-31 at 10 32 57 AM](https://user-images.githubusercontent.com/329075/229191837-b7c88c9b-e30c-41cc-82c4-87df03cce28b.png)

![Screenshot 2023-03-31 at 10 33 34 AM](https://user-images.githubusercontent.com/329075/229192193-b9e1bf31-0e07-402d-a78f-c5262fb97624.png)

### Tab list disabled before

![Screenshot 2023-03-31 at 10 32 47 AM](https://user-images.githubusercontent.com/329075/229191966-589200c1-dad2-4dfe-8d78-8e8e626f36e3.png)

Last two tabs are disabled, and they actually look _more_ interactive than the interactive tab (second one).

### Tab list disabled after

![Screenshot 2023-03-31 at 10 32 20 AM](https://user-images.githubusercontent.com/329075/229192010-f1e24fbb-7e0d-4bb1-90c5-cf68fc73f27d.png)

Last two tabs are disabled, and they now look less interactive than the interactive tab (second one).

### Text link disabled

Disabled text links have a background and border for some reason (no other state has this). To me it looks weird and unnecessary so I would propose we remove this as well, because otherwise the text is very hard to read. We should get Antonio's sign off for this. I didn't make this change in this PR, but I can if there's broad agreement at changing it.

#### Before

![Screenshot 2023-03-31 at 10 35 14 AM](https://user-images.githubusercontent.com/329075/229192720-4456f820-0cab-4b6d-aac7-cef2651b20f2.png)

#### After

![Screenshot 2023-03-31 at 10 34 52 AM](https://user-images.githubusercontent.com/329075/229192827-32500821-4e78-45df-a92d-6c2af3f4ee68.png)

![Screenshot 2023-03-31 at 10 36 08 AM](https://user-images.githubusercontent.com/329075/229193005-37184097-aa6c-4417-b6bc-9989d449f12d.png)

**After sans background and border**

![Screenshot 2023-03-31 at 10 35 40 AM](https://user-images.githubusercontent.com/329075/229192911-2ec0effb-050f-4fa5-bcc3-676990225836.png)

![Screenshot 2023-03-31 at 10 35 57 AM](https://user-images.githubusercontent.com/329075/229192949-f5e79c6c-492b-4bce-af56-68fce6e8bbb1.png)

## Testing approaches

Visually make sure the colors are correct.
