### PR TITLE
fix(popover): merge target refs

### DIFF
--- a/.changeset/strange-dancers-count.md
+++ b/.changeset/strange-dancers-count.md
@@ -1,0 +1,6 @@
+---
+'@launchpad-ui/popover': patch
+'@launchpad-ui/core': patch
+---
+
+[Popover] merge popover target ref with internal ref

--- a/packages/popover/__tests__/Popover.spec.tsx
+++ b/packages/popover/__tests__/Popover.spec.tsx
@@ -1,3 +1,6 @@
+import type { RefObject } from 'react';
+
+import { useRef } from 'react';
 import { it, expect, describe, vi } from 'vitest';
 
 import { render, screen, userEvent, waitFor } from '../../../test/utils';
@@ -124,5 +127,21 @@ describe('Popover', () => {
     await waitFor(() => {
       expect(spy).toHaveBeenCalledTimes(1);
     });
+  });
+
+  it('preserves ref passed to popover target', () => {
+    let ref: RefObject<HTMLButtonElement> | undefined;
+    const Component = () => {
+      ref = useRef<HTMLButtonElement>(null);
+      return (
+        <Popover>
+          <button ref={ref}>Target</button>
+          <span>Content</span>
+        </Popover>
+      );
+    };
+
+    render(<Component />);
+    expect(ref?.current).toBeInstanceOf(HTMLButtonElement);
   });
 });

--- a/packages/popover/package.json
+++ b/packages/popover/package.json
@@ -37,6 +37,7 @@
     "@launchpad-ui/focus-trap": "workspace:~",
     "@launchpad-ui/overlay": "workspace:~",
     "@launchpad-ui/tokens": "workspace:~",
+    "@react-aria/utils": "3.15.0",
     "classix": "2.1.17",
     "framer-motion": "9.0.3"
   },

--- a/packages/popover/src/Popover.tsx
+++ b/packages/popover/src/Popover.tsx
@@ -3,19 +3,20 @@ import type { ComputePositionConfig, Placement, Strategy } from '@floating-ui/do
 import type {
   CSSProperties,
   FocusEvent,
+  ForwardedRef,
+  FunctionComponentElement,
   KeyboardEvent as ReactKeyboardEvent,
   MouseEvent,
   PointerEvent,
-  ReactElement,
   ReactHTML,
   ReactNode,
-  Ref,
   RefObject,
 } from 'react';
 
 import { arrow, computePosition, flip, offset as floatOffset, shift } from '@floating-ui/dom';
 import { FocusTrap } from '@launchpad-ui/focus-trap';
 import { Overlay } from '@launchpad-ui/overlay';
