### PR TITLE
feat(dropdown): allow disabling focus restoration behavior with a new "restoreFocus" prop

### DIFF
--- a/.changeset/brown-moons-press.md
+++ b/.changeset/brown-moons-press.md
@@ -1,0 +1,6 @@
+---
+'@launchpad-ui/dropdown': patch
+'@launchpad-ui/core': patch
+---
+
+[Dropdown]: allow disabling focus restoration behavior via the "restoreFocus" prop

--- a/packages/dropdown/__tests__/Dropdown.spec.tsx
+++ b/packages/dropdown/__tests__/Dropdown.spec.tsx
@@ -91,4 +91,18 @@ describe('Dropdown', () => {
     render(<Component />);
     expect(ref?.current).toBeInstanceOf(HTMLButtonElement);
   });
+
+  it('should not restore focus to menu target on close if "restoreFocus" prop is false', async () => {
+    const user = userEvent.setup();
+    render(
+      <Dropdown restoreFocus={false}>
+        <DropdownButton>Target</DropdownButton>
+        <div>content</div>
+      </Dropdown>
+    );
+
+    await user.click(screen.getByRole('button'));
+    await user.keyboard('{Escape}');
+    expect(document.activeElement).not.toBeInstanceOf(HTMLButtonElement);
+  });
 });

--- a/packages/dropdown/src/Dropdown.tsx
+++ b/packages/dropdown/src/Dropdown.tsx
@@ -13,6 +13,7 @@ type DropdownState = {
 type DropdownProps<T extends string | object | number> = PopoverProps & {
   onSelect?: (item: T, stateChanges: DropdownState) => void;
   onStateChange?: (state: DropdownState) => void;
+  restoreFocus?: boolean;
 };
 
 const Dropdown = <T extends string | object | number>(props: DropdownProps<T>) => {
@@ -27,6 +28,7 @@ const Dropdown = <T extends string | object | number>(props: DropdownProps<T>) =
     onStateChange,
     children,
     'data-test-id': testId = 'dropdown',
+    restoreFocus = true,
     ...rest
   } = props;
 
@@ -42,7 +44,7 @@ const Dropdown = <T extends string | object | number>(props: DropdownProps<T>) =
 
   useEffect(() => {
     // Focus the button upon closing for convenient tabbing
-    if (hasOpened && isOpen === false) {
+    if (restoreFocus && hasOpened && isOpen === false) {
       setTimeout(() => {
         const current = triggerRef.current;
         if (!current) {
@@ -58,7 +60,7 @@ const Dropdown = <T extends string | object | number>(props: DropdownProps<T>) =
         !hasModal && current.focus?.();
       });
     }
-  }, [isOpen, hasOpened]);
+  }, [isOpen, hasOpened, restoreFocus]);
 
   useEffect(() => {
     setHasOpened(isOpen);


### PR DESCRIPTION
## Summary

<!-- What is changing and why? -->
There is one case, with our `SavedDashboards` feature, where we trigger the rendering of a dropdown both by pressing on the "main button" of a split button, as well as the "secondary button".

<img width="459" alt="Screenshot 2023-04-03 at 2 17 12 PM" src="https://user-images.githubusercontent.com/1013151/229605571-5b231844-19da-4a10-be2e-93fae8f49bbb.png">

For accessibility, we need to refocus the MAIN button, and not the secondary button, if that is the button we clicked on the make the dropdown appear. The `SplitButton` component, which uses `Dropdown` internally, automatically returns focus to the _secondary_ button, because that is supposed to be the "trigger" element for the dropdown.

Rather than spend a lot of extra time refactoring a rarely-used feature, this PR introduces a simple `restoreFocus` prop to `Dropdown` which, if `false` (default is `true`), disables the normal focus restoration behavior, so we can manually focus on the main button (or somewhere else), if necessary.

## Screenshots (if appropriate):

<!-- Are there any visual changes that would be helpful to the reviewer to see? -->

## Testing approaches

<!-- How are these changes tested? -->
Added a unit test for this behavior.
