### PR TITLE
ci: use GitHub PAT for changesets action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - main
       - 'release/**'
-      - ci/release-gh-token
 
 jobs:
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - 'release/**'
+      - ci/release-gh-token
 
 jobs:
   release:
@@ -12,11 +13,27 @@ jobs:
     if: github.repository == 'launchdarkly/launchpad-ui'
     timeout-minutes: 15
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          audience: https://github.com/launchdarkly
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - uses: dkershner6/aws-ssm-getparameters-action@v1
+        with:
+          parameterPairs: '/production/common/launchpad-ui/gh-pat-token = CUSTOM_GITHUB_TOKEN'
+          withDecryption: 'true'
+
       - uses: actions/checkout@v3
         with:
           # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
           fetch-depth: 0
+          token: ${{ env.CUSTOM_GITHUB_TOKEN }}
 
       - uses: pnpm/action-setup@v2
 
@@ -40,5 +57,5 @@ jobs:
           publish: pnpm release
           cwd: ${{ github.workspace }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ env.CUSTOM_GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

Use a custom GH token to allow CI checks to run on PRs opened by Changesets as seen in #882.