+import { mergeRefs } from '@react-aria/utils';
 import { cx } from 'classix';
 import { LazyMotion, m } from 'framer-motion';
 import {
@@ -66,7 +67,7 @@ type PopoverProps = {
   rootElementStyle?: CSSProperties;
   rootElementTag?: keyof ReactHTML;
   target?: string | JSX.Element;
-  targetElementRef?: Ref<Element>;
+  targetElementRef?: ForwardedRef<Element>;
   targetClassName?: string;
   targetTestId?: string;
   enableArrow?: boolean;
@@ -451,11 +452,20 @@ const Popover = ({
     targetProps.onClick = handleTargetClick;
   }
 
+  const targetElement = target as FunctionComponentElement<{
+    ref: ForwardedRef<HTMLElement | undefined>;
+    'data-state': 'open' | 'closed';
+  }>;
+
   return createElement(
     rootElementTag,
     targetProps,
-    cloneElement(target as ReactElement, {
-      ref: targetElementRef,
+    cloneElement(targetElement, {
+      ref: mergeRefs(
+        ...([targetElement.ref, targetElementRef].filter(Boolean) as Array<
+          ForwardedRef<HTMLElement | undefined>
+        >)
+      ),
       ...(isOpen && { 'aria-describedby': popoverId.current }),
       'data-state': isOpen ? 'open' : 'closed',
     }),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1038,6 +1038,9 @@ importers:
       '@launchpad-ui/tokens':
         specifier: workspace:~
         version: link:../tokens
+      '@react-aria/utils':
+        specifier: 3.15.0
+        version: 3.15.0(react@18.2.0)
       classix:
         specifier: 2.1.17
         version: 2.1.17
@@ -5865,7 +5868,7 @@ packages:
       '@storybook/csf-plugin': 7.0.0-beta.60
       '@storybook/csf-tools': 7.0.0-beta.60
       '@storybook/global': 5.0.0
-      '@storybook/mdx2-csf': 1.0.0-next.6
+      '@storybook/mdx2-csf': 1.0.0-next.7
       '@storybook/node-logger': 7.0.0-beta.60
       '@storybook/postinstall': 7.0.0-beta.60
       '@storybook/preview-api': 7.0.0-beta.60
@@ -6124,7 +6127,7 @@ packages:
       '@storybook/client-logger': 7.0.0-beta.60
       '@storybook/components': 7.0.0-beta.60(react-dom@18.2.0)(react@18.2.0)
       '@storybook/core-events': 7.0.0-beta.60
-      '@storybook/csf': 0.0.2-next.10
+      '@storybook/csf': 0.0.2-next.11
       '@storybook/docs-tools': 7.0.0-beta.60
       '@storybook/global': 5.0.0
       '@storybook/manager-api': 7.0.0-beta.60(react-dom@18.2.0)(react@18.2.0)
@@ -6195,7 +6198,7 @@ packages:
       '@storybook/client-logger': 7.0.0-beta.60
       '@storybook/core-common': 7.0.0-beta.60
       '@storybook/csf-plugin': 7.0.0-beta.60
-      '@storybook/mdx2-csf': 1.0.0-next.6
+      '@storybook/mdx2-csf': 1.0.0-next.7
       '@storybook/node-logger': 7.0.0-beta.60
       '@storybook/preview': 7.0.0-beta.60
       '@storybook/preview-api': 7.0.0-beta.60
@@ -6321,7 +6324,7 @@ packages:
       '@babel/core': 7.21.0
       '@babel/preset-env': 7.20.2(@babel/core@7.21.0)
       '@babel/types': 7.21.2
-      '@storybook/csf': 0.0.2-next.10
+      '@storybook/csf': 0.0.2-next.11
       '@storybook/csf-tools': 7.0.0-beta.60
       '@storybook/node-logger': 7.0.0-beta.60
       '@storybook/types': 7.0.0-beta.60
@@ -6360,7 +6363,7 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || 18
     dependencies:
       '@storybook/client-logger': 7.0.0-beta.60
-      '@storybook/csf': 0.0.2-next.10
+      '@storybook/csf': 0.0.2-next.11
       '@storybook/global': 5.0.0
       '@storybook/theming': 7.0.0-beta.60(react-dom@18.2.0)(react@18.2.0)
       '@storybook/types': 7.0.0-beta.60
@@ -6423,7 +6426,7 @@ packages:
       '@storybook/builder-manager': 7.0.0-beta.60
       '@storybook/core-common': 7.0.0-beta.60
       '@storybook/core-events': 7.0.0-beta.60
-      '@storybook/csf': 0.0.2-next.10
+      '@storybook/csf': 0.0.2-next.11
       '@storybook/csf-tools': 7.0.0-beta.60
       '@storybook/docs-mdx': 0.0.1-next.6
       '@storybook/global': 5.0.0
@@ -6484,7 +6487,7 @@ packages:
       '@babel/parser': 7.21.2
       '@babel/traverse': 7.21.2
       '@babel/types': 7.21.2
-      '@storybook/csf': 0.0.2-next.10
+      '@storybook/csf': 0.0.2-next.11
       '@storybook/types': 7.0.0-beta.60
       fs-extra: 11.1.0
       recast: 0.23.1
@@ -6499,8 +6502,8 @@ packages:
       lodash: 4.17.21
     dev: true
 
-  /@storybook/csf@0.0.2-next.10:
-    resolution: {integrity: sha512-m2PFgBP/xRIF85VrDhvesn9ktaD2pN3VUjvMqkAL/cINp/3qXsCyI81uw7N5VEOkQAbWrY2FcydnvEPDEdE8fA==}
+  /@storybook/csf@0.0.2-next.11:
+    resolution: {integrity: sha512-xGt0YSVxZb43sKmEf1GIQD8xEbo+c+S6khDEL7Qu/pYA0gh5z3WUuhOlovnelYj/YJod+XRsfVvk23AaRfUJ4Q==}
     dependencies:
       type-fest: 2.19.0
     dev: true
@@ -6559,7 +6562,7 @@ packages:
       '@storybook/channels': 7.0.0-beta.60
       '@storybook/client-logger': 7.0.0-beta.60
       '@storybook/core-events': 7.0.0-beta.60
-      '@storybook/csf': 0.0.2-next.10
+      '@storybook/csf': 0.0.2-next.11
       '@storybook/global': 5.0.0
       '@storybook/router': 7.0.0-beta.60(react-dom@18.2.0)(react@18.2.0)
       '@storybook/theming': 7.0.0-beta.60(react-dom@18.2.0)(react@18.2.0)
@@ -6579,8 +6582,8 @@ packages:
     resolution: {integrity: sha512-XcAAYnd9oHvkG4ieSiCbNJvqAYNh7zO1LYQ2cx2GdDL+Wr40SaUk6VG1/E8s/ETF4QgI6CvQbbg74VaaO2MbBA==}
     dev: true
 
-  /@storybook/mdx2-csf@1.0.0-next.6:
-    resolution: {integrity: sha512-m6plojocU/rmrqWd26yvm8D+oHZPZ6PtSSFmZIgpNDEPVmc8s4fBD6LXOAB5MiPI5f8KLUr2HVhOMZ97o5pDTw==}
+  /@storybook/mdx2-csf@1.0.0-next.7:
+    resolution: {integrity: sha512-xcQ8w4IecABAjsakaZTGiUEnEgFZzVKsMjqECjd+qdkwgD3R/kwrBdfyC15CLM5Ye1miPwYBIwJGeBXB9qxsZg==}
     dev: true
 
   /@storybook/node-logger@7.0.0-beta.60:
@@ -6603,7 +6606,7 @@ packages:
       '@storybook/channels': 7.0.0-beta.60
       '@storybook/client-logger': 7.0.0-beta.60
       '@storybook/core-events': 7.0.0-beta.60
-      '@storybook/csf': 0.0.2-next.10
+      '@storybook/csf': 0.0.2-next.11
       '@storybook/global': 5.0.0
       '@storybook/types': 7.0.0-beta.60
       '@types/qs': 6.9.7
@@ -9157,8 +9160,8 @@ packages:
     resolution: {integrity: sha512-nK7sAtfi+QXbxHCYfhpZsfRtaitZLIA6889kFIouLvz6repszQDgxBu7wf2WbU+Dco7sAnNCJYERCwt54WPC2Q==}
     engines: {node: '>=10'}
     dependencies:
-      is-text-path: 1.0.1
       JSONStream: 1.3.5
+      is-text-path: 1.0.1
       lodash: 4.17.21
       meow: 8.1.2
       split2: 3.2.2


### PR DESCRIPTION
## Summary

<!-- What is changing and why? -->
The `Popover` component was not merging user-supplied `ref`s with its own internal ref for the popover target element. That means that attaching a ref to the element/component supplied as the popover target would not take effect. Updating this is necessary for our a11y audit, as sometimes we need to manually refocus a popover target from the outside.

## Screenshots (if appropriate):

<!-- Are there any visual changes that would be helpful to the reviewer to see? -->

## Testing approaches

<!-- How are these changes tested? -->
Added a unit test for this case.
