### PR TITLE
feat(filter): add disabled prop to disable Filter

### DIFF
--- a/.changeset/young-trains-help.md
+++ b/.changeset/young-trains-help.md
@@ -1,0 +1,6 @@
+---
+'@launchpad-ui/filter': patch
+'@launchpad-ui/core': patch
+---
+
+[Filter] Add disabled prop to disable dropdown and note button inactivity to screen readers

--- a/packages/filter/src/Filter.tsx
+++ b/packages/filter/src/Filter.tsx
@@ -28,6 +28,7 @@ type FilterProps = Pick<MenuProps<string>, 'size' | 'enableVirtualization'> & {
   onSelect?(item: FilterOption): void;
   isEmpty?: boolean;
   isLoading?: boolean;
+  disabled?: boolean;
   onClickFilterButton?(): void;
   disabledOptionTooltip?: string;
   'data-test-id'?: string;
@@ -53,6 +54,7 @@ const Filter = ({
   disabledOptionTooltip,
   'data-test-id': testId = 'filter',
   size,
+  disabled,
   enableVirtualization,
   ...props
 }: FilterProps) => {
@@ -67,12 +69,18 @@ const Filter = ({
   };
 
   return (
-    <Dropdown targetTestId={testId} targetClassName={dropdownClasses} {...props}>
+    <Dropdown
+      targetTestId={testId}
+      disabled={disabled}
+      targetClassName={dropdownClasses}
+      {...props}
+    >
       <FilterButton
         isClearable={isClearable}
         onClear={handleClear}
         name={name}
         hideName={hideName}
+        disabled={disabled}
         isSelected={isSelected}
         onClickFilterButton={onClickFilterButton}
       >

--- a/packages/filter/src/FilterButton.tsx
+++ b/packages/filter/src/FilterButton.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode, SyntheticEvent } from 'react';
+import type { ReactNode, SyntheticEvent, MouseEvent } from 'react';
 
 import { IconButton } from '@launchpad-ui/button';
 import { Close, ExpandMore } from '@launchpad-ui/icons';
@@ -18,6 +18,7 @@ type FilterButtonProps = {
   isSelected?: boolean;
   clearTooltip?: string | JSX.Element;
   children?: ReactNode;
+  disabled?: boolean;
   onClickFilterButton?(): void;
   'data-test-id'?: string;
 };
@@ -32,6 +33,7 @@ const FilterButton = forwardRef<Ref, FilterButtonProps>((props, ref) => {
     isClearable,
     clearTooltip,
     onClear,
+    disabled,
     isSelected,
     onClickFilterButton,
     className,
@@ -50,15 +52,24 @@ const FilterButton = forwardRef<Ref, FilterButtonProps>((props, ref) => {
     </span>
   );
 
+  const isDisabled = disabled;
+
+  const handleClick = (event: MouseEvent<HTMLButtonElement>) => {
+    if (isDisabled) return event.preventDefault();
+    onClickFilterButton?.();
+  };
+
   return (
     <div className={styles.buttonContainer} data-test-id={testId}>
       <button
         {...rest}
         aria-labelledby={`${nameId} ${hasDescription ? descriptionId : ''}`}
         aria-haspopup
+        disabled={isDisabled}
+        aria-disabled={isDisabled}
         className={cx(styles.button, className, (isClearable || isSelected) && styles.isClearable)}
         ref={ref}
-        onClick={onClickFilterButton}
+        onClick={handleClick}
       >
         {hideName ? (
           <VisuallyHidden id={nameId}>{nameElement}</VisuallyHidden>


### PR DESCRIPTION
## Summary

This adds the ability to mark the button as disabled when appropriate and prevent the dropdown from opening when it is so. Currently, the filter button cannot be recognized as inactive by screen readers but this remedies that issue. 
