### PR TITLE
Revert "feat(menu): deprecate menuitemlink in favor of asChild"

### DIFF
--- a/packages/menu/__tests__/Menu.spec.tsx
+++ b/packages/menu/__tests__/Menu.spec.tsx
@@ -4,7 +4,7 @@ import { Popover } from '@launchpad-ui/popover';
 import { it, expect, describe, vi } from 'vitest';
 
 import { render, screen, userEvent, waitFor } from '../../../test/utils';
-import { Menu, MenuDivider, MenuItem, MenuSearch } from '../src';
+import { Menu, MenuDivider, MenuItem, MenuItemLink, MenuSearch } from '../src';
 
 type TestMenu = {
   hideSearch?: boolean;
@@ -39,7 +39,7 @@ describe('Menu', () => {
   it('renders with virtualization', () => {
     render(createMenu({ enableVirtualization: true }));
     const items = screen.getAllByRole('presentation');
-    expect(items).toHaveLength(4);
+    expect(items).toHaveLength(5);
   });
 
   it('renders the search field', () => {
@@ -127,6 +127,18 @@ describe('Menu', () => {
     expect(items[1]).toHaveFocus();
     await user.keyboard('{arrowup}');
     expect(items[0]).toHaveFocus();
+  });
+
+  it('can render items as links', async () => {
+    const { container } = render(
+      <Menu>
+        <MenuItemLink to="#" useHistory={false}>
+          link
+        </MenuItemLink>
+      </Menu>
+    );
+    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+    expect(container.querySelector('a')).not.toBeNull();
   });
 
   it('can render items into child slot', async () => {

--- a/packages/menu/package.json
+++ b/packages/menu/package.json
@@ -41,6 +41,7 @@
     "@react-aria/focus": "3.10.0",
     "@react-aria/separator": "3.2.6",
     "classix": "2.1.17",
+    "react-router-dom": "6.9.0",
     "react-virtual": "2.10.4"
   },
   "peerDependencies": {

--- a/packages/menu/src/Menu.tsx
+++ b/packages/menu/src/Menu.tsx
@@ -18,7 +18,7 @@ import { useVirtual } from 'react-virtual';
 
 import { MenuBase } from './MenuBase';
 import { MenuDivider } from './MenuDivider';
-import { MenuItem } from './MenuItem';
+import { MenuItem, MenuItemLink } from './MenuItem';
 import { MenuItemList } from './MenuItemList';
 import { MenuSearch } from './MenuSearch';
 import {
@@ -37,7 +37,7 @@ type ControlledMenuProps<T> = {
    */
   enableVirtualization?: boolean;
   /**
-   * Class name to be applied to all MenuItem components
+   * Class name to be applied to all MenuItem and MenuItemLink components
    * in the menu.
    */
   menuItemClassName?: string;
@@ -95,6 +95,7 @@ const Menu = <T extends number | string>(props: MenuProps<T>) => {
             searchElem = child;
             break;
           case MenuItem:
+          case MenuItemLink:
           case MenuDivider:
             elements = elements.concat(child);
             break;
@@ -123,6 +124,7 @@ const Menu = <T extends number | string>(props: MenuProps<T>) => {
               }),
             };
           case MenuItem:
+          case MenuItemLink:
             return {
               items: items.concat(
                 child.props.disabled
@@ -277,6 +279,7 @@ const ItemVirtualizer = <T extends number | string>(props: ItemVirtualizerProps<
       const childProps = itemElem.props as MenuItemProps<T>;
       switch (itemElem.type) {
         case MenuItem:
+        case MenuItemLink:
           return {
             className: cx(childProps.className, menuItemClassName),
             // set focus on the first menu item if there is no search input, and set in the tab order
@@ -365,7 +368,11 @@ const ItemVirtualizer = <T extends number | string>(props: ItemVirtualizerProps<
         return (
           <div
             key={virtualRow.index}
-            ref={elem.type !== MenuItem ? virtualRow.measureRef : undefined}
+            ref={
+              elem.type !== MenuItem || elem.type !== MenuItemLink
+                ? virtualRow.measureRef
+                : undefined
+            }
             role="presentation"
             className={cx('VirtualMenu-item')}
             style={{

--- a/packages/menu/src/MenuItem.tsx
+++ b/packages/menu/src/MenuItem.tsx
@@ -6,6 +6,7 @@ import { Tooltip } from '@launchpad-ui/tooltip';
 import { Slot } from '@radix-ui/react-slot';
 import { FocusRing } from '@react-aria/focus';
 import { cx } from 'classix';
+import { Link } from 'react-router-dom';
 
 import './styles/Menu.css';
 
@@ -122,5 +123,48 @@ const MenuItem = <P, T extends ElementType = typeof defaultElement>({
   return renderedItem;
 };
 
-export { MenuItem };
-export type { MenuItemProps };
+type MenuItemLinkOwnProps = {
+  disabled?: boolean;
+  useHistory?: boolean;
+  newTab?: boolean;
+};
+
+type MenuItemLinkProps<P, T extends ElementType = typeof Link> =
+  | Merge<Omit<MenuItemProps<P, T>, 'component' | 'item'>, MenuItemLinkOwnProps> &
+      (
+        | {
+            item?: undefined;
+          }
+        | {
+            item: P;
+          }
+      );
+
+// By default, this is a Link component whenever useHistory is
+// explicitly not false
+// TODO: deprecate this component
+const MenuItemLink = <P, T extends ElementType = typeof Link>({
+  to,
+  disabled = false,
+  useHistory = true,
+  newTab = false,
+  children,
+  ...props
+}: MenuItemLinkProps<P, T>) => {
+  const finalProps = {
+    ...props,
+    disabled,
+    component: useHistory ? Link : ('a' as const),
+    [useHistory ? 'to' : 'href']: disabled ? '' : to,
+    rel: newTab ? 'noopener noreferrer' : undefined,
+    target: newTab ? '_blank' : undefined,
+  };
+
+  // Ideally if this item is disabled, it should be a button rather
+  // than a link https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/anchor-is-valid.md
+
+  return <MenuItem {...finalProps}>{children}</MenuItem>;
+};
+
+export { MenuItem, MenuItemLink };
+export type { MenuItemProps, MenuItemLinkProps };

--- a/packages/menu/src/index.ts
+++ b/packages/menu/src/index.ts
@@ -1,6 +1,6 @@
 export type { MenuBaseProps } from './MenuBase';
 export type { MenuDividerProps } from './MenuDivider';
-export type { MenuItemProps } from './MenuItem';
+export type { MenuItemProps, MenuItemLinkProps } from './MenuItem';
 export type { MenuItemListProps } from './MenuItemList';
 export type { MenuSearchProps } from './MenuSearch';
 export type { MenuProps } from './Menu';
@@ -8,7 +8,7 @@ export type { MenuProps } from './Menu';
 export { MenuBase } from './MenuBase';
 /* c8 ignore stop */
 export { MenuDivider } from './MenuDivider';
-export { MenuItem } from './MenuItem';
+export { MenuItem, MenuItemLink } from './MenuItem';
 /* c8 ignore start */
 export { MenuItemList } from './MenuItemList';
 /* c8 ignore stop */

--- a/packages/menu/src/styles/Menu.css
+++ b/packages/menu/src/styles/Menu.css
@@ -72,7 +72,7 @@
     outline: none;
   }
 
-  /* Override our link styles for link component */
+  /* Override our link styles for MenuItemLink component */
   & a.Menu-item {
     &:focus:not(:hover):not(.has-focus) {
       text-decoration: none;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -889,6 +889,9 @@ importers:
       classix:
         specifier: 2.1.17
         version: 2.1.17
+      react-router-dom:
+        specifier: 6.9.0
+        version: 6.9.0(react-dom@18.2.0)(react@18.2.0)
       react-virtual:
         specifier: 2.10.4
         version: 2.10.4(react@18.2.0)


### PR DESCRIPTION
Reverts launchdarkly/launchpad-ui#835.

The original PR is causing unit test failures in consumers, after spending some time investigating I think we should revert so that we're not blocked releasing new work while doing analysis on the problem(s) this work caused.
