### PR TITLE
feat(menu): deprecate menuitemlink in favor of asChild

### DIFF
--- a/.changeset/chilly-eggs-listen.md
+++ b/.changeset/chilly-eggs-listen.md
@@ -1,0 +1,6 @@
+---
+'@launchpad-ui/menu': minor
+'@launchpad-ui/core': minor
+---
+
+[Menu] Deprecate MenuItemLink in favor of using `asChild`

--- a/packages/menu/__tests__/Menu.spec.tsx
+++ b/packages/menu/__tests__/Menu.spec.tsx
@@ -39,7 +39,7 @@ describe('Menu', () => {
   it('renders with virtualization', () => {
     render(createMenu({ enableVirtualization: true }));
     const items = screen.getAllByRole('presentation');
-    expect(items).toHaveLength(5);
+    expect(items).toHaveLength(4);
   });
 
   it('renders the search field', () => {

--- a/packages/menu/__tests__/Menu.spec.tsx
+++ b/packages/menu/__tests__/Menu.spec.tsx
@@ -4,7 +4,7 @@ import { Popover } from '@launchpad-ui/popover';
 import { it, expect, describe, vi } from 'vitest';
 
 import { render, screen, userEvent, waitFor } from '../../../test/utils';
-import { Menu, MenuDivider, MenuItem, MenuItemLink, MenuSearch } from '../src';
+import { Menu, MenuDivider, MenuItem, MenuSearch } from '../src';
 
 type TestMenu = {
   hideSearch?: boolean;
@@ -127,18 +127,6 @@ describe('Menu', () => {
     expect(items[1]).toHaveFocus();
     await user.keyboard('{arrowup}');
     expect(items[0]).toHaveFocus();
-  });
-
-  it('can render items as links', async () => {
-    const { container } = render(
-      <Menu>
-        <MenuItemLink to="#" useHistory={false}>
-          link
-        </MenuItemLink>
-      </Menu>
-    );
-    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
-    expect(container.querySelector('a')).not.toBeNull();
   });
 
   it('can render items into child slot', async () => {

--- a/packages/menu/package.json
+++ b/packages/menu/package.json
@@ -41,7 +41,6 @@
     "@react-aria/focus": "3.10.0",
     "@react-aria/separator": "3.2.6",
     "classix": "2.1.17",
-    "react-router-dom": "6.9.0",
     "react-virtual": "2.10.4"
   },
   "peerDependencies": {

--- a/packages/menu/src/Menu.tsx
+++ b/packages/menu/src/Menu.tsx
@@ -18,7 +18,7 @@ import { useVirtual } from 'react-virtual';
 
 import { MenuBase } from './MenuBase';
 import { MenuDivider } from './MenuDivider';
-import { MenuItem, MenuItemLink } from './MenuItem';
+import { MenuItem } from './MenuItem';
 import { MenuItemList } from './MenuItemList';
 import { MenuSearch } from './MenuSearch';
 import {
@@ -37,7 +37,7 @@ type ControlledMenuProps<T> = {
    */
   enableVirtualization?: boolean;
   /**
-   * Class name to be applied to all MenuItem and MenuItemLink components
+   * Class name to be applied to all MenuItem components
    * in the menu.
    */
   menuItemClassName?: string;
@@ -95,7 +95,6 @@ const Menu = <T extends number | string>(props: MenuProps<T>) => {
             searchElem = child;
             break;
           case MenuItem:
-          case MenuItemLink:
           case MenuDivider:
             elements = elements.concat(child);
             break;
@@ -124,7 +123,6 @@ const Menu = <T extends number | string>(props: MenuProps<T>) => {
               }),
             };
           case MenuItem:
-          case MenuItemLink:
             return {
               items: items.concat(
                 child.props.disabled
@@ -279,7 +277,6 @@ const ItemVirtualizer = <T extends number | string>(props: ItemVirtualizerProps<
       const childProps = itemElem.props as MenuItemProps<T>;
       switch (itemElem.type) {
         case MenuItem:
-        case MenuItemLink:
           return {
             className: cx(childProps.className, menuItemClassName),
             // set focus on the first menu item if there is no search input, and set in the tab order
@@ -368,11 +365,7 @@ const ItemVirtualizer = <T extends number | string>(props: ItemVirtualizerProps<
         return (
           <div
             key={virtualRow.index}
-            ref={
-              elem.type !== MenuItem || elem.type !== MenuItemLink
-                ? virtualRow.measureRef
-                : undefined
-            }
+            ref={elem.type !== MenuItem ? virtualRow.measureRef : undefined}
             role="presentation"
             className={cx('VirtualMenu-item')}
             style={{

--- a/packages/menu/src/MenuItem.tsx
+++ b/packages/menu/src/MenuItem.tsx
@@ -6,7 +6,6 @@ import { Tooltip } from '@launchpad-ui/tooltip';
 import { Slot } from '@radix-ui/react-slot';
 import { FocusRing } from '@react-aria/focus';
 import { cx } from 'classix';
-import { Link } from 'react-router-dom';
 
 import './styles/Menu.css';
 
@@ -123,48 +122,5 @@ const MenuItem = <P, T extends ElementType = typeof defaultElement>({
   return renderedItem;
 };
 
-type MenuItemLinkOwnProps = {
-  disabled?: boolean;
-  useHistory?: boolean;
-  newTab?: boolean;
-};
-
-type MenuItemLinkProps<P, T extends ElementType = typeof Link> =
-  | Merge<Omit<MenuItemProps<P, T>, 'component' | 'item'>, MenuItemLinkOwnProps> &
-      (
-        | {
-            item?: undefined;
-          }
-        | {
-            item: P;
-          }
-      );
-
-// By default, this is a Link component whenever useHistory is
-// explicitly not false
-// TODO: deprecate this component
-const MenuItemLink = <P, T extends ElementType = typeof Link>({
-  to,
-  disabled = false,
-  useHistory = true,
-  newTab = false,
-  children,
-  ...props
-}: MenuItemLinkProps<P, T>) => {
-  const finalProps = {
-    ...props,
-    disabled,
-    component: useHistory ? Link : ('a' as const),
-    [useHistory ? 'to' : 'href']: disabled ? '' : to,
-    rel: newTab ? 'noopener noreferrer' : undefined,
-    target: newTab ? '_blank' : undefined,
-  };
-
-  // Ideally if this item is disabled, it should be a button rather
-  // than a link https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/anchor-is-valid.md
-
-  return <MenuItem {...finalProps}>{children}</MenuItem>;
-};
-
-export { MenuItem, MenuItemLink };
-export type { MenuItemProps, MenuItemLinkProps };
+export { MenuItem };
+export type { MenuItemProps };

--- a/packages/menu/src/index.ts
+++ b/packages/menu/src/index.ts
@@ -1,6 +1,6 @@
 export type { MenuBaseProps } from './MenuBase';
 export type { MenuDividerProps } from './MenuDivider';
-export type { MenuItemProps, MenuItemLinkProps } from './MenuItem';
+export type { MenuItemProps } from './MenuItem';
 export type { MenuItemListProps } from './MenuItemList';
 export type { MenuSearchProps } from './MenuSearch';
 export type { MenuProps } from './Menu';
@@ -8,7 +8,7 @@ export type { MenuProps } from './Menu';
 export { MenuBase } from './MenuBase';
 /* c8 ignore stop */
 export { MenuDivider } from './MenuDivider';
-export { MenuItem, MenuItemLink } from './MenuItem';
+export { MenuItem } from './MenuItem';
 /* c8 ignore start */
 export { MenuItemList } from './MenuItemList';
 /* c8 ignore stop */

--- a/packages/menu/src/styles/Menu.css
+++ b/packages/menu/src/styles/Menu.css
@@ -72,7 +72,7 @@
     outline: none;
   }
 
-  /* Override our link styles for MenuItemLink component */
+  /* Override our link styles for link component */
   & a.Menu-item {
     &:focus:not(:hover):not(.has-focus) {
       text-decoration: none;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -151,7 +151,7 @@ importers:
         version: 5.0.4(eslint@8.35.0)(typescript@4.9.5)
       eslint-plugin-import:
         specifier: ^2.26.0
-        version: 2.27.5(@typescript-eslint/parser@5.54.0)(eslint@8.35.0)
+        version: 2.27.5(@typescript-eslint/parser@5.54.0)(eslint-import-resolver-typescript@3.5.3)(eslint@8.35.0)
       eslint-plugin-jsx-a11y:
         specifier: ^6.7.0
         version: 6.7.1(eslint@8.35.0)
@@ -229,7 +229,7 @@ importers:
         version: 4.9.5
       typescript-plugin-css-modules:
         specifier: ^4.1.1
-        version: 4.2.2(typescript@4.9.5)
+        version: 4.2.2(ts-node@10.9.1)(typescript@4.9.5)
       vite:
         specifier: ^3.2.0
         version: 3.2.5(@types/node@18.14.5)
@@ -377,7 +377,7 @@ importers:
     devDependencies:
       '@remix-run/dev':
         specifier: ^1.10.0
-        version: 1.14.0(@remix-run/serve@1.14.0)
+        version: 1.14.0(@remix-run/serve@1.14.0)(ts-node@10.9.1)
       '@remix-run/eslint-config':
         specifier: ^1.10.0
         version: 1.14.0(eslint@8.35.0)(react@18.2.0)(typescript@4.9.5)
@@ -886,9 +886,6 @@ importers:
       classix:
         specifier: 2.1.17
         version: 2.1.17
-      react-router-dom:
-        specifier: 6.9.0
-        version: 6.9.0(react-dom@18.2.0)(react@18.2.0)
       react-virtual:
         specifier: 2.10.4
         version: 2.10.4(react@18.2.0)
@@ -1510,7 +1507,7 @@ packages:
       '@babel/traverse': 7.21.2
       '@babel/types': 7.21.2
       convert-source-map: 1.9.0
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.0
@@ -1609,7 +1606,7 @@ packages:
       '@babel/core': 7.21.0
       '@babel/helper-compilation-targets': 7.20.7(@babel/core@7.21.0)
       '@babel/helper-plugin-utils': 7.20.2
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       lodash.debounce: 4.0.8
       resolve: 1.22.1
       semver: 6.3.0
@@ -2801,7 +2798,7 @@ packages:
       '@babel/helper-split-export-declaration': 7.18.6
       '@babel/parser': 7.21.2
       '@babel/types': 7.21.2
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -3480,7 +3477,7 @@ packages:
       chalk: 4.1.2
       cypress: 12.7.0
       dayjs: 1.10.7
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       execa: 4.1.0
       globby: 11.0.4
       istanbul-lib-coverage: 3.0.0
@@ -3535,7 +3532,7 @@ packages:
     dependencies:
       '@babel/core': 7.21.0
       bluebird: 3.7.1
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       lodash: 4.17.21
     transitivePeerDependencies:
       - supports-color
@@ -4009,7 +4006,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       espree: 9.4.1
       globals: 13.20.0
       ignore: 5.2.4
@@ -4113,7 +4110,7 @@ packages:
     engines: {node: '>=10.10.0'}
     dependencies:
       '@humanwhocodes/object-schema': 1.2.1
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -5443,7 +5440,7 @@ packages:
       react: 18.2.0
     dev: false
 
-  /@remix-run/dev@1.14.0(@remix-run/serve@1.14.0):
+  /@remix-run/dev@1.14.0(@remix-run/serve@1.14.0)(ts-node@10.9.1):
     resolution: {integrity: sha512-EG9kG/rGSRucer+g5PJQ8lSMLtJNVVCpxVMzHOciGPRXjPK3pg5acOuOksJGvdiqgFX9UO5itielQZ81ZBy6jA==}
     engines: {node: '>=14'}
     hasBin: true
@@ -5491,7 +5488,7 @@ packages:
       ora: 5.4.1
       postcss: 8.4.21
       postcss-discard-duplicates: 5.1.0(postcss@8.4.21)
-      postcss-load-config: 4.0.1(postcss@8.4.21)
+      postcss-load-config: 4.0.1(postcss@8.4.21)(ts-node@10.9.1)
       postcss-modules: 6.0.0(postcss@8.4.21)
       prettier: 2.7.1
       pretty-ms: 7.0.1
@@ -7535,7 +7532,7 @@ packages:
       '@typescript-eslint/scope-manager': 5.54.0
       '@typescript-eslint/type-utils': 5.54.0(eslint@8.35.0)(typescript@4.9.5)
       '@typescript-eslint/utils': 5.54.0(eslint@8.35.0)(typescript@4.9.5)
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.35.0
       grapheme-splitter: 1.0.4
       ignore: 5.2.4
@@ -7561,7 +7558,7 @@ packages:
       '@typescript-eslint/scope-manager': 5.54.0
       '@typescript-eslint/types': 5.54.0
       '@typescript-eslint/typescript-estree': 5.54.0(typescript@4.9.5)
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.35.0
       typescript: 4.9.5
     transitivePeerDependencies:
@@ -7588,7 +7585,7 @@ packages:
     dependencies:
       '@typescript-eslint/typescript-estree': 5.54.0(typescript@4.9.5)
       '@typescript-eslint/utils': 5.54.0(eslint@8.35.0)(typescript@4.9.5)
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.35.0
       tsutils: 3.21.0(typescript@4.9.5)
       typescript: 4.9.5
@@ -7612,7 +7609,7 @@ packages:
     dependencies:
       '@typescript-eslint/types': 5.54.0
       '@typescript-eslint/visitor-keys': 5.54.0
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.3.8
@@ -7946,7 +7943,7 @@ packages:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
     dependencies:
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -9542,17 +9539,6 @@ packages:
     dependencies:
       ms: 2.0.0
 
-  /debug@3.2.7:
-    resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
-    dependencies:
-      ms: 2.1.3
-    dev: true
-
   /debug@3.2.7(supports-color@8.1.1):
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
     peerDependencies:
@@ -9565,17 +9551,6 @@ packages:
       supports-color: 8.1.1
     dev: true
 
-  /debug@4.3.4:
-    resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
-    engines: {node: '>=6.0'}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
-    dependencies:
-      ms: 2.1.2
-
   /debug@4.3.4(supports-color@8.1.1):
     resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
     engines: {node: '>=6.0'}
@@ -9587,7 +9562,6 @@ packages:
     dependencies:
       ms: 2.1.2
       supports-color: 8.1.1
-    dev: true
 
   /decamelize-keys@1.1.1:
     resolution: {integrity: sha512-WiPxgEirIV0/eIOMcnFBA3/IJZAZqKnwAwWyvvdi4lsr1WCN22nhdf/3db3DoZcUjTV2SqfzIwNyp6y2xs3nmg==}
@@ -9778,7 +9752,7 @@ packages:
     resolution: {integrity: sha512-aBzdj76lueB6uUst5iAs7+0H/oOjqI5D16XUWxlWMIMROhcM0rfsNVk93zTngq1dDNpoXRr++Sus7ETAExppAQ==}
     dependencies:
       address: 1.2.2
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -10272,7 +10246,7 @@ packages:
     peerDependencies:
       esbuild: '>=0.12 <1'
     dependencies:
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       esbuild: 0.16.17
     transitivePeerDependencies:
       - supports-color
@@ -10459,7 +10433,7 @@ packages:
   /eslint-import-resolver-node@0.3.6:
     resolution: {integrity: sha512-0En0w03NRVMn9Uiyn8YRPDKvWjxCWkslUEhGNTdGx15RvPJYQ+lbOlqrlNI2vEAs4pDYK4f/HN2TbDmk5TP0iw==}
     dependencies:
-      debug: 3.2.7
+      debug: 3.2.7(supports-color@8.1.1)
       resolve: 1.22.1
     transitivePeerDependencies:
       - supports-color
@@ -10468,7 +10442,7 @@ packages:
   /eslint-import-resolver-node@0.3.7:
     resolution: {integrity: sha512-gozW2blMLJCeFpBwugLTGyvVjNoeo1knonXAcatC6bjPBZitotxdWf7Gimr25N4c0AAOo4eOUfaG82IJPDpqCA==}
     dependencies:
-      debug: 3.2.7
+      debug: 3.2.7(supports-color@8.1.1)
       is-core-module: 2.11.0
       resolve: 1.22.1
     transitivePeerDependencies:
@@ -10482,7 +10456,7 @@ packages:
       eslint: '*'
       eslint-plugin-import: '*'
     dependencies:
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       enhanced-resolve: 5.12.0
       eslint: 8.35.0
       eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.54.0)(eslint-import-resolver-typescript@3.5.3)(eslint@8.35.0)
@@ -10517,39 +10491,10 @@ packages:
         optional: true
     dependencies:
       '@typescript-eslint/parser': 5.54.0(eslint@8.35.0)(typescript@4.9.5)
-      debug: 3.2.7
+      debug: 3.2.7(supports-color@8.1.1)
       eslint: 8.35.0
       eslint-import-resolver-node: 0.3.7
       eslint-import-resolver-typescript: 3.5.3(eslint-plugin-import@2.27.5)(eslint@8.35.0)
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /eslint-module-utils@2.7.4(@typescript-eslint/parser@5.54.0)(eslint-import-resolver-node@0.3.7)(eslint@8.35.0):
-    resolution: {integrity: sha512-j4GT+rqzCoRKHwURX7pddtIPGySnX9Si/cgMI5ztrcqOPtk5dDEeZ34CQVPphnqkJytlc97Vuk05Um2mJ3gEQA==}
-    engines: {node: '>=4'}
-    peerDependencies:
-      '@typescript-eslint/parser': '*'
-      eslint: '*'
-      eslint-import-resolver-node: '*'
-      eslint-import-resolver-typescript: '*'
-      eslint-import-resolver-webpack: '*'
-    peerDependenciesMeta:
-      '@typescript-eslint/parser':
-        optional: true
-      eslint:
-        optional: true
-      eslint-import-resolver-node:
-        optional: true
-      eslint-import-resolver-typescript:
-        optional: true
-      eslint-import-resolver-webpack:
-        optional: true
-    dependencies:
-      '@typescript-eslint/parser': 5.54.0(eslint@8.35.0)(typescript@4.9.5)
-      debug: 3.2.7
-      eslint: 8.35.0
-      eslint-import-resolver-node: 0.3.7
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -10610,44 +10555,11 @@ packages:
       array-includes: 3.1.6
       array.prototype.flat: 1.3.1
       array.prototype.flatmap: 1.3.1
-      debug: 3.2.7
+      debug: 3.2.7(supports-color@8.1.1)
       doctrine: 2.1.0
       eslint: 8.35.0
       eslint-import-resolver-node: 0.3.7
       eslint-module-utils: 2.7.4(@typescript-eslint/parser@5.54.0)(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.3)(eslint@8.35.0)
-      has: 1.0.3
-      is-core-module: 2.11.0
-      is-glob: 4.0.3
-      minimatch: 3.1.2
-      object.values: 1.1.6
-      resolve: 1.22.1
-      semver: 6.3.0
-      tsconfig-paths: 3.14.2
-    transitivePeerDependencies:
-      - eslint-import-resolver-typescript
-      - eslint-import-resolver-webpack
-      - supports-color
-    dev: true
-
-  /eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.54.0)(eslint@8.35.0):
-    resolution: {integrity: sha512-LmEt3GVofgiGuiE+ORpnvP+kAm3h6MLZJ4Q5HCyHADofsb4VzXFsRiWj3c0OFiV+3DWFh0qg3v9gcPlfc3zRow==}
-    engines: {node: '>=4'}
-    peerDependencies:
-      '@typescript-eslint/parser': '*'
-      eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8
-    peerDependenciesMeta:
-      '@typescript-eslint/parser':
-        optional: true
-    dependencies:
-      '@typescript-eslint/parser': 5.54.0(eslint@8.35.0)(typescript@4.9.5)
-      array-includes: 3.1.6
-      array.prototype.flat: 1.3.1
-      array.prototype.flatmap: 1.3.1
-      debug: 3.2.7
-      doctrine: 2.1.0
-      eslint: 8.35.0
-      eslint-import-resolver-node: 0.3.7
-      eslint-module-utils: 2.7.4(@typescript-eslint/parser@5.54.0)(eslint-import-resolver-node@0.3.7)(eslint@8.35.0)
       has: 1.0.3
       is-core-module: 2.11.0
       is-glob: 4.0.3
@@ -10858,7 +10770,7 @@ packages:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.3
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.1.1
@@ -11695,7 +11607,7 @@ packages:
     dependencies:
       '@tootallnate/once': 1.1.2
       data-uri-to-buffer: 3.0.1
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       file-uri-to-path: 2.0.0
       fs-extra: 8.1.0
       ftp: 0.3.10
@@ -12026,7 +11938,6 @@ packages:
   /has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
-    dev: true
 
   /has-property-descriptors@1.0.0:
     resolution: {integrity: sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==}
@@ -12185,7 +12096,7 @@ packages:
     dependencies:
       '@tootallnate/once': 1.1.2
       agent-base: 6.0.2
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -12196,7 +12107,7 @@ packages:
     dependencies:
       '@tootallnate/once': 2.0.0
       agent-base: 6.0.2
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -12222,7 +12133,7 @@ packages:
     engines: {node: '>= 6.0.0'}
     dependencies:
       agent-base: 5.1.1
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -12232,7 +12143,7 @@ packages:
     engines: {node: '>= 6'}
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -12933,7 +12844,7 @@ packages:
     resolution: {integrity: sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==}
     engines: {node: '>=10'}
     dependencies:
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       istanbul-lib-coverage: 3.2.0
       source-map: 0.6.1
     transitivePeerDependencies:
@@ -13396,7 +13307,7 @@ packages:
       cli-truncate: 3.1.0
       colorette: 2.0.19
       commander: 9.5.0
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       execa: 6.1.0
       lilconfig: 2.0.6
       listr2: 5.0.7
@@ -14289,7 +14200,7 @@ packages:
     resolution: {integrity: sha512-6Mj0yHLdUZjHnOPgr5xfWIMqMWS12zDN6iws9SLuSz76W8jTtAv24MN4/CL7gJrl5vtxGInkkqDv/JIoRsQOvA==}
     dependencies:
       '@types/debug': 4.1.7
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       decode-named-character-reference: 1.0.2
       micromark-core-commonmark: 1.0.6
       micromark-factory-space: 1.0.0
@@ -14525,7 +14436,7 @@ packages:
     engines: {node: '>= 4.4.x'}
     requiresBuild: true
     dependencies:
-      debug: 3.2.7
+      debug: 3.2.7(supports-color@8.1.1)
       iconv-lite: 0.6.3
       sax: 1.2.4
     transitivePeerDependencies:
@@ -15095,7 +15006,7 @@ packages:
     dependencies:
       '@tootallnate/once': 1.1.2
       agent-base: 6.0.2
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       get-uri: 3.0.2
       http-proxy-agent: 4.0.1
       https-proxy-agent: 5.0.1
@@ -15584,7 +15495,7 @@ packages:
       postcss-value-parser: 4.2.0
     dev: true
 
-  /postcss-load-config@3.1.4(postcss@8.4.21):
+  /postcss-load-config@3.1.4(postcss@8.4.21)(ts-node@10.9.1):
     resolution: {integrity: sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg==}
     engines: {node: '>= 10'}
     peerDependencies:
@@ -15598,10 +15509,11 @@ packages:
     dependencies:
       lilconfig: 2.1.0
       postcss: 8.4.21
+      ts-node: 10.9.1(@types/node@18.14.5)(typescript@4.9.5)
       yaml: 1.10.2
     dev: true
 
-  /postcss-load-config@4.0.1(postcss@8.4.21):
+  /postcss-load-config@4.0.1(postcss@8.4.21)(ts-node@10.9.1):
     resolution: {integrity: sha512-vEJIc8RdiBRu3oRAI0ymerOn+7rPuMvRXslTvZUKZonDHFIczxztIyJ1urxM1x9JXEikvpWWTUUqal5j/8QgvA==}
     engines: {node: '>= 14'}
     peerDependencies:
@@ -15615,6 +15527,7 @@ packages:
     dependencies:
       lilconfig: 2.1.0
       postcss: 8.4.21
+      ts-node: 10.9.1(@types/node@18.14.5)(typescript@4.9.5)
       yaml: 2.2.1
     dev: true
 
@@ -16034,7 +15947,7 @@ packages:
     engines: {node: '>= 8'}
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       http-proxy-agent: 4.0.1
       https-proxy-agent: 5.0.1
       lru-cache: 5.1.1
@@ -16096,7 +16009,7 @@ packages:
     engines: {node: '>=8.16.0'}
     dependencies:
       '@types/mime-types': 2.1.1
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       extract-zip: 1.7.0
       https-proxy-agent: 4.0.0
       mime: 2.6.0
@@ -17028,7 +16941,7 @@ packages:
     resolution: {integrity: sha512-wqVMxUGqjjHX+MJrz0WHa/pJTDWU17aRv6cnI/6i7cq93J3TkkJZ8sjgvwCgP8cWX5wTHIlRuMV+IAd59K4X/g==}
     dependencies:
       async: 3.2.4
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       lodash.merge: 4.6.2
       minimist: 1.2.8
     transitivePeerDependencies:
@@ -17062,7 +16975,7 @@ packages:
     engines: {node: '>= 6'}
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       socks: 2.7.1
     transitivePeerDependencies:
       - supports-color
@@ -17512,7 +17425,7 @@ packages:
       cosmiconfig: 8.1.0
       css-functions-list: 3.1.0
       css-tree: 2.3.1
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       fast-glob: 3.2.12
       fastest-levenshtein: 1.0.16
       file-entry-cache: 6.0.1
@@ -17553,7 +17466,7 @@ packages:
     resolution: {integrity: sha512-lQ9w/XIOH5ZHVNuNbWW8D822r+/wBSO/d6XvtyHLF7LW4KaCIDeVbvn5DF8fGCJAUCwVhVi/h6J0NUcnylUEjg==}
     dependencies:
       '@adobe/css-tools': 4.2.0
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       glob: 7.2.3
       sax: 1.2.4
       source-map: 0.7.4
@@ -17580,7 +17493,6 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       has-flag: 4.0.0
-    dev: true
 
   /supports-hyperlinks@2.3.0:
     resolution: {integrity: sha512-RpsAZlpWcDwOPQA22aCH4J0t7L8JmAvsCxfOSEwm7cQs3LshN36QaTkwd70DnBOXDWGssw2eUoc8CaRWT0XunA==}
@@ -18066,7 +17978,7 @@ packages:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
     dev: true
 
-  /typescript-plugin-css-modules@4.2.2(typescript@4.9.5):
+  /typescript-plugin-css-modules@4.2.2(ts-node@10.9.1)(typescript@4.9.5):
     resolution: {integrity: sha512-X5OYGkX96ENq2c7xFJO4tgtiMTlBkOMoRmVHQXH2H4CGFcVODKGieDqPU2B0IV0I+AyvKYDFdKh4ZKtKxAcAww==}
     peerDependencies:
       typescript: '>=3.9.0'
@@ -18078,7 +17990,7 @@ packages:
       less: 4.1.3
       lodash.camelcase: 4.3.0
       postcss: 8.4.21
-      postcss-load-config: 3.1.4(postcss@8.4.21)
+      postcss-load-config: 3.1.4(postcss@8.4.21)(ts-node@10.9.1)
       postcss-modules-local-by-default: 4.0.0(postcss@8.4.21)
       postcss-modules-scope: 3.0.0(postcss@8.4.21)
       reserved-words: 0.1.2
@@ -18446,7 +18358,7 @@ packages:
     engines: {node: '>=v14.16.0'}
     dependencies:
       cac: 6.7.14
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       mlly: 1.1.1
       pathe: 0.2.0
       picocolors: 1.0.0
@@ -18545,7 +18457,7 @@ packages:
       acorn-walk: 8.2.0
       cac: 6.7.14
       chai: 4.3.7
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       jsdom: 21.1.0
       local-pkg: 0.4.3
       picocolors: 1.0.0


### PR DESCRIPTION
## Summary
We have feature flagged this change for the last 2 months in the LaunchDarkly application, and confirmed that the router-agnostic method of using `asChild` works as expected.