### PR TITLE
feat: use ComponentProps type to simplify intrinsic element props

### DIFF
--- a/.changeset/healthy-ravens-design.md
+++ b/.changeset/healthy-ravens-design.md
@@ -1,0 +1,24 @@
+---
+'@launchpad-ui/split-button': patch
+'@launchpad-ui/collapsible': patch
+'@launchpad-ui/navigation': patch
+'@launchpad-ui/pagination': patch
+'@launchpad-ui/clipboard': patch
+'@launchpad-ui/snackbar': patch
+'@launchpad-ui/counter': patch
+'@launchpad-ui/avatar': patch
+'@launchpad-ui/banner': patch
+'@launchpad-ui/button': patch
+'@launchpad-ui/drawer': patch
+'@launchpad-ui/portal': patch
+'@launchpad-ui/select': patch
+'@launchpad-ui/alert': patch
+'@launchpad-ui/modal': patch
+'@launchpad-ui/table': patch
+'@launchpad-ui/toast': patch
+'@launchpad-ui/chip': patch
+'@launchpad-ui/form': patch
+'@launchpad-ui/core': patch
+---
+
+use ComponentProps type to simplify intrinsic element props

--- a/packages/alert/src/Alert.tsx
+++ b/packages/alert/src/Alert.tsx
@@ -1,4 +1,4 @@
-import type { HTMLAttributes, ReactNode } from 'react';
+import type { ComponentProps, ReactNode } from 'react';
 
 import { IconButton } from '@launchpad-ui/button';
 import { Close, StatusIcon } from '@launchpad-ui/icons';
@@ -7,7 +7,7 @@ import { cx } from 'classix';
 
 import styles from './styles/Alert.module.css';
 
