### PR TITLE
feat: suppress errors in Avatar when fetching image

### DIFF
--- a/.changeset/pink-tips-draw.md
+++ b/.changeset/pink-tips-draw.md
@@ -1,0 +1,6 @@
+---
+'@launchpad-ui/avatar': patch
+'@launchpad-ui/core': patch
+---
+
+Suppress errors in Avatar when fetching image

--- a/packages/avatar/src/Avatar.tsx
+++ b/packages/avatar/src/Avatar.tsx
@@ -56,7 +56,8 @@ const Avatar = ({
             processImageSource(res);
           }
         })
-        .catch();
+        // eslint-disable-next-line @typescript-eslint/no-empty-function
+        .catch(() => {});
     } else {
       setImageSource('');
     }


### PR DESCRIPTION
## Summary

The `Avatar` component doesn't expose error-handling to consumers, so it seems better to intentionally swallow errors from `fetch( ... )`.

## Screenshots (if appropriate):

<!-- Are there any visual changes that would be helpful to the reviewer to see? -->

## Testing approaches

<!-- How are these changes tested? -->
