### PR TITLE
fix(button): don't include the type prop when the Button kind is 'link'

### DIFF
--- a/.changeset/soft-terms-hug.md
+++ b/.changeset/soft-terms-hug.md
@@ -1,0 +1,5 @@
+---
+'@launchpad-ui/button': minor
+---
+
+[Button] Don't include the type prop when the Button kind is "link"

--- a/packages/button/src/Button.tsx
+++ b/packages/button/src/Button.tsx
@@ -120,7 +120,7 @@ const ButtonComponent = forwardRef<HTMLButtonElement, ButtonProps>((props, ref) 
       onClick={handleClick}
       onKeyDown={onKeyDown || handleKeyDown}
       disabled={isDisabled}
-      type={type}
+      type={kind === 'link' ? undefined : type}
       data-test-id={testId}
       {...rest}
     >


### PR DESCRIPTION
## Summary

The `<button>` element in HTML has a `type` prop, with a value of either "submit", "reset", or "button".
The `<a>` element, though, doesn't have a similar prop.

For better or worse, we're currently using the `<Button>` component to render both _things-that-look-like-buttons-but-are-really-links_ and _things-that-look-like-buttons-and-that-are-actually-buttons_. Our current `Button` component defaults to using `type="button"` for both kinds of elements, even when we intend for the final rendered component to be an `<a>` element.

Here's a button-looking-element that should be a **button** under the hood:
![Screenshot 2023-04-12 at 2 21 38 PM](https://user-images.githubusercontent.com/22547/231587946-c8380b8c-68d8-4dfb-8469-2c5afa2bc4bb.png)

Here's a **link** that uses the same component for visual styling:
![Screenshot 2023-04-12 at 2 15 25 PM](https://user-images.githubusercontent.com/22547/231587833-41784810-5ce8-4e9f-9e4d-64a6d382ec23.png)

You can see that both have a `type` prop, but we only actually want that one on the `button`.

This PR only sets that `type` value for the button when the `kind` prop is something other than `link`. In those cases, it makes that prop `undefined`.
