### PR TITLE
fix: prevent css injection by forbidding style tags in Markdown component + adding base allowed tags

### DIFF
--- a/.changeset/smooth-masks-end.md
+++ b/.changeset/smooth-masks-end.md
@@ -1,0 +1,6 @@
+---
+"@launchpad-ui/markdown": patch
+"@launchpad-ui/core": patch
+---
+
+[Markdown] Prevent css injection by forbidding style tags and adding base allowed tags

--- a/packages/markdown/src/utils.ts
+++ b/packages/markdown/src/utils.ts
@@ -37,6 +37,8 @@ function renderMarkdown(
     KEEP_CONTENT: false,
     ADD_ATTR: ['target'],
     FORBID_ATTR: ['style', 'class'],
+    FORBID_TAGS: ['style'],
+    ALLOWED_TAGS: ['a', '#text', 'p', 'li', 'ol', 'ul', 'b', 'strong', 'i', 'em'],
   };
 
   if (allowedTags) {

--- a/packages/markdown/src/utils.ts
+++ b/packages/markdown/src/utils.ts
@@ -38,7 +38,7 @@ function renderMarkdown(
     ADD_ATTR: ['target'],
     FORBID_ATTR: ['style', 'class'],
     FORBID_TAGS: ['style'],
-    ALLOWED_TAGS: ['a', '#text', 'p', 'li', 'ol', 'ul', 'b', 'strong', 'i', 'em'],
+    ALLOWED_TAGS: ['a', '#text', 'p', 'li', 'ol', 'ul', 'b', 'strong', 'i', 'em', 'del', 'code'],
   };
 
   if (allowedTags) {


### PR DESCRIPTION
## Summary

Meant to systemically address CSS injections via Markdown component: https://app.shortcut.com/launchdarkly/story/207785/css-injection-on-segments#activity-208280

Forbidding style tags prevents malicious users from injecting style tags into user input that loads potentially malicious stylesheets from user-controlled sources (e.g., https://evil.com/style.css). CSS injection resources: https://owasp.org/www-project-web-security-testing-guide/v41/4-Web_Application_Security_Testing/11-Client_Side_Testing/05-Testing_for_CSS_Injection

Additionally, setting a base config for ALLOWED_TAGS gives us a base level configuration for when engineers forget to specify the allowedTags prop with the Markdown components, which has been a source of repeated HackerOne findings in the past. These tags should still be overridable if the Markdown component in question needs to support additional tags, but this should be a good baseline config (pulled from existing Gonfalon instances) to start. 

Not sure if this potentially constitutes a breaking change; happy to update the commit message here if we think it should require a major version update. 

## Screenshots (if appropriate):

<!-- Are there any visual changes that would be helpful to the reviewer to see? -->

## Testing approaches

<!-- How are these changes tested? -->
