### PR TITLE
fix(icons,snackbar): improve aria-labeling for icons, fix word-break issue for snackbars

### DIFF
--- a/.changeset/two-jobs-retire.md
+++ b/.changeset/two-jobs-retire.md
@@ -1,0 +1,8 @@
+---
+'@launchpad-ui/snackbar': patch
+'@launchpad-ui/icons': patch
+'@launchpad-ui/core': patch
+---
+
+[Icons]: Pass all attribute props directly to svg
+[Snackbar]: Fix word-break issue in header

--- a/packages/icons/__tests__/Icon.spec.tsx
+++ b/packages/icons/__tests__/Icon.spec.tsx
@@ -24,4 +24,17 @@ describe('Icon', () => {
     render(<StatusIcon kind="info" />);
     expect(screen.getByTitle('Info')).toBeInTheDocument();
   });
+
+  it('passes aria labeling to svg', () => {
+    render(<Info kind="warning" aria-label="test" />);
+
+    expect(screen.getByRole('img')).toHaveAttribute('aria-label', 'test');
+    expect(screen.getByRole('img')).toHaveAttribute('aria-hidden', 'false');
+  });
+
+  it('hides svg by default when aria label is not passed', () => {
+    render(<Info kind="warning" />);
+
+    expect(screen.getByRole('img', { hidden: true })).toHaveAttribute('aria-hidden', 'true');
+  });
 });

--- a/packages/icons/src/Icon.tsx
+++ b/packages/icons/src/Icon.tsx
@@ -19,6 +19,9 @@ const Icon = ({
   size,
   children,
   'data-test-id': testId = 'icon',
+  'aria-label': ariaLabel,
+  'aria-labelledby': ariaLabelledBy,
+  'aria-hidden': ariaHidden,
   ...props
 }: IconProps) => {
   const sizeClass = size ? styles[size] : false;
@@ -43,13 +46,18 @@ const Icon = ({
     }
   }, [name, prefix]);
 
+  const isAriaHidden = ariaHidden ?? (!ariaLabelledBy && !ariaLabel);
+
   return (
-    <span {...props} data-test-id={testId} className={classes}>
+    <span data-test-id={testId} className={classes}>
       {Children.map(children, (child) => {
         if (isValidElement(child)) {
           return cloneElement(child as ReactElement, {
-            'aria-hidden': true,
+            'aria-hidden': isAriaHidden,
+            'aria-label': ariaLabel,
+            'aria-labelledby': ariaLabelledBy,
             ref: svgRef,
+            ...props,
           });
         }
         return null;

--- a/packages/snackbar/src/styles/Snackbar.module.css
+++ b/packages/snackbar/src/styles/Snackbar.module.css
@@ -7,6 +7,7 @@
   box-sizing: border-box;
   width: 37.6rem;
   border-radius: 2px;
+  word-break: break-word;
 }
 
 .Snackbar .Snackbar-icon {

--- a/packages/snackbar/stories/Snackbar.stories.tsx
+++ b/packages/snackbar/stories/Snackbar.stories.tsx
@@ -18,7 +18,6 @@ type Story = StoryObj<typeof Snackbar>;
 export const Error: Story = {
   args: {
     kind: 'error',
-    header: 'Snackbar header',
     description: 'This is a message.',
     cta: (
       <a href="/" target="_blank">
@@ -55,6 +54,19 @@ export const Warning: Story = {
 export const Success: Story = {
   args: {
     kind: 'success',
+    description: 'This is a message.',
+    cta: (
+      <a href="/" target="_blank">
+        Link
+      </a>
+    ),
+  },
+};
+
+export const WithHeader: Story = {
+  args: {
+    kind: 'info',
+    header: 'Snackbar header',
     description: 'This is a message.',
     cta: (
       <a href="/" target="_blank">


### PR DESCRIPTION
…issue for snackbars

## Summary
- Add `word-break` property to snackbar to avoid text that overflows outside of parent bounds
- Refactor icon props so that they get passed down to the svg itself instead of being applied to the span. This makes our icons more accessible since aria properties will be applied to the svg instead of a span.
- Move Header variant of snackbar to its own story
