### PR TITLE
feat: add side-by-side theme in Storybook for snapshots

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,3 +1,6 @@
+import isChromatic from 'chromatic';
+import React from 'react';
+
 import '../packages/tokens/dist/index.css';
 import '../packages/tokens/dist/themes.css';
 
@@ -40,22 +43,70 @@ export const globalTypes = {
   theme: {
     name: 'Theme',
     description: 'Global theme for components',
+    defaultValue: isChromatic() ? 'side-by-side' : 'default',
     toolbar: {
       icon: 'circlehollow',
       title: 'Theme',
       items: [
         { value: 'default', icon: 'circlehollow', title: 'default' },
         { value: 'dark', icon: 'circle', title: 'dark' },
+        { value: 'side-by-side', icon: 'sidebar', title: 'side by side' },
       ],
     },
   },
 };
 
-export const decorators = [
-  (story, { globals, parameters }) => {
-    const theme = globals.theme || parameters.theme || 'default';
-    document.documentElement.setAttribute('data-theme', theme);
+const ThemeBlock = ({
+  children,
+  left,
+  'data-theme': dataTheme,
+}: {
+  children;
+  left?: boolean;
+  'data-theme'?: string;
+}) => {
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        top: 0,
+        left: left ? 0 : '50vw',
+        right: left ? '50vw' : 0,
+        width: '50vw',
+        height: '100vh',
+        bottom: 0,
+        overflow: 'auto',
+        padding: '1rem',
+      }}
+      data-theme={dataTheme}
+    >
+      {children}
+    </div>
+  );
+};
 
-    return story();
+export const decorators = [
+  (StoryFn, context) => {
+    const theme = context.parameters.theme || context.globals.theme;
+
+    switch (theme) {
+      case 'side-by-side': {
+        document.documentElement.setAttribute('data-theme', 'default');
+        return (
+          <>
+            <ThemeBlock left>
+              <StoryFn />
+            </ThemeBlock>
+            <ThemeBlock data-theme="dark">
+              <StoryFn />
+            </ThemeBlock>
+          </>
+        );
+      }
+      default: {
+        document.documentElement.setAttribute('data-theme', theme);
+        return <StoryFn />;
+      }
+    }
   },
 ];

--- a/.storybook/styles.css
+++ b/.storybook/styles.css
@@ -15,8 +15,11 @@ html {
 body {
   font-family: var(--lp-font-family-base);
   font-size: var(--lp-font-size-300);
-  background-color: var(--lp-color-bg-ui-primary);
   line-height: var(--lp-line-height-300);
+}
+
+[data-theme] {
+  background-color: var(--lp-color-bg-ui-primary);
   color: var(--lp-color-text-ui-secondary);
 }
 

--- a/packages/clipboard/stories/CopyToClipboard.stories.tsx
+++ b/packages/clipboard/stories/CopyToClipboard.stories.tsx
@@ -1,11 +1,10 @@
 import type { CopyToClipboardHandleRef } from '../src/CopyToClipboard';
-import type { StoryObj } from '@storybook/react';
-import type { ReactNode } from 'react';
+import type { ReactRenderer, StoryObj, StoryFn } from '@storybook/react';
+import type { StoryContext } from '@storybook/types';
 
 import { userEvent, within } from '@storybook/testing-library';
 import { useRef } from 'react';
 
-import { sleep } from '../../../.storybook/utils';
 import { CopyToClipboard } from '../src';
 
 export default {
@@ -30,17 +29,17 @@ export default {
     },
   },
   decorators: [
-    (storyFn: () => ReactNode) => (
+    (Story: StoryFn, context: StoryContext<ReactRenderer>) => (
       <div
         style={{
-          width: '100vw',
-          height: '100vh',
+          width: context.globals.theme === 'side-by-side' ? '50w' : '100vw',
+          height: context.globals.theme === 'side-by-side' ? '50vh' : '100vh',
           display: 'grid',
           alignItems: 'center',
           justifyContent: 'center',
         }}
       >
-        {storyFn()}
+        <Story />
       </div>
     ),
   ],
@@ -52,8 +51,10 @@ export const Default: Story = {
   args: { text: 'Code content', children: 'Copy content' },
   play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
     const canvas = within(canvasElement);
-    await sleep(500);
-    await userEvent.click(canvas.getByRole('button'));
+
+    const buttons = canvas.getAllByRole('button');
+    userEvent.hover(buttons[0]);
+    userEvent.click(buttons[1]);
   },
 };
 
@@ -61,8 +62,10 @@ export const Basic: Story = {
   args: { text: 'Code content', children: 'Copy content', kind: 'basic' },
   play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
     const canvas = within(canvasElement);
-    await sleep(500);
-    await userEvent.click(canvas.getByRole('button'));
+
+    const buttons = canvas.getAllByRole('button');
+    userEvent.hover(buttons[0]);
+    userEvent.click(buttons[1]);
   },
 };
 
