### PR TITLE
ci: benchmark style sheet sizes

### DIFF
--- a/.github/workflows/package-size.yml
+++ b/.github/workflows/package-size.yml
@@ -20,3 +20,5 @@ jobs:
           cache: pnpm
 
       - uses: preactjs/compressed-size-action@v2
+        with:
+          pattern: '**/dist/**/*.{css,js}'

--- a/renovate.json
+++ b/renovate.json
@@ -9,7 +9,7 @@
   ],
   "packageRules": [
     {
-      "updateTypes": ["patch"],
+      "matchUpdateTypes": ["patch"],
       "enabled": false
     }
   ],


### PR DESCRIPTION
## Summary

To inform styling refactors or new solutions we should benchmark style sheet sizes to compare against.