### PR TITLE
ci: update checks to make them required

### DIFF
--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -2,36 +2,31 @@ name: Changeset Check
 
 on:
   pull_request:
-    branches-ignore:
-      - 'changeset-release/**'
+    types:
+      - labeled
+      - unlabeled
+      - opened
+      - synchronize
+      - reopened
 
 jobs:
   changeset-check:
+    if: |
+      !contains(github.event.pull_request.head.ref, 'changeset-release') &&
+      !contains(github.event.pull_request.labels.*.name, 'skip changeset')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
-      - name: Get changed files
-        id: changed-files
-        uses: tj-actions/changed-files@v36
-        with:
-          files: |
-            packages/**/src/**
-            packages/**/package.json
-            packages/icons/icons/**
+      - uses: pnpm/action-setup@v2
 
-      - name: Check for changeset
-        if: steps.changed-files.outputs.any_changed == 'true'
-        id: added-changeset
-        uses: tj-actions/changed-files@v36
+      - name: Setup Node
+        uses: actions/setup-node@v3
         with:
-          files: |
-            .changeset/*.md
+          node-version: 18
+          cache: pnpm
 
-      - name: Verify
-        if: steps.added-changeset.outcome == 'success' && steps.added-changeset.outputs.added_files == ''
-        run: |
-          echo "::error::Please add a changeset for these changes"
-          exit 1
+      - name: Check for Changeset
+        run: pnpx @changesets/cli status --since="origin/main"

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,6 +1,11 @@
 name: Verify changes
 
-on: pull_request
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - 'release/**'
 
 jobs:
   branch-info:


### PR DESCRIPTION
## Summary

Update our CI checks so that we can set them as required checks:

- Update `verify` to run on `main` so that Cypress cache persists across branch builds so that the check doesn't fail inconsistently
- Update `changeset-check` to run on all pull requests but succeed for Changeset release PRs and ones with the `skip changeset` label added