### PR TITLE
feat: add vars package

### DIFF
--- a/.changeset/small-flowers-sin.md
+++ b/.changeset/small-flowers-sin.md
@@ -1,0 +1,6 @@
+---
+'@launchpad-ui/vars': minor
+'@launchpad-ui/tokens': patch
+---
+
+Add vars package for Vanilla Extract usage

--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,3 @@ test-results/
 *.log
 .nyc_output
 .idea
-
-packages/tokens/stories/tokens.json

--- a/docs/adr-005-styles.md
+++ b/docs/adr-005-styles.md
@@ -1,0 +1,36 @@
+# Use CSS modules for component styles
+
+- Status: accepted
+- Deciders: Robb Niznik and Chase Wackerfuss
+
+## Context and Problem Statement
+
+We want to style components in a way that allows for multiple versions of a component to exist on a page.
+
+## Decision Drivers
+
+- Avoid class collisions
+- Works with Vite and Remix
+- Good DX
+
+## Considered Options
+
+- [Plain CSS](https://developer.mozilla.org/en-US/docs/Web/CSS)
+- [CSS Modules](https://github.com/css-modules/css-modules)
+
+## Decision Outcome
+
+Chosen option: CSS Modules, because of the class scoping and tooling compatibility.
+
+## Pros and Cons of the Options
+
+### Plain CSS
+
+- Good, because it doesn't require additional tooling
+- Bad, because of global scoping and class collisions
+
+### CSS Modules
+
+- Good, because class names get hashed based off the stylesheet content
+- Good, because it's supported in Vite and [Remix](https://remix.run/docs/en/main/guides/styling#css-modules)
+- Bad, because [global scoping and composition](https://github.com/css-modules/css-modules#exceptions) can be tricky/complex

--- a/docs/adr-006-scoped-styles.md
+++ b/docs/adr-006-scoped-styles.md
@@ -1,0 +1,41 @@
+# Scope component styles to support multiple versions
+
+- Status: proposed
+- Date: 07/06/2023
+
+## Context and Problem Statement
+
+We want to improve DX for styling LaunchPad components and support multiple scoped versions of themes and/or component tokens.
+
+## Decision Drivers
+
+- Allows scoping themes, styles and/or component tokens
+- Is type‑safe for better DX and token usage
+- Supports our current tool chain
+
+## Considered Options
+
+- [Vanilla Extract](https://vanilla-extract.style/)
+- [Panda](https://panda-css.com/)
+
+## Decision Outcome
+
+Chosen option: Vanilla Extract, because of the improved DX and similarities to CSS modules (our current solution). To be evaluated in new components.
+
+## Pros and Cons of the Options
+
+### Vanilla Extract
+
+- Good, because it's type‑safe and supports locally scoped classes, [variables](https://vanilla-extract.style/documentation/api/create-var/) and themes
+- Good, because it generates static CSS files at build time
+- Good, because it's supported in Vite and [Remix](https://remix.run/docs/en/main/guides/styling#vanilla-extract)
+- Good, because it offers an [optional package](https://vanilla-extract.style/documentation/packages/recipes/#recipevariants) to easily style and type variants
+- Bad, because it can't be linted by Stylelint
+
+### Panda
+
+- Good, because it supports [design tokens](https://panda-css.com/docs/theming/tokens)
+- Good, because it generates atomic CSS
+- Good, because it's supported in Vite and Remix
+- Bad, because it is in early stages with a smaller community
+- Bad, because it is [not optimized](https://panda-css.com/docs/guides/component-library) for shipping individual static CSS files

--- a/package.json
+++ b/package.json
@@ -71,6 +71,8 @@
     "@types/testing-library__jest-dom": "^5.14.3",
     "@typescript-eslint/eslint-plugin": "^5.61.0",
     "@typescript-eslint/parser": "^5.61.0",
+    "@vanilla-extract/css": "^1.12.0",
+    "@vanilla-extract/vite-plugin": "^3.8.2",
     "@vitejs/plugin-react-swc": "^3.3.1",
     "@vitest/coverage-v8": "^0.32.0",
     "@vitest/ui": "^0.32.0",

--- a/packages/tokens/README.md
+++ b/packages/tokens/README.md
@@ -18,7 +18,9 @@ $ npm install @launchpad-ui/tokens
 ### CSS Custom Properties
 
 ```css
-@import '@launchpad-ui/tokens/index.css';
+@import '@launchpad-ui/tokens/dist/index.css';
+@import '@launchpad-ui/tokens/dist/media-queries.css';
+@import '@launchpad-ui/tokens/dist/themes.css';
 ```
 
 ### ES Modules

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -25,7 +25,8 @@
     "./package.json": "./package.json",
     "./themes.css": "./dist/themes.css",
     "./index.css": "./dist/index.css",
-    "./media-queries.css": "./dist/media-queries.css"
+    "./media-queries.css": "./dist/media-queries.css",
+    "./dist/contract.json": "./dist/contract.json"
   },
   "scripts": {
     "build": "style-dictionary build --config ./sd.config.js",

--- a/packages/tokens/sd.config.js
+++ b/packages/tokens/sd.config.js
@@ -74,7 +74,7 @@ module.exports = {
       ],
     },
     json: {
-      buildPath: 'stories/',
+      buildPath: 'dist/',
       transforms: [
         'attribute/cti',
         'name/cti/kebab',
@@ -85,8 +85,12 @@ module.exports = {
       ],
       files: [
         {
+          format: 'json/nested/contract',
+          destination: 'contract.json',
+        },
+        {
           format: 'json/nested',
-          destination: 'tokens.json',
+          destination: 'default.json',
         },
       ],
     },
@@ -146,3 +150,36 @@ StyleDictionary.registerFormat({
     })}${defaultColorCSSVariables}\n${darkColorCSSVariables}`;
   },
 });
+
+StyleDictionary.registerFormat({
+  name: 'json/nested/contract',
+  formatter({ dictionary }) {
+    return JSON.stringify(minifyDictionary(dictionary.tokens), null, 2) + '\n';
+  },
+});
+
+const minifyDictionary = (obj) => {
+  if (typeof obj !== 'object' || Array.isArray(obj)) {
+    return obj;
+  }
+
+  const dict = {};
+
+  if (Object.prototype.hasOwnProperty.call(obj, 'value')) {
+    let variable = '';
+    const path = obj.path.filter((item) => item !== ' ');
+    path.forEach((item, index) => {
+      variable += item;
+      variable += index !== path.length - 1 ? '-' : '';
+    });
+
+    return variable;
+  } else {
+    for (const name in obj) {
+      if (Object.prototype.hasOwnProperty.call(obj, name)) {
+        dict[name] = minifyDictionary(obj[name]);
+      }
+    }
+  }
+  return dict;
+};

--- a/packages/tokens/stories/tokens.stories.tsx
+++ b/packages/tokens/stories/tokens.stories.tsx
@@ -1,6 +1,6 @@
 import { CopyToClipboard } from '@launchpad-ui/clipboard';
 
-import tokens from './tokens.json';
+import tokens from '../dist/default.json';
 
 export default {
   title: 'Tokens/Colors',

--- a/packages/vars/README.md
+++ b/packages/vars/README.md
@@ -32,4 +32,4 @@ export const container = style({
 
 **Note**
 
-The `@launchpad-ui/tokens` package must be installed and its tokens imported to ensure styles are applied.
+The [@launchpad-ui/tokens](../tokens/README.md) package must be installed and its tokens imported to ensure styles are applied.

--- a/packages/vars/README.md
+++ b/packages/vars/README.md
@@ -1,0 +1,35 @@
+# @launchpad-ui/vars
+
+> Vanilla Extract design token references for LaunchPad styles.
+
+[![See it on NPM!](https://img.shields.io/npm/v/@launchpad-ui/vars?style=for-the-badge)](https://www.npmjs.com/package/@launchpad-ui/vars)
+[![How big is this package in your project?](https://img.shields.io/bundlephobia/minzip/@launchpad-ui/vars?style=for-the-badge)](https://bundlephobia.com/result?p=@launchpad-ui/vars)
+
+## Installation
+
+```sh
+$ yarn add @launchpad-ui/vars
+# or
+$ npm install @launchpad-ui/vars
+```
+
+## Usage
+
+### Vanilla Extract styles
+
+```js
+import { vars } from '@launchpad-ui/vars';
+import { style } from '@vanilla-extract/css';
+
+export const container = style({
+  backgroundColor: vars.color.bg.ui.secondary,
+  color: vars.color.text.ui.secondary,
+  padding: vars.spacing[500],
+  border: `${vars.border.width[300]} solid ${vars.color.border.ui.primary}`,
+  fontSize: vars.font.size[300],
+});
+```
+
+**Note**
+
+The `@launchpad-ui/tokens` package must be installed and its tokens imported to ensure styles are applied.

--- a/packages/vars/package.json
+++ b/packages/vars/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@launchpad-ui/vars",
+  "version": "0.0.1",
+  "status": "alpha",
+  "publishConfig": {
+    "access": "public"
+  },
+  "description": "Vanilla Extract design token references for LaunchPad styles.",
+  "files": [
+    "dist"
+  ],
+  "main": "dist/index.js",
+  "module": "dist/index.es.js",
+  "types": "dist/index.d.ts",
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.es.js",
+      "require": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "source": "src/index.ts",
+  "scripts": {
+    "build": "vite build -c ../../vite.config.ts && tsc --project tsconfig.build.json",
+    "clean": "rm -rf dist",
+    "lint": "eslint '**/*.{ts,tsx,js}'",
+    "test": "exit 0"
+  },
+  "dependencies": {
+    "@launchpad-ui/tokens": "workspace:~"
+  },
+  "peerDependencies": {
+    "@vanilla-extract/css": "^1.12.0"
+  },
+  "peerDependenciesMeta": {
+    "@vanilla-extract/css": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@vanilla-extract/css": "^1.12.0"
+  }
+}

--- a/packages/vars/src/index.ts
+++ b/packages/vars/src/index.ts
@@ -1,0 +1,1 @@
+export { vars } from './vars.css';

--- a/packages/vars/src/vars.css.ts
+++ b/packages/vars/src/vars.css.ts
@@ -1,0 +1,6 @@
+import contract from '@launchpad-ui/tokens/dist/contract.json';
+import { createGlobalThemeContract } from '@vanilla-extract/css';
+
+const vars = createGlobalThemeContract(contract, (value) => `lp-${value}`);
+
+export { vars };

--- a/packages/vars/stories/Story.css.ts
+++ b/packages/vars/stories/Story.css.ts
@@ -1,0 +1,22 @@
+import { createVar, style } from '@vanilla-extract/css';
+
+import { vars } from '../src';
+
+export const accentVar = createVar();
+
+export const container = style({
+  backgroundColor: vars.color.bg.ui.secondary,
+  color: vars.color.text.ui.secondary,
+  padding: vars.spacing[500],
+  border: `${vars.border.width[300]} solid ${vars.color.border.ui.primary}`,
+  fontSize: vars.font.size[300],
+});
+
+export const local = style({
+  vars: {
+    [accentVar]: vars.color.pink[500],
+  },
+  backgroundColor: accentVar,
+  height: '10rem',
+  width: '10rem',
+});

--- a/packages/vars/stories/vars.stories.tsx
+++ b/packages/vars/stories/vars.stories.tsx
@@ -1,0 +1,24 @@
+import type { StoryObj } from '@storybook/react';
+
+import { local, container } from './Story.css';
+
+export default {
+  title: 'Styles/Vars',
+  parameters: {
+    status: {
+      type: import.meta.env.STORYBOOK_PACKAGE_STATUS__VARS,
+    },
+  },
+};
+
+type Story = StoryObj;
+
+export const Example: Story = {
+  render: () => (
+    <div className={container}>I&apos;m styled by Vanilla Extract using our tokens</div>
+  ),
+};
+
+export const LocalScoped: Story = {
+  render: () => <div className={local} />,
+};

--- a/packages/vars/tsconfig.build.json
+++ b/packages/vars/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src/*.ts", "src/*.tsx", "../../types/declarations.d.ts"],
+  "compilerOptions": {
+    "outDir": "./dist"
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -306,9 +306,6 @@ importers:
       '@launchpad-ui/icons':
         specifier: workspace:~
         version: link:../icons
-      '@launchpad-ui/styles':
-        specifier: workspace:~
-        version: link:../styles
       '@launchpad-ui/tokens':
         specifier: workspace:~
         version: link:../tokens
@@ -1274,16 +1271,6 @@ importers:
         specifier: 18.2.0
         version: 18.2.0(react@18.2.0)
 
-  packages/styles:
-    dependencies:
-      '@launchpad-ui/tokens':
-        specifier: workspace:~
-        version: link:../tokens
-    devDependencies:
-      '@vanilla-extract/css':
-        specifier: ^1.12.0
-        version: 1.12.0
-
   packages/tab-list:
     dependencies:
       '@launchpad-ui/tokens':
@@ -1456,6 +1443,16 @@ importers:
         version: 18.2.0(react@18.2.0)
 
   packages/types: {}
+
+  packages/vars:
+    dependencies:
+      '@launchpad-ui/tokens':
+        specifier: workspace:~
+        version: link:../tokens
+    devDependencies:
+      '@vanilla-extract/css':
+        specifier: ^1.12.0
+        version: 1.12.0
 
 packages:
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,6 +104,12 @@ importers:
       '@typescript-eslint/parser':
         specifier: ^5.61.0
         version: 5.61.0(eslint@8.44.0)(typescript@5.1.3)
+      '@vanilla-extract/css':
+        specifier: ^1.12.0
+        version: 1.12.0
+      '@vanilla-extract/vite-plugin':
+        specifier: ^3.8.2
+        version: 3.8.2(@types/node@18.16.16)(ts-node@10.9.1)(vite@4.3.9)
       '@vitejs/plugin-react-swc':
         specifier: ^3.3.1
         version: 3.3.1(vite@4.3.9)
@@ -300,6 +306,9 @@ importers:
       '@launchpad-ui/icons':
         specifier: workspace:~
         version: link:../icons
+      '@launchpad-ui/styles':
+        specifier: workspace:~
+        version: link:../styles
       '@launchpad-ui/tokens':
         specifier: workspace:~
         version: link:../tokens
@@ -1264,6 +1273,16 @@ importers:
       react-dom:
         specifier: 18.2.0
         version: 18.2.0(react@18.2.0)
+
+  packages/styles:
+    dependencies:
+      '@launchpad-ui/tokens':
+        specifier: workspace:~
+        version: link:../tokens
+    devDependencies:
+      '@vanilla-extract/css':
+        specifier: ^1.12.0
+        version: 1.12.0
 
   packages/tab-list:
     dependencies:
@@ -8752,8 +8771,8 @@ packages:
       - supports-color
     dev: true
 
-  /@vanilla-extract/css@1.11.1:
-    resolution: {integrity: sha512-iLalh4K4sXgkfzsiFUsiek4IY1/N4jtJKdr1ubpyszPE7W7G2v+DAl8KcmKkRA6vS7k5mFNW34e4fNki6T2cbQ==}
+  /@vanilla-extract/css@1.12.0:
+    resolution: {integrity: sha512-TEttZfnqTRtwgVYiBWQSGGUiVaYWReHp59DsavITEvh4TpJNifZFGhBznHx4wQFEsyio6xA513jps4tmqR6zmw==}
     dependencies:
       '@emotion/hash': 0.9.1
       '@vanilla-extract/private': 1.0.3
@@ -8774,7 +8793,7 @@ packages:
       '@babel/core': 7.22.1
       '@babel/plugin-syntax-typescript': 7.21.4(@babel/core@7.22.1)
       '@vanilla-extract/babel-plugin-debug-ids': 1.0.3
-      '@vanilla-extract/css': 1.11.1
+      '@vanilla-extract/css': 1.12.0
       esbuild: 0.17.6
       eval: 0.1.6
       find-up: 5.0.0
@@ -8796,6 +8815,27 @@ packages:
 
   /@vanilla-extract/private@1.0.3:
     resolution: {integrity: sha512-17kVyLq3ePTKOkveHxXuIJZtGYs+cSoev7BlP+Lf4916qfDhk/HBjvlYDe8egrea7LNPHKwSZJK/bzZC+Q6AwQ==}
+    dev: true
+
+  /@vanilla-extract/vite-plugin@3.8.2(@types/node@18.16.16)(ts-node@10.9.1)(vite@4.3.9):
+    resolution: {integrity: sha512-i0vpuBUoh10Obl0hJr0dWQa6M3Udu/irm4tnsg1lUze8DXTbv3ctHmVu/wrRZHKw1EzzW/v+nLoJJRvisApspQ==}
+    peerDependencies:
+      vite: ^2.2.3 || ^3.0.0 || ^4.0.3
+    dependencies:
+      '@vanilla-extract/integration': 6.2.1(@types/node@18.16.16)
+      outdent: 0.8.0
+      postcss: 8.4.24
+      postcss-load-config: 3.1.4(postcss@8.4.24)(ts-node@10.9.1)
+      vite: 4.3.9(@types/node@18.16.16)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - sass
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - ts-node
     dev: true
 
   /@vitejs/plugin-react-swc@3.3.1(vite@4.3.9):

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -41,7 +41,8 @@
       "@launchpad-ui/toast": ["./packages/toast/src"],
       "@launchpad-ui/toggle": ["./packages/toggle/src"],
       "@launchpad-ui/tooltip": ["./packages/tooltip/src"],
-      "@launchpad-ui/types": ["./packages/types/src"]
+      "@launchpad-ui/types": ["./packages/types/src"],
+      "@launchpad-ui/vars": ["./packages/vars/src"]
     }
   }
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,6 +2,7 @@
 
 import path from 'path';
 
+import { vanillaExtractPlugin } from '@vanilla-extract/vite-plugin';
 import react from '@vitejs/plugin-react-swc';
 import { defineConfig } from 'vite';
 import istanbul from 'vite-plugin-istanbul';
@@ -19,7 +20,12 @@ Object.keys(paths).forEach((key) => {
 const packageJSON = require(path.resolve('./package.json'));
 
 export default defineConfig({
-  plugins: [react(), cssImport(), ...(process.env.CYPRESS ? [istanbul({ cypress: true })] : [])],
+  plugins: [
+    react(),
+    vanillaExtractPlugin(),
+    cssImport(),
+    ...(process.env.CYPRESS ? [istanbul({ cypress: true })] : []),
+  ],
   resolve: {
     alias,
   },


### PR DESCRIPTION
## Summary

- Add `vars` package to allow [Vanilla Extract](https://vanilla-extract.style/) users to consume our tokens in their styles
- Use the new package to evaluate Vanilla Extract for LaunchPad styles
- Add ADRs for styling decisions

## Screenshots (if appropriate):

<img width="892" alt="Screenshot 2023-07-06 at 1 29 26 PM" src="https://github.com/launchdarkly/launchpad-ui/assets/2147624/fde806a2-d47e-4301-a66b-a87f19b75669">


## Testing approaches

Check out vars stories.