### PR TITLE
refactor(tokens)!: add base suffix

### DIFF
--- a/.changeset/slow-lions-judge.md
+++ b/.changeset/slow-lions-judge.md
@@ -1,0 +1,50 @@
+---
+'@launchpad-ui/tokens': minor
+'@launchpad-ui/vars': minor
+'@launchpad-ui/progress-bubbles': patch
+'@launchpad-ui/split-button': patch
+'@launchpad-ui/navigation': patch
+'@launchpad-ui/clipboard': patch
+'@launchpad-ui/markdown': patch
+'@launchpad-ui/snackbar': patch
+'@launchpad-ui/tab-list': patch
+'@launchpad-ui/popover': patch
+'@launchpad-ui/tooltip': patch
+'@launchpad-ui/avatar': patch
+'@launchpad-ui/banner': patch
+'@launchpad-ui/button': patch
+'@launchpad-ui/filter': patch
+'@launchpad-ui/select': patch
+'@launchpad-ui/slider': patch
+'@launchpad-ui/toggle': patch
+'@launchpad-ui/alert': patch
+'@launchpad-ui/modal': patch
+'@launchpad-ui/toast': patch
+'@launchpad-ui/chip': patch
+'@launchpad-ui/form': patch
+'@launchpad-ui/menu': patch
+'@launchpad-ui/core': patch
+---
+
+[Tokens] Add `0` and `base` suffix to default tokens:
+
+Primitives:
+
+- `lp-color-black-0`
+- `lp-color-white-0`
+
+Aliases:
+
+- `lp-color-bg-interactive-primary-base`
+- `lp-color-bg-interactive-secondary-base`
+- `lp-color-bg-interactive-tertiary-base`
+- `lp-color-bg-interactive-destructive-base`
+- `lp-color-bg-field-base`
+- `lp-color-border-field-base`
+- `lp-color-border-interactive-primary-base`
+- `lp-color-border-interactive-secondary-base`
+- `lp-color-fill-field-base`
+- `lp-color-text-feedback-base`
+- `lp-color-text-interactive-base`
+- `lp-color-text-ui-primary-base`
+- `lp-color-text-field-base`

--- a/.storybook/styles.css
+++ b/.storybook/styles.css
@@ -26,7 +26,7 @@ body {
 h1,
 h2,
 h3 {
-  color: var(--lp-color-text-ui-primary);
+  color: var(--lp-color-text-ui-primary-base);
 }
 
 @font-face {

--- a/packages/alert/src/styles/Alert.module.css
+++ b/packages/alert/src/styles/Alert.module.css
@@ -9,7 +9,7 @@
   white-space: normal;
   width: 100%;
   background-color: var(--lp-color-bg-ui-primary);
-  color: var(--lp-color-text-feedback);
+  color: var(--lp-color-text-feedback-base);
   box-sizing: border-box;
   border-radius: 2px;
 }
@@ -18,7 +18,7 @@
   margin-top: 0;
   margin-bottom: 0.4rem;
   font-size: 1.6rem;
-  color: var(--lp-color-text-feedback);
+  color: var(--lp-color-text-feedback-base);
   font-weight: var(--lp-font-weight-medium);
   line-height: 1.25;
 }
