### PR TITLE
fix(textField): disable password managers from adding autofill icon to input

### DIFF
--- a/.changeset/smooth-clouds-chew.md
+++ b/.changeset/smooth-clouds-chew.md
@@ -1,0 +1,6 @@
+---
+'@launchpad-ui/form': patch
+'@launchpad-ui/core': patch
+---
+
+[TextField]: Disable 1Password and LastPass from displaying autofill icons

--- a/packages/form/src/TextField.tsx
+++ b/packages/form/src/TextField.tsx
@@ -24,6 +24,7 @@ const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
       suffix,
       overrideWidth,
       'data-test-id': testId = 'text-field',
+      autoComplete,
       ...rest
     },
     ref
@@ -39,6 +40,7 @@ const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
             {...rest}
             type={type}
             data-test-id={testId}
+            autoComplete={autoComplete}
             className={classes}
             readOnly={readOnly}
             ref={ref}
@@ -51,6 +53,31 @@ const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
       );
     }
 
+    if (autoComplete === 'off') {
+      return (
+        <input
+          {...rest}
+          data-lpignore="true" // "data-lpignore" is added to prevent LastPass from injecting a password autofill icon
+          data-1p-ignore // "data-1p-ignore" is added to prevent 1Password from injecting a password autofill icon
+          autoComplete={autoComplete}
+          type={type}
+          className={classes}
+          readOnly={readOnly}
+          tabIndex={tabIndex}
+          ref={ref}
+          data-test-id={testId}
+          style={
+            overrideWidth
+              ? {
+                  width: overrideWidth,
+                }
+              : undefined
+          }
+          aria-describedby={rest['aria-describedby'] || createFieldErrorId(rest.id)}
+        />
+      );
+    }
+
     return (
       <input
         {...rest}
@@ -58,6 +85,7 @@ const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
         className={classes}
         readOnly={readOnly}
         tabIndex={tabIndex}
+        autoComplete={autoComplete}
         ref={ref}
         data-test-id={testId}
         style={

--- a/packages/form/src/TextField.tsx
+++ b/packages/form/src/TextField.tsx
@@ -33,6 +33,8 @@ const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
       ? className
       : cx(styles.formInput, tiny && styles.formInputTiny, className);
 
+    const disablePasswordManagers = autoComplete === 'off';
+
     if (suffix) {
       return (
         <div className={styles.suffixContainer}>
@@ -53,34 +55,10 @@ const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
       );
     }
 
-    if (autoComplete === 'off') {
-      return (
-        <input
-          {...rest}
-          data-lpignore="true" // "data-lpignore" is added to prevent LastPass from injecting a password autofill icon
-          data-1p-ignore // "data-1p-ignore" is added to prevent 1Password from injecting a password autofill icon
-          autoComplete={autoComplete}
-          type={type}
-          className={classes}
-          readOnly={readOnly}
-          tabIndex={tabIndex}
-          ref={ref}
-          data-test-id={testId}
-          style={
-            overrideWidth
-              ? {
-                  width: overrideWidth,
-                }
-              : undefined
-          }
-          aria-describedby={rest['aria-describedby'] || createFieldErrorId(rest.id)}
-        />
-      );
-    }
-
     return (
       <input
         {...rest}
+        data-1p-ignore={disablePasswordManagers} // "data-1p-ignore" is added to prevent 1Password from injecting a password autofill icon
         type={type}
         className={classes}
         readOnly={readOnly}

--- a/packages/form/stories/FormField.stories.tsx
+++ b/packages/form/stories/FormField.stories.tsx
@@ -83,6 +83,17 @@ export const WithHint: Story = {
     name: 'Email',
     htmlFor: 'Email',
     hint: 'Must be a valid email',
-    children: <TextField id="Email" value="testing@launchdarkly.com" />,
+    children: <TextField id="Email" autoComplete="email" value="testing@launchdarkly.com" />,
+  },
+};
+
+export const WithPasswordManagerDisabled: Story = {
+  args: {
+    isRequired: true,
+    label: 'Name',
+    name: 'Name',
+    htmlFor: 'Name',
+    hint: 'Must not be blank',
+    children: <TextField id="Name" autoComplete="off" value="First Name" />,
   },
 };


### PR DESCRIPTION
## Summary
- If `autoComplete = "off"` for `TextField` input, 1Password will not inject autofill options and icons to the field
- I tried to implement this for LastPass as well, but recent updates disabled the fix, so as of now, there is no option to disable LastPass :(

<!-- What is changing and why? -->

## Screenshots (if appropriate):
Without fix:
![Screenshot 2023-07-12 at 3 00 06 PM](https://github.com/launchdarkly/launchpad-ui/assets/17274027/dd39f8d9-1e75-424c-80ed-04db197437d5)

With Password manager disabled:
![Screenshot 2023-07-12 at 3 00 12 PM](https://github.com/launchdarkly/launchpad-ui/assets/17274027/9d915d73-a510-4b3c-b61f-0f7dfdd71f7c)
<!-- Are there any visual changes that would be helpful to the reviewer to see? -->

## Testing approaches
- manual
<!-- How are these changes tested? -->
