### PR TITLE
fix: icon alignment for chip

### DIFF
--- a/.changeset/lazy-meals-drum.md
+++ b/.changeset/lazy-meals-drum.md
@@ -1,0 +1,5 @@
+---
+'@launchpad-ui/chip': patch
+---
+
+center icon in chip component

--- a/.changeset/lazy-meals-drum.md
+++ b/.changeset/lazy-meals-drum.md
@@ -1,5 +1,6 @@
 ---
 '@launchpad-ui/chip': patch
+'@launchpad-ui/core': patch
 ---
 
-center icon in chip component
+[Chip] Center icons

--- a/packages/chip/src/styles/Chip.module.css
+++ b/packages/chip/src/styles/Chip.module.css
@@ -37,10 +37,9 @@
 
 .chip {
   display: inline-flex;
+  align-items: center;
   font-weight: var(--lp-font-weight-semibold);
   border-radius: 0.2rem;
-  vertical-align: bottom;
-  text-align: center;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -105,16 +104,12 @@
 
 .clickable:focus {
   outline: 0;
-  box-shadow: 0 0 0 1px var(--lp-color-bg-ui-primary),
+  box-shadow:
+    0 0 0 1px var(--lp-color-bg-ui-primary),
     0 0 0 2px var(--lp-color-shadow-interactive-focus);
   z-index: 2;
 }
 
 .icon {
   margin-right: 0.2rem;
-  transform: translateY(1px);
-
-  .tiny & {
-    transform: translateY(2px);
-  }
 }


### PR DESCRIPTION
## Summary

Chip's icons are currently not centered which does not match with [design mocks](https://www.figma.com/file/ITlrRueSW0eYdUp7acr9Xi/LaunchPad?type=design&node-id=13919-73672&mode=design&t=OE0Itam0czr6C5q3-0)

I adjusted styles so that icons are centered in Chip.

## Screenshots (if appropriate):

Before:
<img width="93" alt="image" src="https://github.com/launchdarkly/launchpad-ui/assets/21208260/e7624c71-59e6-46cf-8742-97a3c2e9d6b4">


After:
<img width="97" alt="image" src="https://github.com/launchdarkly/launchpad-ui/assets/21208260/30aefd97-07e3-4f01-b3dd-a26adcc9807f">

## Testing approaches

Visually