-type AlertProps = HTMLAttributes<HTMLDivElement> & {
+type AlertProps = ComponentProps<'div'> & {
   'data-test-id'?: string;
   /**
    * When true, shows the compact Alert variant,

--- a/packages/avatar/src/Avatar.tsx
+++ b/packages/avatar/src/Avatar.tsx
@@ -1,5 +1,5 @@
 import type { IconProps } from '@launchpad-ui/icons';
-import type { ComponentType, HTMLAttributes } from 'react';
+import type { ComponentType, ComponentProps } from 'react';
 
 import { Person } from '@launchpad-ui/icons';
 import { cx } from 'classix';
@@ -8,7 +8,7 @@ import { useCallback, useEffect, useState } from 'react';
 import styles from './styles/Avatar.module.css';
 import { useIsMounted } from './utils';
 
-type AvatarProps = HTMLAttributes<HTMLDivElement> & {
+type AvatarProps = ComponentProps<'img'> & {
   alt?: string;
   url: string;
   size?: 'tiny' | 'small' | 'medium' | 'large';

--- a/packages/banner/src/Banner.tsx
+++ b/packages/banner/src/Banner.tsx
@@ -1,4 +1,4 @@
-import type { HTMLAttributes, ReactNode } from 'react';
+import type { ComponentProps, ReactNode } from 'react';
 
 import { IconButton } from '@launchpad-ui/button';
 import { Close, StatusIcon } from '@launchpad-ui/icons';
@@ -6,7 +6,7 @@ import { cx } from 'classix';
 
 import styles from './styles/Banner.module.css';
 
-type BannerProps = HTMLAttributes<HTMLDivElement> & {
+type BannerProps = ComponentProps<'div'> & {
   'data-test-id'?: string;
   kind: 'info' | 'warning' | 'error';
   onDismiss?(): void;

--- a/packages/button/src/ButtonGroup.tsx
+++ b/packages/button/src/ButtonGroup.tsx
@@ -1,10 +1,10 @@
-import type { HTMLAttributes } from 'react';
+import type { ComponentProps } from 'react';
 
 import { cx } from 'classix';
 
 import './styles/ButtonGroup.css';
 
-type ButtonGroupProps = HTMLAttributes<HTMLDivElement> & {
+type ButtonGroupProps = ComponentProps<'div'> & {
   spacing?: 'compact' | 'normal' | 'large';
   'data-test-id'?: string;
 };

--- a/packages/chip/src/Chip.tsx
+++ b/packages/chip/src/Chip.tsx
@@ -1,12 +1,12 @@
 import type { IconProps } from '@launchpad-ui/icons';
-import type { HTMLAttributes, ReactElement } from 'react';
+import type { ComponentProps, ReactElement } from 'react';
 
 import { cx } from 'classix';
 import { cloneElement } from 'react';
 
 import styles from './styles/Chip.module.css';
 
-type ChipProps = HTMLAttributes<HTMLSpanElement> & {
+type ChipProps = ComponentProps<'span'> & {
   kind?: 'success' | 'warning' | 'error' | 'info' | 'new' | 'beta' | 'federal';
   size?: 'tiny' | 'small';
   icon?: Omit<ReactElement<IconProps>, 'size'>;

--- a/packages/clipboard/src/CopyToClipboard.tsx
+++ b/packages/clipboard/src/CopyToClipboard.tsx
@@ -1,5 +1,5 @@
 import type { TooltipProps } from '@launchpad-ui/tooltip';
-import type { HTMLAttributes, KeyboardEventHandler } from 'react';
+import type { ComponentProps, KeyboardEventHandler } from 'react';
 
 import { CheckCircle } from '@launchpad-ui/icons';
 import { Tooltip } from '@launchpad-ui/tooltip';
@@ -11,7 +11,7 @@ import { forwardRef, useCallback, useImperativeHandle, useRef, useState } from '
 import { CopyCodeButton } from './CopyCodeButton';
 import styles from './styles/CopyToClipboard.module.css';
 
-type CopyToClipboardProps = HTMLAttributes<HTMLSpanElement> & {
+type CopyToClipboardProps = ComponentProps<'span'> & {
   triggerAriaLabel?: string;
   customCopiedText?: string;
   text: string;

--- a/packages/collapsible/src/Collapsible.tsx
+++ b/packages/collapsible/src/Collapsible.tsx
@@ -1,5 +1,5 @@
 import type { CollapsibleTriggerProps } from './CollapsibleTrigger';
-import type { HTMLAttributes, ReactNode } from 'react';
+import type { ComponentProps, ReactNode } from 'react';
 
 import { ExpandLess, ExpandMore } from '@launchpad-ui/icons';
 import { cx } from 'classix';
@@ -8,7 +8,7 @@ import { useId, useRef, useState } from 'react';
 import { CollapsibleTrigger } from './CollapsibleTrigger';
 import styles from './styles/Collapsible.module.css';
 
-type CollapsibleProps = Omit<HTMLAttributes<HTMLDivElement>, 'className'> & {
+type CollapsibleProps = Omit<ComponentProps<'div'>, 'className'> & {
   label: string | ((isOpen: boolean) => string);
   trigger?: (props: CollapsibleTriggerProps) => ReactNode;
   onToggle?: (isOpen: boolean) => void;

--- a/packages/counter/src/Counter.tsx
+++ b/packages/counter/src/Counter.tsx
@@ -1,10 +1,10 @@
-import type { HTMLAttributes } from 'react';
+import type { ComponentProps } from 'react';
 
 import { cx } from 'classix';
 
 import styles from './styles/Counter.module.css';
 
-type CounterProps = HTMLAttributes<HTMLSpanElement> & {
+type CounterProps = ComponentProps<'span'> & {
   value: number;
   subtle?: boolean;
   children?: never;

--- a/packages/drawer/src/DrawerHeader.tsx
+++ b/packages/drawer/src/DrawerHeader.tsx
@@ -1,8 +1,8 @@
-import type { HTMLAttributes } from 'react';
+import type { ComponentProps } from 'react';
 
 import { DRAWER_LABELLED_BY } from './constants';
 
-type DrawerHeaderProps = HTMLAttributes<HTMLDivElement> & {
+type DrawerHeaderProps = ComponentProps<'div'> & {
   closeable?: boolean;
   titleID?: string;
   titleClassName?: string;

--- a/packages/form/src/Checkbox.tsx
+++ b/packages/form/src/Checkbox.tsx
@@ -1,11 +1,11 @@
-import type { InputHTMLAttributes } from 'react';
+import type { ComponentProps } from 'react';
 
 import { forwardRef } from 'react';
 
 import { Label } from './Label';
 import styles from './styles/Form.module.css';
 
-type CheckboxProps = InputHTMLAttributes<HTMLInputElement> & {
+type CheckboxProps = ComponentProps<'input'> & {
   /**
    * The className to pass into the Checkbox's Label component
    */

--- a/packages/form/src/FieldError.tsx
+++ b/packages/form/src/FieldError.tsx
@@ -1,5 +1,5 @@
 import type { FieldPath } from './utils';
-import type { HTMLAttributes } from 'react';
+import type { ComponentProps } from 'react';
 
 import { AlertRhombus } from '@launchpad-ui/icons';
 import { cx } from 'classix';
@@ -7,7 +7,7 @@ import { cx } from 'classix';
 import styles from './styles/Form.module.css';
 import { createFieldErrorId } from './utils';
 
-type FieldErrorProps = HTMLAttributes<HTMLSpanElement> & {
+type FieldErrorProps = ComponentProps<'span'> & {
   name: FieldPath;
   errorMessage?: string;
   'data-test-id'?: string;

--- a/packages/form/src/FieldSet.tsx
+++ b/packages/form/src/FieldSet.tsx
@@ -1,10 +1,10 @@
-import type { HTMLAttributes } from 'react';
+import type { ComponentProps } from 'react';
 
 import { cx } from 'classix';
 
 import styles from './styles/Form.module.css';
 
-type FieldSetProps = HTMLAttributes<HTMLFieldSetElement> & {
+type FieldSetProps = ComponentProps<'fieldset'> & {
   'data-test-id'?: string;
 };
 

--- a/packages/form/src/Form.tsx
+++ b/packages/form/src/Form.tsx
@@ -1,10 +1,10 @@
-import type { FormHTMLAttributes } from 'react';
+import type { ComponentProps } from 'react';
 
 import { cx } from 'classix';
 
 import styles from './styles/Form.module.css';
 
-type FormProps = FormHTMLAttributes<HTMLFormElement> & {
+type FormProps = ComponentProps<'form'> & {
   inline?: boolean;
   // Increases margin between form fields to make room for error messages.
   // This prevents the form from shifting when rendering a field error.

--- a/packages/form/src/FormGroup.tsx
+++ b/packages/form/src/FormGroup.tsx
@@ -1,10 +1,10 @@
-import type { HTMLAttributes } from 'react';
+import type { ComponentProps } from 'react';
 
 import { cx } from 'classix';
 
 import styles from './styles/Form.module.css';
 
-type FormGroupProps = HTMLAttributes<HTMLFieldSetElement> & {
+type FormGroupProps = ComponentProps<'fieldset'> & {
   name?: string | string[];
   ignoreValidation?: boolean;
   isInvalid?: boolean;

--- a/packages/form/src/FormHint.tsx
+++ b/packages/form/src/FormHint.tsx
@@ -1,10 +1,10 @@
-import type { HTMLAttributes } from 'react';
+import type { ComponentProps } from 'react';
 
 import { cx } from 'classix';
 
 import styles from './styles/Form.module.css';
 
-type FormHintProps = HTMLAttributes<HTMLDivElement> & {
+type FormHintProps = ComponentProps<'div'> & {
   'data-test-id'?: string;
 };
 

--- a/packages/form/src/IconField.tsx
+++ b/packages/form/src/IconField.tsx
@@ -1,11 +1,11 @@
 import type { IconProps } from '@launchpad-ui/icons';
-import type { HTMLAttributes } from 'react';
+import type { ComponentProps } from 'react';
 
 import { cx } from 'classix';
 
 import styles from './styles/Form.module.css';
 
-type IconFieldProps = HTMLAttributes<HTMLDivElement> & {
+type IconFieldProps = ComponentProps<'div'> & {
   icon(args: IconProps): JSX.Element;
   children: JSX.Element | JSX.Element[];
   'data-test-id'?: string;

--- a/packages/form/src/Label.tsx
+++ b/packages/form/src/Label.tsx
@@ -1,11 +1,11 @@
-import type { LabelHTMLAttributes } from 'react';
+import type { ComponentProps } from 'react';
 
 import { cx } from 'classix';
 
 import { RequiredAsterisk } from './RequiredAsterisk';
 import styles from './styles/Form.module.css';
 
-type LabelProps = LabelHTMLAttributes<HTMLLabelElement> & {
+type LabelProps = ComponentProps<'label'> & {
   required?: boolean;
   optional?: boolean;
   disabled?: boolean;

--- a/packages/form/src/Radio.tsx
+++ b/packages/form/src/Radio.tsx
@@ -1,11 +1,11 @@
-import type { CSSProperties, InputHTMLAttributes } from 'react';
+import type { CSSProperties, ComponentProps } from 'react';
 
 import { cx } from 'classix';
 
 import { Label } from './Label';
 import styles from './styles/Form.module.css';
 
-type RadioProps = Omit<InputHTMLAttributes<HTMLInputElement>, 'type'> & {
+type RadioProps = Omit<ComponentProps<'input'>, 'type'> & {
   labelClassName?: string;
   labelStyle?: CSSProperties;
   'data-test-id'?: string;

--- a/packages/form/src/RequiredAsterisk.tsx
+++ b/packages/form/src/RequiredAsterisk.tsx
@@ -1,10 +1,10 @@
-import type { HTMLAttributes } from 'react';
+import type { ComponentProps } from 'react';
 
 import { cx } from 'classix';
 
 import styles from './styles/Form.module.css';
 
-type RequiredAsteriskProps = HTMLAttributes<HTMLSpanElement> & {
+type RequiredAsteriskProps = ComponentProps<'span'> & {
   'data-test-id'?: string;
 };
 

--- a/packages/form/src/SelectField.tsx
+++ b/packages/form/src/SelectField.tsx
@@ -1,10 +1,10 @@
-import type { SelectHTMLAttributes } from 'react';
+import type { ComponentProps } from 'react';
 
 import { cx } from 'classix';
 
 import styles from './styles/Form.module.css';
 
-type SelectFieldProps = SelectHTMLAttributes<HTMLSelectElement> & {
+type SelectFieldProps = ComponentProps<'select'> & {
   'data-test-id'?: string;
 };
 

--- a/packages/form/src/TextArea.tsx
+++ b/packages/form/src/TextArea.tsx
@@ -1,4 +1,4 @@
-import type { KeyboardEvent, TextareaHTMLAttributes } from 'react';
+import type { KeyboardEvent, ComponentProps } from 'react';
 
 import { cx } from 'classix';
 import { forwardRef } from 'react';
@@ -6,7 +6,7 @@ import { forwardRef } from 'react';
 import styles from './styles/Form.module.css';
 import { createFieldErrorId } from './utils';
 
-type TextAreaProps = TextareaHTMLAttributes<HTMLTextAreaElement> & {
+type TextAreaProps = ComponentProps<'textarea'> & {
   'data-test-id'?: string;
 };
 

--- a/packages/form/src/TextField.tsx
+++ b/packages/form/src/TextField.tsx
@@ -1,4 +1,4 @@
-import type { InputHTMLAttributes } from 'react';
+import type { ComponentProps } from 'react';
 
 import { cx } from 'classix';
 import { forwardRef } from 'react';
@@ -6,7 +6,7 @@ import { forwardRef } from 'react';
 import styles from './styles/Form.module.css';
 import { createFieldErrorId } from './utils';
 
-type TextFieldProps = InputHTMLAttributes<HTMLInputElement> & {
+type TextFieldProps = ComponentProps<'input'> & {
   suffix?: string;
   tiny?: boolean;
   overrideWidth?: string;

--- a/packages/modal/src/ModalBody.tsx
+++ b/packages/modal/src/ModalBody.tsx
@@ -1,4 +1,4 @@
-import type { HTMLAttributes } from 'react';
+import type { ComponentProps } from 'react';
 
 import cx from 'classix';
 import { useRef } from 'react';
@@ -6,7 +6,7 @@ import { useRef } from 'react';
 import styles from './styles/Modal.module.css';
 import { useOverflowY } from './utils';
 
-type ModalBodyProps = HTMLAttributes<HTMLDivElement> & {
+type ModalBodyProps = ComponentProps<'div'> & {
   'data-test-id'?: string;
 };
 

--- a/packages/navigation/src/Nav.tsx
+++ b/packages/navigation/src/Nav.tsx
@@ -1,11 +1,11 @@
-import type { HTMLAttributes, Ref } from 'react';
+import type { ComponentProps, Ref } from 'react';
 
 import { cx } from 'classix';
 import { forwardRef } from 'react';
 
 import styles from './styles/Navigation.module.css';
 
-type NavBaseProps = HTMLAttributes<HTMLElement> & {
+type NavBaseProps = ComponentProps<'nav'> & {
   kind?: 'primary' | 'secondary';
   innerRef?: Ref<HTMLDivElement>;
   'data-test-id'?: string;

--- a/packages/pagination/src/Pagination.tsx
+++ b/packages/pagination/src/Pagination.tsx
@@ -1,5 +1,5 @@
 import type { PaginationChange } from './PaginationButton';
-import type { HTMLAttributes } from 'react';
+import type { ComponentProps } from 'react';
 
 import { cx } from 'classix';
 
@@ -7,7 +7,7 @@ import { PaginationButton } from './PaginationButton';
 import { PaginationText } from './PaginationText';
 import styles from './styles/Pagination.module.css';
 
-type PaginationProps = HTMLAttributes<HTMLElement> & {
+type PaginationProps = ComponentProps<'nav'> & {
   resourceName: string;
   isFirstDisabled?: boolean;
   isPrevDisabled?: boolean;

--- a/packages/portal/src/Portal.tsx
+++ b/packages/portal/src/Portal.tsx
@@ -1,9 +1,9 @@
-import type { HTMLAttributes } from 'react';
+import type { ComponentProps } from 'react';
 
 import { forwardRef, useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
 
-type PortalProps = HTMLAttributes<HTMLDivElement> & {
+type PortalProps = ComponentProps<'div'> & {
   container?: HTMLElement | null;
   'data-test-id'?: string;
 };

--- a/packages/select/src/SelectListBox.tsx
+++ b/packages/select/src/SelectListBox.tsx
@@ -6,7 +6,7 @@ import type { SingleSelectState } from './SingleSelect';
 import type { AriaListBoxOptions } from '@react-aria/listbox';
 import type { SingleSelectListState } from '@react-stately/list';
 import type { Node } from '@react-types/shared';
-import type { ElementType, InputHTMLAttributes, RefObject } from 'react';
+import type { ElementType, ComponentProps, RefObject } from 'react';
 
 import { Search } from '@launchpad-ui/icons';
 import { getItemId, useListBox, useListBoxSection, useOption } from '@react-aria/listbox';
@@ -22,7 +22,7 @@ type SelectListBoxProps<T extends object> = AriaListBoxOptions<T> & {
   listBoxRef?: RefObject<HTMLDivElement>;
   filterInputRef?: RefObject<HTMLInputElement>;
   state: SingleSelectState<T> | MultiSelectState<T>;
-  filterInputProps: InputHTMLAttributes<HTMLInputElement>;
+  filterInputProps: ComponentProps<'input'>;
   hasFilter?: boolean;
 };
 

--- a/packages/select/src/types.ts
+++ b/packages/select/src/types.ts
@@ -9,14 +9,7 @@ import type {
   DOMProps,
   FocusableElement,
 } from '@react-types/shared';
-import type {
-  ButtonHTMLAttributes,
-  DOMAttributes,
-  HTMLAttributes,
-  InputHTMLAttributes,
-  ReactNode,
-  RefObject,
-} from 'react';
+import type { DOMAttributes, HTMLAttributes, ComponentProps, ReactNode, RefObject } from 'react';
 
 type SharedSelectProps<T extends object> = CollectionBase<T> &
   DOMProps &
@@ -78,7 +71,7 @@ type SharedSelectProps<T extends object> = CollectionBase<T> &
 
 type SelectAria<T extends object> = {
   /** Props for the label element. */
-  labelProps: HTMLAttributes<HTMLElement>;
+  labelProps: ComponentProps<'label'>;
 
   /** Props for the popup trigger element. */
   triggerProps: AriaButtonProps;
@@ -89,7 +82,7 @@ type SelectAria<T extends object> = {
   /** Props for the popup. */
   menuProps: AriaListBoxOptions<T>;
 
-  filterInputProps: InputHTMLAttributes<HTMLInputElement>;
+  filterInputProps: ComponentProps<'input'>;
 
   delegate: ListKeyboardDelegate<T>;
 };
@@ -106,7 +99,7 @@ type SharedSelectState = MenuTriggerState & {
 };
 
 type SharedSelectTriggerProps = {
-  triggerProps: ButtonHTMLAttributes<HTMLButtonElement> & DOMAttributes<FocusableElement>;
+  triggerProps: ComponentProps<'button'> & DOMAttributes<FocusableElement>;
   valueProps: DOMAttributes<FocusableElement>;
   triggerRef: RefObject<HTMLButtonElement>;
   placeholder?: string;

--- a/packages/snackbar/src/Snackbar.tsx
+++ b/packages/snackbar/src/Snackbar.tsx
@@ -1,4 +1,4 @@
-import type { AnchorHTMLAttributes, HTMLAttributes, ReactElement, ReactNode } from 'react';
+import type { ComponentProps, ReactElement, ReactNode } from 'react';
 
 import { IconButton } from '@launchpad-ui/button';
 import { Close, StatusIcon } from '@launchpad-ui/icons';
@@ -11,12 +11,12 @@ type SnackbarBaseProps = {
   kind: 'info' | 'error' | 'warning' | 'success';
   header?: ReactNode;
   description: ReactNode;
-  cta?: ReactElement<AnchorHTMLAttributes<HTMLAnchorElement>>;
+  cta?: ReactElement<ComponentProps<'a'>>;
   onDismiss?: () => void;
   'data-test-id'?: string;
 };
 
-type SnackbarProps = Omit<HTMLAttributes<HTMLDivElement>, 'children'> & SnackbarBaseProps;
+type SnackbarProps = Omit<ComponentProps<'div'>, 'children'> & SnackbarBaseProps;
 
 const Snackbar = ({
   className,

--- a/packages/split-button/src/SplitButton.tsx
+++ b/packages/split-button/src/SplitButton.tsx
@@ -1,12 +1,12 @@
 import type { ButtonProps } from '@launchpad-ui/button';
-import type { HTMLAttributes } from 'react';
+import type { ComponentProps } from 'react';
 
 import { cx } from 'classix';
 
 import { SplitButtonContext } from './context';
 import './styles/SplitButton.css';
 
-type SplitButtonProps = HTMLAttributes<HTMLDivElement> & {
+type SplitButtonProps = ComponentProps<'div'> & {
   kind?: Extract<ButtonProps['kind'], 'primary' | 'default'>;
   size?: ButtonProps['size'];
   disabled?: boolean;

--- a/packages/table/src/Table.tsx
+++ b/packages/table/src/Table.tsx
@@ -1,10 +1,10 @@
-import type { TableHTMLAttributes } from 'react';
+import type { ComponentProps } from 'react';
 
 import { cx } from 'classix';
 
 import styles from './styles/Table.module.css';
 
-type TableProps = TableHTMLAttributes<HTMLTableElement> & {
+type TableProps = ComponentProps<'table'> & {
   auto?: boolean;
   compact?: boolean;
   isResourceTable?: boolean;

--- a/packages/table/src/TableBody.tsx
+++ b/packages/table/src/TableBody.tsx
@@ -1,10 +1,10 @@
-import type { HTMLAttributes } from 'react';
+import type { ComponentProps } from 'react';
 
 import { cx } from 'classix';
 
 import styles from './styles/Table.module.css';
 
-type TableBodyProps = HTMLAttributes<HTMLTableSectionElement> & {
+type TableBodyProps = ComponentProps<'tbody'> & {
   'data-test-id'?: string;
 };
 

--- a/packages/table/src/TableCell.tsx
+++ b/packages/table/src/TableCell.tsx
@@ -1,4 +1,4 @@
-import type { TdHTMLAttributes } from 'react';
+import type { ComponentProps } from 'react';
 
 import { cx } from 'classix';
 
@@ -7,18 +7,18 @@ import styles from './styles/Table.module.css';
 // Ensure that the headers are properly associated with table content.
 type TableCellWithHeadersProps = {
   headers: string;
-} & TdHTMLAttributes<HTMLTableCellElement>;
+} & ComponentProps<'td'>;
 
 // When a cell acts as a header for all cells below it -- a scope of col needs to be used unless a colgroup is present.
 type TableCellWithDirectScopeProps = {
   scope: 'row' | 'col';
-} & TdHTMLAttributes<HTMLTableCellElement>;
+} & ComponentProps<'td'>;
 
 // hasScope indicates that no identifying header info will be added to the dom element.
 // instead, it is assumed that the head element in the table has its scope property defined
 type TableCellWithScopedProps = {
   hasScope: boolean;
-} & TdHTMLAttributes<HTMLTableCellElement>;
+} & ComponentProps<'td'>;
 
 type TableCellWithScopeProps = TableCellWithDirectScopeProps | TableCellWithScopedProps;
 

--- a/packages/table/src/TableHead.tsx
+++ b/packages/table/src/TableHead.tsx
@@ -1,10 +1,10 @@
-import type { HTMLAttributes } from 'react';
+import type { ComponentProps } from 'react';
 
 import { cx } from 'classix';
 
 import styles from './styles/Table.module.css';
 
-type TableHeadProps = HTMLAttributes<HTMLTableSectionElement> & {
+type TableHeadProps = ComponentProps<'thead'> & {
   'data-test-id'?: string;
 };
 

--- a/packages/table/src/TableHeadCell.tsx
+++ b/packages/table/src/TableHeadCell.tsx
@@ -1,10 +1,10 @@
-import type { ThHTMLAttributes } from 'react';
+import type { ComponentProps } from 'react';
 
 import { cx } from 'classix';
 
 import styles from './styles/Table.module.css';
 
-type TableHeadCellProps = ThHTMLAttributes<HTMLTableCellElement> & {
+type TableHeadCellProps = ComponentProps<'th'> & {
   defaultColWidth?:
     | 'zero'
     | 'one-of-twelve'

--- a/packages/toast/src/Toast.tsx
+++ b/packages/toast/src/Toast.tsx
@@ -1,4 +1,4 @@
-import type { HTMLAttributes, ReactNode } from 'react';
+import type { ComponentProps, ReactNode } from 'react';
 
 import { StatusIcon } from '@launchpad-ui/icons';
 import { cx } from 'classix';
@@ -13,7 +13,7 @@ type ToastBaseProps = {
   'data-test-id'?: string;
 };
 
-type ToastProps = Omit<HTMLAttributes<HTMLDivElement>, 'children'> & ToastBaseProps;
+type ToastProps = Omit<ComponentProps<'div'>, 'children'> & ToastBaseProps;
 
 const Toast = ({
   className,


### PR DESCRIPTION
## Summary

We can replace the use of `ElementAttributesType<ElementType>` by using the built-in `ComponentProps` utility type in React.

I found that this doesn't work well with prop types that get passed to `forwardRef`, it might be worth addressing that in a future pass but for now this is a simple change that I think reduces overall complexity.

## Screenshots (if appropriate):

<!-- Are there any visual changes that would be helpful to the reviewer to see? -->

## Testing approaches

<!-- How are these changes tested? -->