@@ -70,8 +73,10 @@ export const Minimal: Story = {
   args: { text: 'Code content', children: 'Copy content', kind: 'minimal' },
   play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
     const canvas = within(canvasElement);
-    await sleep(500);
-    await userEvent.click(canvas.getByRole('button'));
+
+    const buttons = canvas.getAllByRole('button');
+    userEvent.hover(buttons[0]);
+    userEvent.click(buttons[1]);
   },
 };
 

--- a/packages/dropdown/stories/Dropdown.stories.tsx
+++ b/packages/dropdown/stories/Dropdown.stories.tsx
@@ -1,10 +1,8 @@
-import type { StoryObj } from '@storybook/react';
-import type { ReactNode } from 'react';
+import type { ReactRenderer, StoryObj, StoryFn } from '@storybook/react';
+import type { StoryContext } from '@storybook/types';
 
 import { Menu, MenuItem } from '@launchpad-ui/menu';
-import { userEvent, within } from '@storybook/testing-library';
 
-import { sleep } from '../../../.storybook/utils';
 import { Dropdown, DropdownButton } from '../src';
 
 export default {
@@ -18,18 +16,17 @@ export default {
     },
   },
   decorators: [
-    (storyFn: () => ReactNode) => (
+    (Story: StoryFn, context: StoryContext<ReactRenderer>) => (
       <div
         style={{
-          position: 'relative',
-          width: '100vw',
-          height: '100vh',
+          width: context.globals.theme === 'side-by-side' ? '50w' : '100vw',
+          height: context.globals.theme === 'side-by-side' ? '50vh' : '100vh',
           display: 'grid',
           alignItems: 'center',
           justifyContent: 'center',
         }}
       >
-        {storyFn()}
+        <Story />
       </div>
     ),
   ],
@@ -52,11 +49,7 @@ export const Example: Story = {
         <MenuItem>Item 3</MenuItem>
       </Menu>,
     ],
-  },
-  play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
-    const canvas = within(canvasElement);
-    await sleep(500);
-    await userEvent.click(canvas.getByRole('button'));
+    isOpen: true,
   },
 };
 

--- a/packages/icons/stories/Icon.stories.tsx
+++ b/packages/icons/stories/Icon.stories.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable import/namespace */
-import type { Meta } from '@storybook/react';
+import type { Meta, ReactRenderer } from '@storybook/react';
+import type { ArgsStoryFn } from '@storybook/types';
 
 import { Icon } from '../src';
 import * as icons from '../src';
@@ -34,27 +35,29 @@ export default {
   },
 } as Meta;
 
+const render: ArgsStoryFn<ReactRenderer> = (args, { globals }) => (
+  <div
+    style={{
+      display: 'grid',
+      justifyContent: 'space-evenly',
+      gridTemplateColumns: globals.theme === 'side-by-side' ? 'repeat(3, auto)' : 'repeat(4, auto)',
+      rowGap: '4rem',
+      marginTop: '4rem',
+    }}
+  >
+    {Object.keys(icons).map((key, index) => {
+      if (!['Icon', 'StatusIcon', 'FlairIcon', '__namedExportsOrder'].includes(key))
+        return (
+          <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }} key={index}>
+            {icons[key as IconName]({ size: 'medium' })}
+            <span>{key}</span>
+          </div>
+        );
+      return null;
+    })}
+  </div>
+);
+
 export const Default = {
-  render: () => (
-    <div
-      style={{
-        display: 'grid',
-        justifyContent: 'space-evenly',
-        gridTemplateColumns: 'repeat(4, auto)',
-        rowGap: '4rem',
-        marginTop: '4rem',
-      }}
-    >
-      {Object.keys(icons).map((key, index) => {
-        if (!['Icon', 'StatusIcon', 'FlairIcon', '__namedExportsOrder'].includes(key))
-          return (
-            <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }} key={index}>
-              {icons[key as IconName]({ size: 'medium' })}
-              <span>{key}</span>
-            </div>
-          );
-        return null;
-      })}
-    </div>
-  ),
+  render,
 };