@@ -116,7 +116,7 @@
 }
 
 .Alert-content :global(a:not(.Button)) {
-  color: var(--lp-color-text-interactive);
+  color: var(--lp-color-text-interactive-base);
 
   &:hover {
     text-decoration: none;
@@ -124,7 +124,9 @@
   }
 
   &:focus {
-    box-shadow: 0 0 0 1px hsl(0 0 100% / 0.7), 0 0 0 4px hsl(0 0% 9.8% / 0.1);
+    box-shadow:
+      0 0 0 1px hsl(0 0 100% / 0.7),
+      0 0 0 4px hsl(0 0% 9.8% / 0.1);
   }
 
   &:active {

--- a/packages/avatar/src/styles/Avatar.module.css
+++ b/packages/avatar/src/styles/Avatar.module.css
@@ -5,7 +5,7 @@
   flex-shrink: 0;
   max-width: unset;
   overflow: hidden;
-  color: var(--lp-color-text-ui-primary);
+  color: var(--lp-color-text-ui-primary-base);
   display: inline-flex;
   vertical-align: top;
   justify-content: center;
@@ -15,7 +15,7 @@
 
 .Avatar--initials {
   border: none;
-  color: var(--lp-color-white);
+  color: var(--lp-color-white-0);
 }
 
 .Avatar--color0 {

--- a/packages/banner/src/styles/Banner.module.css
+++ b/packages/banner/src/styles/Banner.module.css
@@ -32,7 +32,7 @@
 }
 
 .Banner-content {
-  color: var(--lp-color-text-feedback);
+  color: var(--lp-color-text-feedback-base);
   font-style: normal;
   font-weight: 400;
   font-size: 16px;

--- a/packages/button/src/styles/Button.css
+++ b/packages/button/src/styles/Button.css
@@ -176,8 +176,8 @@
 /* ------- MINIMAL ------- */
 
 .Button.Button--minimal {
-  background-color: var(--lp-color-bg-interactive-tertiary);
-  color: var(--lp-color-text-ui-primary);
+  background-color: var(--lp-color-bg-interactive-tertiary-base);
+  color: var(--lp-color-text-ui-primary-base);
 }
 
 .Button.Button--minimal:hover,
@@ -191,7 +191,7 @@
 
 .Button.Button--minimal[disabled],
 .Button.Button--minimal[disabled]:hover {
-  background-color: var(--lp-color-bg-interactive-tertiary);
+  background-color: var(--lp-color-bg-interactive-tertiary-base);
   border: none;
   color: var(--lp-color-text-interactive-disabled);
 }
@@ -201,7 +201,7 @@
 .Button.Button--close {
   background-color: transparent;
   fill: var(--lp-color-gray-700);
-  color: var(--lp-color-text-ui-primary);
+  color: var(--lp-color-text-ui-primary-base);
 }
 
 .Button.Button--close svg {
@@ -210,18 +210,24 @@
 
 .Button.Button--close:hover {
   background-color: rgb(33 33 33 / 0.1);
-  box-shadow: 0 0 0 1px hsl(216 2.4% 58.6% / 0.7), 0 0 0 4px hsl(0 0% 12.9% / 0.1);
+  box-shadow:
+    0 0 0 1px hsl(216 2.4% 58.6% / 0.7),
+    0 0 0 4px hsl(0 0% 12.9% / 0.1);
 }
 
 .Button.Button--close:focus-visible {
   background-color: hsl(0 0 100% / 0.1);
-  box-shadow: 0 0 0 1px hsl(225 1.8% 43.5% / 0.7), 0 0 0 4px hsl(0 0% 12.9% / 0.1);
+  box-shadow:
+    0 0 0 1px hsl(225 1.8% 43.5% / 0.7),
+    0 0 0 4px hsl(0 0% 12.9% / 0.1);
 }
 
 .Button.Button--close:active {
   background-color: hsl(0 0% 12.9% / 0.7);
-  box-shadow: 0 0 0 1px var(--lp-color-black-200), 0 0 0 4px hsl(0 0% 12.9% / 0.1);
-  color: var(--lp-color-white);
+  box-shadow:
+    0 0 0 1px var(--lp-color-black-200),
+    0 0 0 4px hsl(0 0% 12.9% / 0.1);
+  color: var(--lp-color-white-0);
 }
 
 .Button.Button--close[disabled],
@@ -329,7 +335,7 @@
   text-decoration: none;
   background-color: transparent;
   border-color: transparent;
-  color: var(--lp-color-text-interactive);
+  color: var(--lp-color-text-interactive-base);
 }
 
 .Button--link:active {

--- a/packages/button/src/styles/ButtonVariables.css
+++ b/packages/button/src/styles/ButtonVariables.css
@@ -1,6 +1,6 @@
 :root,
 [data-theme='default'] {
-  --lp-component-button-color-bg-default: var(--lp-color-bg-interactive-secondary);
+  --lp-component-button-color-bg-default: var(--lp-color-bg-interactive-secondary-base);
   --lp-component-button-color-border-destructive: var(--lp-color-border-interactive-destructive);
   --lp-component-button-color-bg-destructive-hover: var(
     --lp-color-bg-interactive-destructive-hover
@@ -26,15 +26,15 @@
   /* Remaining Legacy Tokens */
   --Button-border-default: 1px solid transparent;
   --Button-box-shadow-default-active: none;
-  --Button-color-boxShadow-1-default-active: var(--lp-color-white);
+  --Button-color-boxShadow-1-default-active: var(--lp-color-white-0);
   --Button-color-boxShadow-2-default-active: hsl(231.5 100% 62.5% / 0.1);
   --Button-color-boxShadow-1-default-withIcon-focus: var(--lp-color-shadow-interactive-focus);
   --Button-color-boxShadow-2-default-withIcon-focus: hsl(231.5 100% 62.5% / 0.1);
   --Button-box-shadow-withIcon-focus: 0 0 0 1px
       var(--Button-color-boxShadow-1-default-withIcon-focus),
     0 0 0 4px var(--Button-color-boxShadow-2-default-withIcon-focus);
-  --Button-color-text-destructive-focus: var(--lp-color-white);
-  --Button-color-background-disabled-withIcon: var(--lp-color-white);
+  --Button-color-text-destructive-focus: var(--lp-color-white-0);
+  --Button-color-background-disabled-withIcon: var(--lp-color-white-0);
   --Button-color-border-disabled-withIcon: transparent;
 
   /* End Remaining Legacy Tokens */
@@ -56,7 +56,7 @@
   --Button-color-background-default-hover: var(--lp-color-bg-interactive-secondary-hover);
   --Button-color-background-default-focus: var(--lp-color-bg-interactive-secondary-focus);
   --Button-color-background-default-active: var(--lp-color-bg-interactive-secondary-active);
-  --Button-color-border-default: var(--lp-color-border-interactive-secondary);
+  --Button-color-border-default: var(--lp-color-border-interactive-secondary-base);
 
   /* named for hover state for default, primary, destructive */
   --Button-box-shadow-hover: 0 2px 8px -1px hsl(0 0% 0% / 0.04), 0 2px 4px 0 hsl(0 0% 0% / 0.08),
@@ -74,19 +74,19 @@
   --Button-box-shadow-link-focus: 0 0 0 2px var(--Button-color-boxShadow-1-default-focus),
     0 0 0 4px var(--Button-color-boxShadow-2-default-focus);
   --Button-box-shadow-link-active: none;
-  --Button-color-link-default: var(--lp-color-text-interactive);
+  --Button-color-link-default: var(--lp-color-text-interactive-base);
   --Button-color-link-active: var(--lp-color-text-interactive-active);
-  --Button-color-text-default: var(--lp-color-text-ui-primary);
-  --Button-color-text-default-hover: var(--lp-color-text-ui-primary);
-  --Button-color-text-default-focus: var(--lp-color-text-ui-primary);
-  --Button-color-text-default-active: var(--lp-color-text-ui-primary);
+  --Button-color-text-default: var(--lp-color-text-ui-primary-base);
+  --Button-color-text-default-hover: var(--lp-color-text-ui-primary-base);
+  --Button-color-text-default-focus: var(--lp-color-text-ui-primary-base);
+  --Button-color-text-default-active: var(--lp-color-text-ui-primary-base);
 
   /* ------- PRIMARY ------- */
-  --Button-color-background-primary: var(--lp-color-bg-interactive-primary);
+  --Button-color-background-primary: var(--lp-color-bg-interactive-primary-base);
   --Button-color-background-primary-hover: var(--lp-color-bg-interactive-primary-hover);
   --Button-color-background-primary-focus: var(--lp-color-bg-interactive-primary-focus);
   --Button-color-background-primary-active: var(--lp-color-bg-interactive-primary-active);
-  --Button-color-border-primary: var(--lp-color-border-interactive-primary);
+  --Button-color-border-primary: var(--lp-color-border-interactive-primary-base);
   --Button-color-border-primary-hover: var(--lp-color-border-interactive-primary-hover);
   --Button-color-border-primary-focus: var(--lp-color-border-interactive-primary-focus);
   --Button-color-border-primary-active: var(--lp-color-border-interactive-primary-active);
@@ -94,8 +94,8 @@
   --Button-color-text-primary-hover: var(--lp-color-text-interactive-primary);
 
   /* PRIMARY WITH ICON */
-  --Button-color-background-primary-withIcon: var(--lp-color-bg-interactive-primary);
-  --Button-color-border-primary-withIcon: var(--lp-color-border-interactive-primary);
+  --Button-color-background-primary-withIcon: var(--lp-color-bg-interactive-primary-base);
+  --Button-color-border-primary-withIcon: var(--lp-color-border-interactive-primary-base);
   --Button-color-text-primary-withIcon: var(--lp-color-text-interactive-primary);
 
   /* ------- DESTRUCTIVE ------- */
@@ -150,9 +150,9 @@
   /* ------- BUTTON ICONS ------- */
 
   /* BUTTON ICON DEFAULT */
-  --Button-icon-color-default: var(--lp-color-text-ui-primary);
-  --Button-icon-color-fill-default: var(--lp-color-text-ui-primary);
-  --Button-icon-color-text-default: var(--lp-color-text-ui-primary);
+  --Button-icon-color-default: var(--lp-color-text-ui-primary-base);
+  --Button-icon-color-fill-default: var(--lp-color-text-ui-primary-base);
+  --Button-icon-color-text-default: var(--lp-color-text-ui-primary-base);
 
   /* BUTTON ICON PRIMARY */
   --Button-icon-color-fill-primary: var(--lp-color-fill-interactive-primary);

--- a/packages/chip/src/styles/Chip.module.css
+++ b/packages/chip/src/styles/Chip.module.css
@@ -11,7 +11,7 @@
   --lp-component-chip-color-bg-beta: var(--lp-color-purple-200);
   --lp-component-chip-color-text-beta: var(--lp-color-purple-600);
   --lp-component-chip-color-bg-federal: var(--lp-color-yellow-500);
-  --lp-component-chip-color-text-federal: var(--lp-color-black);
+  --lp-component-chip-color-text-federal: var(--lp-color-black-0);
   --lp-component-chip-color-bg-default: var(--lp-color-gray-100);
   --lp-component-chip-color-text-default: var(--lp-color-gray-800);
 }

--- a/packages/clipboard/src/styles/CopyCodeButton.module.css
+++ b/packages/clipboard/src/styles/CopyCodeButton.module.css
@@ -1,6 +1,6 @@
 :root,
 [data-theme='default'] {
-  --lp-component-copy-color-bg-default: var(--lp-color-bg-interactive-secondary);
+  --lp-component-copy-color-bg-default: var(--lp-color-bg-interactive-secondary-base);
 }
 
 [data-theme='dark'] {
@@ -16,14 +16,14 @@
   margin: 0;
   padding: 0.275rem 0.8rem;
   cursor: pointer;
-  color: var(--lp-color-text-ui-primary);
-  border: 1px solid var(--lp-color-border-interactive-secondary);
+  color: var(--lp-color-text-ui-primary-base);
+  border: 1px solid var(--lp-color-border-interactive-secondary-base);
 
   &.minimal {
     border: 1px solid transparent;
 
     svg {
-      fill: var(--lp-color-border-interactive-secondary);
+      fill: var(--lp-color-border-interactive-secondary-base);
     }
   }
 
@@ -43,13 +43,13 @@
     &:hover,
     &:focus {
       &:not(.basic) {
-        border: 1px solid var(--lp-color-border-interactive-secondary);
+        border: 1px solid var(--lp-color-border-interactive-secondary-base);
       }
 
-      color: var(--lp-color-text-ui-primary);
+      color: var(--lp-color-text-ui-primary-base);
 
       svg {
-        fill: var(--lp-color-text-ui-primary);
+        fill: var(--lp-color-text-ui-primary-base);
       }
     }
 
@@ -60,15 +60,18 @@
 }
 
 .CopyCodeButton:hover {
-  box-shadow: 0 2px 8px -1px hsl(0 0% 0% / 0.04), 0 2px 4px 0 hsl(0 0% 0% / 0.08),
+  box-shadow:
+    0 2px 8px -1px hsl(0 0% 0% / 0.04),
+    0 2px 4px 0 hsl(0 0% 0% / 0.08),
     0 1px 2px 0 hsl(0 0% 0% / 0.14);
   background-color: var(--lp-color-bg-interactive-secondary-hover);
-  color: var(--lp-color-text-ui-primary);
+  color: var(--lp-color-text-ui-primary-base);
 }
 
 .CopyCodeButton:focus {
   outline: 0;
-  box-shadow: 0 0 0 2px var(--lp-color-bg-ui-primary),
+  box-shadow:
+    0 0 0 2px var(--lp-color-bg-ui-primary),
     0 0 0 4px var(--lp-color-shadow-interactive-focus);
   background-color: var(--lp-color-bg-interactive-secondary-focus);
 }
@@ -80,7 +83,7 @@
 
 .CopyCodeButton:active {
   background-color: var(--lp-color-bg-interactive-secondary-active);
-  color: var(--lp-color-text-ui-primary);
+  color: var(--lp-color-text-ui-primary-base);
 }
 
 .CopyCodeButton--icon {

--- a/packages/filter/src/styles/Filter.module.css
+++ b/packages/filter/src/styles/Filter.module.css
@@ -30,12 +30,12 @@
   display: flex;
   align-items: center;
   margin: 0;
-  color: var(--lp-color-text-ui-primary);
-  background-color: var(--lp-color-bg-interactive-secondary);
+  color: var(--lp-color-text-ui-primary-base);
+  background-color: var(--lp-color-bg-interactive-secondary-base);
 }
 
 .appliedButton {
-  color: var(--lp-color-text-ui-primary);
+  color: var(--lp-color-text-ui-primary-base);
   height: 2rem;
   background-color: var(--lp-color-bg-interactive-secondary-hover);
   padding: 0.2rem 0.6rem;
@@ -60,7 +60,8 @@
   &:focus-visible {
     outline: none;
     border-color: var(--lp-color-border-interactive-secondary-focus);
-    box-shadow: 0 0 0 2px var(--lp-color-bg-ui-primary),
+    box-shadow:
+      0 0 0 2px var(--lp-color-bg-ui-primary),
       0 0 0 4px var(--lp-color-shadow-interactive-focus);
   }
 }
@@ -75,7 +76,7 @@
 }
 
 .description {
-  color: var(--lp-color-text-ui-primary);
+  color: var(--lp-color-text-ui-primary-base);
   font-weight: var(--lp-font-weight-medium);
 }
 
@@ -131,7 +132,7 @@
   font-weight: var(--lp-font-weight-medium);
   padding: 1rem;
   width: 100%;
-  border-bottom: 1px solid var(--lp-color-border-interactive-secondary);
+  border-bottom: 1px solid var(--lp-color-border-interactive-secondary-base);
 }
 
 .filterClearButton:active,

--- a/packages/form/src/styles/Form.module.css
+++ b/packages/form/src/styles/Form.module.css
@@ -40,9 +40,9 @@
   font-size: 1.3rem;
   font-family: var(--lp-font-family-base);
   line-height: var(--lp-line-height-300);
-  background-color: var(--lp-color-bg-field);
-  color: var(--lp-color-text-ui-primary);
-  border: 1px solid var(--lp-color-border-field);
+  background-color: var(--lp-color-bg-field-base);
+  color: var(--lp-color-text-ui-primary-base);
+  border: 1px solid var(--lp-color-border-field-base);
   border-radius: var(--lp-border-radius-regular);
   transition: all var(--lp-duration-100) linear;
   height: 3.2rem;
@@ -66,7 +66,9 @@ select.formInput {
   background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M7.41 8.84L12 13.42l4.59-4.58L18 10.25l-6 6-6-6 1.41-1.41z" fill="%23646f7a"/></svg>');
   background-size: 2rem;
   background-repeat: no-repeat;
-  background-position: right 0.4em top 50%, 0 0;
+  background-position:
+    right 0.4em top 50%,
+    0 0;
   padding-right: 2rem;
 }
 
@@ -116,7 +118,7 @@ select.formInput {
   top: -2px;
   left: 10px;
   padding: 0 3px;
-  color: var(--lp-color-text-ui-primary);
+  color: var(--lp-color-text-ui-primary-base);
   opacity: 0;
   pointer-events: none;
   background-color: var(--lp-color-bg-ui-primary);
@@ -198,7 +200,7 @@ select.formInput {
 
 .form .field label,
 .form .field .isInvalid label {
-  color: var(--lp-color-text-ui-primary);
+  color: var(--lp-color-text-ui-primary-base);
 }
 
 .fieldErrorMessage {
@@ -244,7 +246,7 @@ textarea.formInput:read-only {
 }
 
 input.formInput::-webkit-autofill {
-  box-shadow: 0 0 0 50px var(--lp-color-bg-field) inset;
+  box-shadow: 0 0 0 50px var(--lp-color-bg-field-base) inset;
 }
 
 /* Hide the type=search cancel button in Webkit for consistency */
@@ -298,7 +300,7 @@ input[type='checkbox']:disabled {
 
 .suffixContainer {
   display: inline-flex;
-  border: 1px solid var(--lp-color-border-field);
+  border: 1px solid var(--lp-color-border-field-base);
   border-radius: var(--lp-border-radius-regular);
   overflow: hidden;
   transition: all 0.1s linear;
@@ -332,7 +334,7 @@ input[type='checkbox']:disabled {
 
 .iconFieldIcon {
   position: absolute;
-  fill: var(--lp-color-fill-field);
+  fill: var(--lp-color-fill-field-base);
   top: 50%;
   transform: translateY(-50%);
   left: 1rem;
@@ -392,7 +394,7 @@ input[type='checkbox']:disabled {
       --numberField-stepper-padding: 0.4rem;
       --numberField-stepper-border-radius: calc(var(--lp-border-radius-regular) - 0.1rem);
 
-      background-color: var(--lp-color-bg-field);
+      background-color: var(--lp-color-bg-field-base);
       flex: auto;
       display: flex;
       justify-content: center;
@@ -424,7 +426,7 @@ input[type='checkbox']:disabled {
 
       & span:has(svg) {
         width: 100%;
-        color: var(--lp-color-text-ui-primary);
+        color: var(--lp-color-text-ui-primary-base);
       }
     }
   }

--- a/packages/markdown/src/styles/Markdown.module.css
+++ b/packages/markdown/src/styles/Markdown.module.css
@@ -26,7 +26,7 @@
 }
 
 .Markdown a {
-  color: var(--lp-color-text-interactive);
+  color: var(--lp-color-text-interactive-base);
 }
 
 .Markdown a:visited {

--- a/packages/menu/src/styles/Menu.css
+++ b/packages/menu/src/styles/Menu.css
@@ -1,7 +1,7 @@
 .Menu-item {
   display: block;
   position: relative;
-  color: var(--lp-color-text-ui-primary);
+  color: var(--lp-color-text-ui-primary-base);
   background: var(--lp-color-bg-overlay-primary);
   text-decoration: none;
   cursor: pointer;

--- a/packages/modal/src/styles/Modal.module.css
+++ b/packages/modal/src/styles/Modal.module.css
@@ -3,7 +3,7 @@
 :root,
 [data-theme='default'] {
   --lp-component-modal-color-bg-overlay: rgb(40 40 40 / 0.5);
-  --lp-component-modal-color-bg-content: var(--lp-color-white);
+  --lp-component-modal-color-bg-content: var(--lp-color-white-0);
 }
 
 [data-theme='dark'] {
@@ -100,7 +100,7 @@
   padding: 0 1.6rem;
   font-size: 1.5rem;
   line-height: 1.5;
-  color: var(--lp-color-text-ui-primary);
+  color: var(--lp-color-text-ui-primary-base);
 
   > *:first-child {
     margin-top: 0;

--- a/packages/navigation/src/styles/Navigation.module.css
+++ b/packages/navigation/src/styles/Navigation.module.css
@@ -85,7 +85,7 @@
 }
 
 .Nav--primary .NavItem.is-active {
-  color: var(--lp-color-text-ui-primary);
+  color: var(--lp-color-text-ui-primary-base);
   font-weight: var(--lp-font-weight-bold);
 }
 
@@ -106,7 +106,7 @@
 }
 
 .NavItem.is-active .NavItem-name {
-  border-bottom-color: var(--lp-color-text-ui-primary);
+  border-bottom-color: var(--lp-color-text-ui-primary-base);
 }
 
 .NavItem:focus {
@@ -146,12 +146,12 @@
 }
 
 .Nav--primary .NavItem:hover {
-  color: var(--lp-color-text-ui-primary);
+  color: var(--lp-color-text-ui-primary-base);
 }
 
 .Nav--primary a.NavItem:hover,
 .Nav--primary a.NavItem:active {
-  color: var(--lp-color-text-ui-primary);
+  color: var(--lp-color-text-ui-primary-base);
   text-decoration: none;
 }
 
@@ -175,7 +175,7 @@
 }
 
 .Nav--secondary .NavItem.is-active {
-  color: var(--lp-color-text-ui-primary);
+  color: var(--lp-color-text-ui-primary-base);
 }
 
 .Nav--secondary .NavItem.is-active .NavItem-name {

--- a/packages/popover/src/styles/Popover.module.css
+++ b/packages/popover/src/styles/Popover.module.css
@@ -72,7 +72,7 @@
   height: 10px;
   background: inherit;
   background-color: var(--lp-color-bg-overlay-primary);
-  color: var(--lp-color-text-ui-primary);
+  color: var(--lp-color-text-ui-primary-base);
 }
 
 :global(#arrow) {

--- a/packages/progress-bubbles/src/styles/ProgressBubbles.module.css
+++ b/packages/progress-bubbles/src/styles/ProgressBubbles.module.css
@@ -106,13 +106,13 @@ div.ProgressBubbles-icon--current {
 }
 
 .ProgressBubbles-icon svg {
-  fill: var(--lp-color-white);
+  fill: var(--lp-color-white-0);
   height: 1.6rem;
   width: 1.6rem;
 }
 
 .ProgressBubbles-icon--pending svg {
-  fill: var(--lp-color-white);
+  fill: var(--lp-color-white-0);
 }
 
 div.ProgressBubbles-icon--current svg {
@@ -124,7 +124,7 @@ div.ProgressBubbles-icon--pending {
 }
 
 div.ProgressBubbles-icon--warning {
-  background-color: var(--lp-color-white);
+  background-color: var(--lp-color-white-0);
   border: none;
 }
 

--- a/packages/select/src/styles/Select.module.css
+++ b/packages/select/src/styles/Select.module.css
@@ -30,7 +30,7 @@
 
 .option {
   padding: 0.8rem 1.6rem;
-  color: var(--lp-color-text-ui-primary);
+  color: var(--lp-color-text-ui-primary-base);
   cursor: pointer;
   list-style-type: none;
   margin: 0;
@@ -79,8 +79,8 @@
 }
 
 .trigger {
-  background-color: var(--lp-color-bg-field);
-  border: 1px solid var(--lp-color-border-field);
+  background-color: var(--lp-color-bg-field-base);
+  border: 1px solid var(--lp-color-border-field-base);
   position: relative;
   flex-direction: row;
   border-radius: var(--lp-border-radius-regular);
@@ -96,7 +96,9 @@
 
   &.isOpen,
   &.isFocused {
-    box-shadow: inset 0 1px 1px rgb(0 0 0 / 0.075), 0 0 0 3px rgb(0 126 255 / 0.1);
+    box-shadow:
+      inset 0 1px 1px rgb(0 0 0 / 0.075),
+      0 0 0 3px rgb(0 126 255 / 0.1);
     border-color: var(--lp-color-border-field-focus);
   }
 
@@ -119,7 +121,7 @@
 }
 
 .singleValue {
-  color: var(--lp-color-text-ui-primary);
+  color: var(--lp-color-text-ui-primary-base);
   grid-area: 1/1/2/3;
   margin-left: 2px;
   margin-right: 2px;
@@ -197,7 +199,7 @@
   padding-bottom: 2px;
   padding-top: 2px;
   visibility: visible;
-  color: var(--lp-color-text-ui-primary);
+  color: var(--lp-color-text-ui-primary-base);
   flex: 1 1 auto;
   display: inline-grid;
   grid-area: 1/1/2/3;

--- a/packages/slider/src/styles/Slider.module.css
+++ b/packages/slider/src/styles/Slider.module.css
@@ -54,7 +54,7 @@
   background-image: linear-gradient(#fafafa, #f5f5f5);
   border-radius: var(--lp-border-radius-regular);
   border: solid 1px var(--lp-color-border-ui-primary);
-  box-shadow: 0 0 0 1px var(--lp-color-white);
+  box-shadow: 0 0 0 1px var(--lp-color-white-0);
   box-sizing: border-box;
 }
 
@@ -63,7 +63,9 @@
 }
 
 .Slider input[type='range']:focus::-webkit-slider-thumb {
-  box-shadow: 0 0 0 1px var(--lp-color-white), 0 0 0 2px var(--lp-color-blue-500),
+  box-shadow:
+    0 0 0 1px var(--lp-color-white-0),
+    0 0 0 2px var(--lp-color-blue-500),
     0 0 0 5px rgb(0 126 255 / 0.1);
 }
 
@@ -76,7 +78,7 @@
   background-image: linear-gradient(#fafafa, #f5f5f5);
   border-radius: var(--lp-border-radius-regular);
   border: solid 1px var(--lp-color-border-ui-primary);
-  box-shadow: 0 0 0 1px var(--lp-color-white);
+  box-shadow: 0 0 0 1px var(--lp-color-white-0);
   box-sizing: border-box;
 }
 
@@ -85,7 +87,9 @@
 }
 
 .Slider input[type='range']:focus::-moz-range-thumb {
-  box-shadow: 0 0 0 1px var(--lp-color-white), 0 0 0 2px var(--lp-color-blue-500),
+  box-shadow:
+    0 0 0 1px var(--lp-color-white-0),
+    0 0 0 2px var(--lp-color-blue-500),
     0 0 0 5px rgb(0 126 255 / 0.1);
 }
 

--- a/packages/snackbar/src/styles/Snackbar.module.css
+++ b/packages/snackbar/src/styles/Snackbar.module.css
@@ -1,6 +1,6 @@
 .Snackbar {
   background-color: var(--lp-color-bg-feedback-primary);
-  color: var(--lp-color-white);
+  color: var(--lp-color-white-0);
   padding: var(--lp-spacing-500);
   display: inline-flex;
   gap: 1.4rem;
@@ -37,7 +37,7 @@
   font-size: 1.6rem;
   font-weight: var(--lp-font-weight-medium);
   line-height: 1.5;
-  color: var(--lp-color-white);
+  color: var(--lp-color-white-0);
 }
 
 .Snackbar-content {

--- a/packages/split-button/src/styles/SplitButton.css
+++ b/packages/split-button/src/styles/SplitButton.css
@@ -1,5 +1,5 @@
 :root {
-  --lp-component-splitbutton--color-border-primary: var(--lp-color-border-interactive-primary);
+  --lp-component-splitbutton--color-border-primary: var(--lp-color-border-interactive-primary-base);
   --lp-component-splitbutton-color-shadow-focus: 0 0 0 2px
       var(--lp-color-shadow-interactive-primary),
     0 0 0 4px var(--lp-color-shadow-interactive-focus);

--- a/packages/tab-list/src/styles/TabList.module.css
+++ b/packages/tab-list/src/styles/TabList.module.css
@@ -19,17 +19,17 @@
 .TabList-item:focus {
   outline: none;
   background-color: var(--lp-color-bg-interactive-secondary-hover);
-  color: var(--lp-color-text-ui-primary);
+  color: var(--lp-color-text-ui-primary-base);
 }
 
 .TabList-item:hover {
   outline: none;
   background-color: var(--lp-color-bg-interactive-secondary-hover);
-  color: var(--lp-color-text-ui-primary);
+  color: var(--lp-color-text-ui-primary-base);
 }
 
 .TabList-item.is-active {
-  color: var(--lp-color-text-ui-primary);
+  color: var(--lp-color-text-ui-primary-base);
 }
 
 .TabList-item.is-active::after {

--- a/packages/toast/src/styles/Toast.module.css
+++ b/packages/toast/src/styles/Toast.module.css
@@ -1,13 +1,15 @@
 .Toast {
   background-color: var(--lp-color-bg-feedback-primary);
-  color: var(--lp-color-white);
+  color: var(--lp-color-white-0);
   padding: var(--lp-spacing-300) var(--lp-spacing-500);
   display: inline-flex;
   gap: var(--lp-spacing-300);
   box-sizing: border-box;
   width: auto;
   border-radius: 3px;
-  box-shadow: 0 4px 4px 0 rgb(0 0 0 / 0.06), 0 1px 2px 0 rgb(0 0 0 / 0.14),
+  box-shadow:
+    0 4px 4px 0 rgb(0 0 0 / 0.06),
+    0 1px 2px 0 rgb(0 0 0 / 0.14),
     0 0 1px 0 rgb(0 0 0 / 0.25);
 }
 

--- a/packages/toggle/src/styles/Toggle.module.css
+++ b/packages/toggle/src/styles/Toggle.module.css
@@ -8,10 +8,10 @@
   --lp-component-toggle-color-background-disabled: hsl(0 0% 90% / 0.55);
   --lp-component-toggle-color-background-disabled-on: hsl(154 100% 36% / 0.55);
   --lp-component-toggle-color-background-on: var(--lp-color-system-green-700);
-  --lp-component-toggle-color-text: var(--lp-color-text-ui-primary);
+  --lp-component-toggle-color-text: var(--lp-color-text-ui-primary-base);
   --lp-component-toggle-color-text-disabled: var(--lp-color-gray-500);
-  --lp-component-toggle-color-text-disabled-on: var(--lp-color-white);
-  --lp-component-toggle-color-text-on: var(--lp-color-white);
+  --lp-component-toggle-color-text-disabled-on: var(--lp-color-white-0);
+  --lp-component-toggle-color-text-on: var(--lp-color-white-0);
   --lp-component-toggle-height: 2.4rem; /* 24px */
   --lp-component-toggle-transition-timing-function: ease-in-out;
   --lp-component-toggle-transition-duration: var(--lp-duration-100);
@@ -160,7 +160,7 @@
   left: 0;
   width: var(--lp-component-toggle-pin-size);
   height: var(--lp-component-toggle-pin-size);
-  background-color: var(--lp-color-white);
+  background-color: var(--lp-color-white-0);
   border-radius: 50%;
   box-shadow: var(--lp-component-toggle-pin-box-shadow);
   transform: var(--lp-component-toggle-pin-transform);

--- a/packages/tokens/src/color-aliases.yaml
+++ b/packages/tokens/src/color-aliases.yaml
@@ -13,7 +13,7 @@ color:
         value: hsla(45.2, 83.7%, 59.2%, 0.15)
     interactive:
       primary:
-        ' ':
+        base:
           value: '{ color.blue.500.value }'
         active:
           value: '{ color.blue.700.value }'
@@ -22,8 +22,8 @@ color:
         hover:
           value: '{ color.blue.600.value }'
       secondary:
-        ' ':
-          value: '{ color.white. .value }'
+        base:
+          value: '{ color.white.0.value }'
           dark: '{ color.black.200.value }'
         active:
           value: '{ color.gray.200.value }'
@@ -35,7 +35,7 @@ color:
           value: '{ color.gray.100.value }'
           dark: '{ color.gray.700.value }'
       tertiary:
-        ' ':
+        base:
           value: transparent
         active:
           value: '{ color.gray.200.value }'
@@ -47,8 +47,8 @@ color:
           value: '{ color.gray.100.value }'
           dark: '{ color.gray.700.value }'
       destructive:
-        ' ':
-          value: '{ color.white. .value }'
+        base:
+          value: '{ color.white.0.value }'
           dark: '{ color.black.300.value }'
         active:
           value: '{ color.system.red.200.value }'
@@ -64,7 +64,7 @@ color:
         dark: '{ color.gray.800.value }'
     ui:
       primary:
-        value: '{ color.white. .value }'
+        value: '{ color.white.0.value }'
         dark: '{ color.black.300.value }'
       secondary:
         value: '{ color.white.100.value }'
@@ -74,14 +74,14 @@ color:
         dark: '{ color.black.400.value }'
     overlay:
       primary:
-        value: '{ color.white. .value }'
+        value: '{ color.white.0.value }'
         dark: '{ color.black.100.value }'
       secondary:
         value: '{ color.black.300.value }'
         dark: '{ color.black.100.value }'
     field:
-      ' ':
-        value: '{ color.white. .value }'
+      base:
+        value: '{ color.white.0.value }'
         dark: 'rgb(0 0 0 / .15)'
       disabled:
         value: '{ color.gray.100.value }'
@@ -105,7 +105,7 @@ color:
         value: '{ color.system.yellow.700.value }'
         dark: '{ color.system.yellow.500.value }'
     field:
-      ' ':
+      base:
         value: '{ color.gray.300.value }'
         dark: '{ color.gray.500.value }'
       active:
@@ -125,7 +125,7 @@ color:
         value: '{ color.blue.500.value }'
         dark: '{ color.cyan.500.value }'
       primary:
-        ' ':
+        base:
           value: '{ color.blue.500.value }'
         active:
           value: '{ color.blue.700.value }'
@@ -134,7 +134,7 @@ color:
         hover:
           value: '{ color.blue.600.value }'
       secondary:
-        ' ':
+        base:
           value: '{ color.gray.300.value }'
           dark: '{ color.gray.500.value }'
         active:
@@ -174,19 +174,19 @@ color:
         dark: '{ color.system.yellow.500.value }'
     interactive:
       primary:
-        value: '{ color.white. .value }'
+        value: '{ color.white.0.value }'
       destructive:
         value: '{ color.system.red.700.value }'
-        dark: '{ color.white. .value }'
+        dark: '{ color.white.0.value }'
       disabled:
         value: '{ color.gray.700.value }'
         dark: '{ color.gray.500.value }'
     ui:
       primary:
         value: currentvalue
-        dark: '{ color.white. .value }'
+        dark: '{ color.white.0.value }'
     field:
-      ' ':
+      base:
         value: '{ color.gray.600.value }'
         dark: '{ color.gray.400.value }'
 
@@ -196,18 +196,18 @@ color:
         value: '{ color.blue.500.value }'
         dark: '{ color.cyan.500.value }'
       primary:
-        value: '{ color.white. .value }'
+        value: '{ color.white.0.value }'
         dark: '{ color.black.300.value }'
     ui:
       primary:
         value: '{ color.gray.500.value }'
-        dark: '{ color.black. .value }'
+        dark: '{ color.black.0.value }'
 
   text:
     feedback:
-      ' ':
+      base:
         value: '{ color.black.300.value }'
-        dark: '{ color.white. .value }'
+        dark: '{ color.white.0.value }'
       error:
         value: '{ color.system.red.600.value }'
         dark: '{ color.system.red.400.value }'
@@ -222,7 +222,7 @@ color:
         dark: '{ color.blue.400.value }'
     interactive:
       # links
-      ' ':
+      base:
         value: '{ color.blue.600.value }'
         dark: '{ color.cyan.500.value }'
       active:
@@ -230,23 +230,23 @@ color:
         dark: '{ color.purple.400.value }'
 
       primary:
-        value: '{ color.white. .value }'
+        value: '{ color.white.0.value }'
       secondary:
         value: '{ color.gray.600.value }'
         dark: '{ color.gray.400.value }'
       destructive:
         value: '{ color.system.red.700.value }'
-        dark: '{ color.white. .value }'
+        dark: '{ color.white.0.value }'
       disabled:
         value: '{ color.gray.500.value }'
         dark: '{ color.gray.700.value }'
     ui:
       primary:
-        ' ':
+        base:
           value: '{ color.black.300.value }'
-          dark: '{ color.white. .value }'
+          dark: '{ color.white.0.value }'
         inverted:
-          value: '{ color.white. .value }'
+          value: '{ color.white.0.value }'
           dark: '{ color.black.300.value }'
       secondary:
         value: '{ color.gray.800.value }'
@@ -259,10 +259,10 @@ color:
         value: '{ color.gray.800.value }'
         dark: '{ color.gray.100.value }'
       secondary:
-        value: '{ color.white. .value }'
+        value: '{ color.white.0.value }'
         dark: '{ color.black.300.value }'
     field:
-      ' ':
+      base:
         value: '{ color.gray.600.value }'
         dark: '{ color.gray.400.value }'
       disabled:

--- a/packages/tokens/src/color-primitives.yaml
+++ b/packages/tokens/src/color-primitives.yaml
@@ -99,7 +99,7 @@ color:
       value: hsl(0, 0%, 97.3%)
     200:
       value: hsl(0, 0%, 93.7%)
-    ' ':
+    0:
       value: hsl(0, 0%, 100%)
   gray:
     100:
@@ -129,7 +129,7 @@ color:
       value: hsl(0, 0%, 9.8%)
     400:
       value: hsl(0, 0%, 7%)
-    ' ':
+    0:
       value: hsl(0, 0%, 0%)
   system:
     green:

--- a/packages/tokens/stories/theme.stories.tsx
+++ b/packages/tokens/stories/theme.stories.tsx
@@ -23,7 +23,7 @@ export const NestedThemes = {
           <div
             style={{
               backgroundColor: 'var(--lp-color-bg-ui-primary)',
-              color: 'var(--lp-color-text-ui-primary)',
+              color: 'var(--lp-color-text-ui-primary-base)',
               border: '1px solid var(--lp-color-border-ui-primary)',
               padding: 'var(--lp-spacing-300)',
             }}
@@ -35,8 +35,8 @@ export const NestedThemes = {
             <div data-theme={theme === 'default' ? 'dark' : 'default'}>
               <div
                 style={{
-                  backgroundColor: 'var(--lp-color-bg-ui-primary',
-                  color: 'var(--lp-color-text-ui-primary',
+                  backgroundColor: 'var(--lp-color-bg-ui-primary)',
+                  color: 'var(--lp-color-text-ui-primary-base)',
                   border: '1px solid var(--lp-color-border-ui-primary)',
                   marginTop: 'var(--lp-spacing-500)',
                   padding: 'var(--lp-spacing-300)',

--- a/packages/tooltip/src/styles/Tooltip.module.css
+++ b/packages/tooltip/src/styles/Tooltip.module.css
@@ -7,7 +7,7 @@
 
 [data-theme='dark'] {
   --lp-component-popover-color-bg: var(--lp-color-bg-overlay-primary);
-  --lp-component-popover-color-text: var(--lp-color-text-ui-primary);
+  --lp-component-popover-color-text: var(--lp-color-text-ui-primary-base);
   --lp-component-popover-color-border: var(--lp-color-border-ui-secondary);
 }
 


### PR DESCRIPTION
## Summary

Tokens with multiple variants have not used a suffix to denote the `default` state of the token. This makes them difficult to implement in Figma and reference in the `vars` package for Vanilla Extract. For example, now instead of `vars.color.text.ui.primary[' ']` the token can be accessed via `vars.color.text.ui.primary.base` for better DX.