### PR TITLE
chore: add repo info to core package.json

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -9,6 +9,11 @@
   "files": [
     "dist"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/launchdarkly/launchpad-ui",
+    "directory": "packages/core"
+  },
   "main": "dist/index.js",
   "module": "dist/index.es.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

<!-- What is changing and why? -->
I have noticed that renovate bot isn't able to [pull in release notes when opening update PRs](https://github.com/launchdarkly/accelerate/pull/1815) for the `@launchpad/core` package.

After [doing some research](https://github.com/renovatebot/renovate/issues/4724#issuecomment-543171930), I'm hoping that adding this [info to the package.json](https://docs.npmjs.com/cli/v9/configuring-npm/package-json#repository) will help.