--- a/packages/icons/stories/Icon.stories.tsx
+++ b/packages/icons/stories/Icon.stories.tsx
@@ -15,6 +15,7 @@ export default {
     status: {
       type: import.meta.env.STORYBOOK_PACKAGE_STATUS__ICONS,
     },
+    chromatic: { viewports: [1700] },
   },
   argTypes: {
     name: {

--- a/packages/modal/stories/Modal.stories.tsx
+++ b/packages/modal/stories/Modal.stories.tsx
@@ -8,7 +8,7 @@ import { useState } from '@storybook/client-api';
 import { userEvent, within } from '@storybook/testing-library';
 import { useRef } from 'react';
 
-import { sleep, REACT_NODE_TYPE_DOCS } from '../../../.storybook/utils';
+import { REACT_NODE_TYPE_DOCS } from '../../../.storybook/utils';
 import { AbsoluteModalFooter, Modal, ModalBody, ModalFooter, ModalHeader } from '../src';
 
 export default {
@@ -78,8 +78,7 @@ const play = async ({
 }) => {
   if (viewMode !== 'docs') {
     const canvas = within(canvasElement);
-    await sleep(500);
-    await userEvent.click(canvas.getByRole('button'));
+    await userEvent.click(canvas.getAllByRole('button')[0]);
   }
 };
 

--- a/packages/popover/stories/Popover.stories.tsx
+++ b/packages/popover/stories/Popover.stories.tsx
@@ -1,10 +1,9 @@
-import type { StoryObj } from '@storybook/react';
-import type { ReactNode } from 'react';
+import type { ReactRenderer, StoryObj, StoryFn } from '@storybook/react';
+import type { StoryContext } from '@storybook/types';
 
 import { Button } from '@launchpad-ui/button';
 import { userEvent, within } from '@storybook/testing-library';
 
-import { sleep } from '../../../.storybook/utils';
 import { Popover } from '../src';
 
 export default {
@@ -49,17 +48,17 @@ export default {
     },
   },
   decorators: [
-    (storyFn: () => ReactNode) => (
+    (Story: StoryFn, context: StoryContext<ReactRenderer>) => (
       <div
         style={{
-          width: '100vw',
-          height: '100vh',
+          width: context.globals.theme === 'side-by-side' ? '50w' : '100vw',
+          height: context.globals.theme === 'side-by-side' ? '50vh' : '100vh',
           display: 'grid',
           alignItems: 'center',
           justifyContent: 'center',
         }}
       >
-        {storyFn()}
+        <Story />
       </div>
     ),
   ],
@@ -75,10 +74,13 @@ export const Default: Story = {
         Content to show
       </div>,
     ],
+    interactionKind: 'hover-or-focus',
   },
   play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
     const canvas = within(canvasElement);
-    await sleep(500);
-    await userEvent.click(canvas.getByRole('button'));
+
+    for (const button of canvas.getAllByRole('button')) {
+      await userEvent.hover(button);
+    }
   },
 };

--- a/packages/snackbar/stories/SnackbarCenter.stories.tsx
+++ b/packages/snackbar/stories/SnackbarCenter.stories.tsx
@@ -60,6 +60,6 @@ export const Default: Story = {
   },
   play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
     const canvas = within(canvasElement);
-    await userEvent.click(canvas.getByRole('button'));
+    await userEvent.click(canvas.getAllByRole('button')[0]);
   },
 };

--- a/packages/toast/stories/ToastCenter.stories.tsx
+++ b/packages/toast/stories/ToastCenter.stories.tsx
@@ -55,6 +55,6 @@ export const Default: Story = {
   },
   play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
     const canvas = within(canvasElement);
-    await userEvent.click(canvas.getByRole('button'));
+    await userEvent.click(canvas.getAllByRole('button')[0]);
   },
 };

--- a/packages/tooltip/stories/Tooltip.stories.tsx
+++ b/packages/tooltip/stories/Tooltip.stories.tsx
@@ -1,10 +1,9 @@
-import type { StoryObj } from '@storybook/react';
-import type { ReactNode } from 'react';
+import type { ReactRenderer, StoryObj, StoryFn } from '@storybook/react';
+import type { StoryContext } from '@storybook/types';
 
 import { Button } from '@launchpad-ui/button';
 import { userEvent, within } from '@storybook/testing-library';
 
-import { sleep } from '../../../.storybook/utils';
 import { Tooltip } from '../src';
 
 export default {
@@ -34,17 +33,17 @@ export default {
     },
   },
   decorators: [
-    (storyFn: () => ReactNode) => (
+    (Story: StoryFn, context: StoryContext<ReactRenderer>) => (
       <div
         style={{
-          width: '100vw',
-          height: '100vh',
+          width: context.globals.theme === 'side-by-side' ? '50w' : '100vw',
+          height: context.globals.theme === 'side-by-side' ? '50vh' : '100vh',
           display: 'grid',
           alignItems: 'center',
           justifyContent: 'center',
         }}
       >
-        {storyFn()}
+        <Story />
       </div>
     ),
   ],
@@ -54,13 +53,13 @@ type Story = StoryObj<typeof Tooltip>;
 
 export const Default: Story = {
   args: {
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
     children: [<Button key="1">Target</Button>, <span key="2">Content to show</span>],
   },
   play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
     const canvas = within(canvasElement);
-    await sleep(500);
-    await userEvent.click(canvas.getByRole('button'));
+
+    for (const button of canvas.getAllByRole('button')) {
+      await userEvent.hover(button);
+    }
   },
 };


### PR DESCRIPTION
## Summary

Add a `side-by-side` option in our Storybook theme toggle and enable it during Chromatic builds so we can catch any dark mode issues/regressions.

## Screenshots (if appropriate):

<img width="1495" alt="Screenshot 2023-06-27 at 3 16 32 PM" src="https://github.com/launchdarkly/launchpad-ui/assets/2147624/3613f637-a2fe-4a41-b6f3-bde1d6e4a24b">
