### PR TITLE
feat(clipboard): Update component height to match other button heights

### DIFF
--- a/.changeset/sour-panthers-build.md
+++ b/.changeset/sour-panthers-build.md
@@ -1,0 +1,6 @@
+---
+'@launchpad-ui/clipboard': patch
+'@launchpad-ui/core': patch
+---
+
+[clipboard] Component height adjusted to match other button heights

--- a/packages/clipboard/src/styles/CopyCodeButton.module.css
+++ b/packages/clipboard/src/styles/CopyCodeButton.module.css
@@ -14,7 +14,7 @@
   font-size: var(--lp-font-size-200);
   text-align: left;
   margin: 0;
-  padding: 0.4rem 0.8rem;
+  padding: 0.275rem 0.8rem;
   cursor: pointer;
   color: var(--lp-color-text-ui-primary);
   border: 1px solid var(--lp-color-border-interactive-secondary);

--- a/packages/clipboard/src/styles/CopyCodeButton.module.css
+++ b/packages/clipboard/src/styles/CopyCodeButton.module.css
@@ -11,7 +11,7 @@
   background-color: var(--lp-component-copy-color-bg-default);
   border-radius: 20px;
   font-family: var(--lp-font-family-monospace);
-  font-size: 87.5%;
+  font-size: var(--lp-font-size-200);
   text-align: left;
   margin: 0;
   padding: 0.4rem 0.8rem;
@@ -33,7 +33,7 @@
 
   &.basic,
   &.minimal {
-    padding: 0.4rem;
+    padding: 0.275rem 0.4rem;
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -85,10 +85,10 @@
 
 .CopyCodeButton--icon {
   padding: 0;
-  line-height: 1;
   height: 1.5rem;
   width: 1.7rem;
   min-height: auto;
   margin-left: 0.65rem;
   flex-shrink: 0;
+  top: -0.5px;
 }


### PR DESCRIPTION
## Summary

The Clipboard component has been updated to use the standard height used by the other button, `24px`

## Screenshots (if appropriate):
Before:
<img width="150" alt="before" src="https://user-images.githubusercontent.com/14228430/234981993-4191d01f-0cd5-4204-96b1-45358cdb5f7b.png">

After:
<img width="191" alt="after" src="https://user-images.githubusercontent.com/14228430/234982079-01093014-5b28-4449-8d4e-e7320602b55d.png">


