### PR TITLE
fix(menu): Allow different size shaped menu items when virtual

### DIFF
--- a/.changeset/quiet-gorillas-applaud.md
+++ b/.changeset/quiet-gorillas-applaud.md
@@ -1,0 +1,6 @@
+---
+'@launchpad-ui/menu': minor
+'@launchpad-ui/core': minor
+---
+
+[Menu] Fix clipping for menu items when virtualized

--- a/packages/menu/__tests__/Menu.spec.tsx
+++ b/packages/menu/__tests__/Menu.spec.tsx
@@ -39,7 +39,7 @@ describe('Menu', () => {
   it('renders with virtualization', () => {
     render(createMenu({ enableVirtualization: true }));
     const items = screen.getAllByRole('presentation');
-    expect(items).toHaveLength(4);
+    expect(items).toHaveLength(5);
   });
 
   it('renders the search field', () => {

--- a/packages/menu/src/Menu.tsx
+++ b/packages/menu/src/Menu.tsx
@@ -192,7 +192,7 @@ const ItemVirtualizer = <T extends number | string>(props: ItemVirtualizerProps<
   const {
     overscan,
     searchElement,
-    itemHeight = 33,
+    itemHeight = 31.5,
     menuItemClassName,
     items: items,
     focusManager,
@@ -365,7 +365,7 @@ const ItemVirtualizer = <T extends number | string>(props: ItemVirtualizerProps<
         return (
           <div
             key={virtualRow.index}
-            ref={elem.type !== MenuItem ? virtualRow.measureRef : undefined}
+            ref={virtualRow.measureRef}
             role="presentation"
             className={cx('VirtualMenu-item')}
             style={{


### PR DESCRIPTION
## Summary

Items were getting clipped when virtualized such as when adding a profile picture or other element in the menu item. This will allows to have dynamic items. 


