### PR TITLE
fix: selectField ref forwarding

### DIFF
--- a/.changeset/heavy-berries-grab.md
+++ b/.changeset/heavy-berries-grab.md
@@ -1,0 +1,6 @@
+---
+'@launchpad-ui/form': patch
+'@launchpad-ui/core': patch
+---
+
+Ref forwarding for SelectField

--- a/packages/form/src/SelectField.tsx
+++ b/packages/form/src/SelectField.tsx
@@ -1,6 +1,7 @@
 import type { ComponentProps } from 'react';
 
 import { cx } from 'classix';
+import { forwardRef } from 'react';
 
 import styles from './styles/Form.module.css';
 
@@ -8,20 +9,19 @@ type SelectFieldProps = ComponentProps<'select'> & {
   'data-test-id'?: string;
 };
 
-const SelectField = ({
-  className,
-  children,
-  'data-test-id': testId = 'select',
-  ...rest
-}: SelectFieldProps) => {
-  const classes = cx(styles.formInput, className);
+const SelectField = forwardRef<HTMLSelectElement, SelectFieldProps>(
+  ({ className, children, 'data-test-id': testId = 'select', ...rest }: SelectFieldProps, ref) => {
+    const classes = cx(styles.formInput, className);
 
-  return (
-    <select {...rest} data-test-id={testId} className={classes}>
-      {children}
-    </select>
-  );
-};
+    return (
+      <select {...rest} data-test-id={testId} className={classes} ref={ref}>
+        {children}
+      </select>
+    );
+  }
+);
+
+SelectField.displayName = 'SelectField';
 
 export { SelectField };
 export type { SelectFieldProps };


### PR DESCRIPTION
## Summary

Adds ref forwarding to the `SelectField` component so it can be used with e.g. react-hook-forms.

## Testing approaches

No functional changes to test ^_^

I'm happy to add a unit test if you like, but I feel like that would just be testing React 😅 
