### PR TITLE
feat(icons): add unique id prefix and allow empty path

### DIFF
--- a/.changeset/cuddly-cows-applaud.md
+++ b/.changeset/cuddly-cows-applaud.md
@@ -1,0 +1,5 @@
+---
+'@launchpad-ui/icons': patch
+---
+
+Add unique id prefix and allow empty path

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -152,8 +152,8 @@ Simply run `pnpm generate component` and follow the prompts, and you'll be well 
 
 ### Adding Icons to LaunchPad
 
-- Add the SVG body content into a new symbol entry in the `/src/image/sprite.svg` file in the `@launchpad/icons` package.
-- Add its `id` to the icons array in `/src/types.ts`.
+- Add the SVG body content into a new symbol entry with id `lp-icon-{name}` in the `/src/image/sprite.svg` file in the `@launchpad/icons` package.
+- Add its `id` (minus prefix `lp-icon`) to the icons array in `/src/types.ts`.
 - Run `pnpm storybook` and visit the "Icons" page to ensure your icon was generated properly.
 
 ---

--- a/packages/icons/README.md
+++ b/packages/icons/README.md
@@ -43,3 +43,40 @@ root.render(
   </IconContext.Provider>
 );
 ```
+
+### CORS limitation
+
+Unfortunately SVG sprites [cannot be accessed cross-domain](https://oreillymedia.github.io/Using_SVG/extras/ch10-cors.html). If you are hosting the sprite file in a CDN or different domain you will have to fetch the file and inject it into the document to access the icons directly.
+
+First set the `Icon` context path to an empty string to indicate the symbols are available in the DOM:
+
+```js
+import { IconContext } from '@launchpad-ui/icons';
+import { createRoot } from 'react-dom/client';
+
+const domNode = document.getElementById('root');
+const root = createRoot(domNode);
+
+root.render(
+  <IconContext.Provider value={{ path: '' }}>
+    <App />
+  </IconContext.Provider>
+);
+```
+
+Then fetch and inject the sprite for `Icon` to render icons correctly:
+
+```js
+fetch('https://cdn.example.com/sprite.hash123.svg')
+  .then(async (response) => response.text())
+  .then((data) => {
+    const div = document.createElement('div');
+    div.id = 'lp-icons-sprite';
+    div.style.display = 'none';
+    div.innerHTML = data;
+    document.body.appendChild(div);
+  })
+  .catch((err) => {
+    console.log('Failed to fetch sprite', err);
+  });
+```

--- a/packages/icons/README.md
+++ b/packages/icons/README.md
@@ -67,7 +67,7 @@ root.render(
 Then fetch and inject the sprite for `Icon` to render icons correctly:
 
 ```js
-fetch('https://cdn.example.com/sprite.hash123.svg')
+fetch('https://cdn.example.com/sprite.svg')
   .then(async (response) => response.text())
   .then((data) => {
     const div = document.createElement('div');
@@ -79,4 +79,16 @@ fetch('https://cdn.example.com/sprite.hash123.svg')
   .catch((err) => {
     console.log('Failed to fetch sprite', err);
   });
+```
+
+To minimize latency, you can preload the sprite file accordingly:
+
+```html
+<link
+  rel="preload"
+  href="https://cdn.example.com/sprite.svg"
+  as="fetch"
+  type="image/svg+xml"
+  crossorigin
+/>
 ```

--- a/packages/icons/src/Icon.tsx
+++ b/packages/icons/src/Icon.tsx
@@ -53,7 +53,9 @@ const Icon = ({
       >
         {title && <title id={titleId}>{title}</title>}
         {description && <desc id={descriptionId}>{description}</desc>}
-        <use href={`${spritePath || '/static/sprite.svg'}#${name}`} />
+        <use
+          href={`${spritePath === undefined ? '/static/sprite.svg' : spritePath}#lp-icon-${name}`}
+        />
       </svg>
     </span>
   );

--- a/packages/icons/src/Icon.tsx
+++ b/packages/icons/src/Icon.tsx
@@ -38,7 +38,10 @@ const Icon = ({
   const isAriaHidden = ariaHidden ?? (!ariaLabelledBy && !ariaLabel);
   const titleId = title && `${prefix}-${name}-title`;
   const descriptionId = description && `${prefix}-${name}-description`;
-  const { path: spritePath } = useContext(IconContext);
+
+  const { path: contextPath } = useContext(IconContext);
+  const iconId = `lp-icon-${name}`;
+  const spritePath = contextPath === undefined ? '/static/sprite.svg' : contextPath;
 
   return (
     <span data-test-id={testId} className={classes}>
@@ -53,9 +56,7 @@ const Icon = ({
       >
         {title && <title id={titleId}>{title}</title>}
         {description && <desc id={descriptionId}>{description}</desc>}
-        <use
-          href={`${spritePath === undefined ? '/static/sprite.svg' : spritePath}#lp-icon-${name}`}
-        />
+        <use href={`${spritePath}#${iconId}`} />
       </svg>
     </span>
   );

--- a/packages/icons/src/Icon.tsx
+++ b/packages/icons/src/Icon.tsx
@@ -34,13 +34,13 @@ const Icon = ({
 }: IconProps) => {
   const sizeClass = size ? styles[size] : false;
   const classes = cx(styles.icon, sizeClass, subtle && styles.subtle, `icon-${name}`, className);
-  const uniqueId = `svg-${useId()}`;
+  const prefix = `svg-${useId()}`;
   const isAriaHidden = ariaHidden ?? (!ariaLabelledBy && !ariaLabel);
-  const titleId = title && `${uniqueId}-${name}-title`;
-  const descriptionId = description && `${uniqueId}-${name}-description`;
+  const titleId = title && `${prefix}-${name}-title`;
+  const descriptionId = description && `${prefix}-${name}-description`;
 
-  const { path: contextPath, prefix } = useContext(IconContext);
-  const iconPrefix = prefix === undefined ? 'lp-icon-' : prefix;
+  const { path: contextPath } = useContext(IconContext);
+  const iconId = `lp-icon-${name}`;
   const spritePath = contextPath === undefined ? '/static/sprite.svg' : contextPath;
 
   return (
@@ -56,7 +56,7 @@ const Icon = ({
       >
         {title && <title id={titleId}>{title}</title>}
         {description && <desc id={descriptionId}>{description}</desc>}
-        <use href={`${spritePath}#${iconPrefix}${name}`} />
+        <use href={`${spritePath}#${iconId}`} />
       </svg>
     </span>
   );

--- a/packages/icons/src/Icon.tsx
+++ b/packages/icons/src/Icon.tsx
@@ -34,13 +34,13 @@ const Icon = ({
 }: IconProps) => {
   const sizeClass = size ? styles[size] : false;
   const classes = cx(styles.icon, sizeClass, subtle && styles.subtle, `icon-${name}`, className);
-  const prefix = `svg-${useId()}`;
+  const uniqueId = `svg-${useId()}`;
   const isAriaHidden = ariaHidden ?? (!ariaLabelledBy && !ariaLabel);
-  const titleId = title && `${prefix}-${name}-title`;
-  const descriptionId = description && `${prefix}-${name}-description`;
+  const titleId = title && `${uniqueId}-${name}-title`;
+  const descriptionId = description && `${uniqueId}-${name}-description`;
 
-  const { path: contextPath } = useContext(IconContext);
-  const iconId = `lp-icon-${name}`;
+  const { path: contextPath, prefix } = useContext(IconContext);
+  const iconPrefix = prefix === undefined ? 'lp-icon-' : prefix;
   const spritePath = contextPath === undefined ? '/static/sprite.svg' : contextPath;
 
   return (
@@ -56,7 +56,7 @@ const Icon = ({
       >
         {title && <title id={titleId}>{title}</title>}
         {description && <desc id={descriptionId}>{description}</desc>}
-        <use href={`${spritePath}#${iconId}`} />
+        <use href={`${spritePath}#${iconPrefix}${name}`} />
       </svg>
     </span>
   );

--- a/packages/icons/src/context.ts
+++ b/packages/icons/src/context.ts
@@ -1,10 +1,10 @@
 import { createContext } from 'react';
 
 type IconContextState = {
-  path: string;
+  path?: string;
 };
 
-const IconContext = createContext<IconContextState>({ path: '' });
+const IconContext = createContext<IconContextState>({ path: undefined });
 
 export { IconContext };
 export type { IconContextState };

--- a/packages/icons/src/context.ts
+++ b/packages/icons/src/context.ts
@@ -2,9 +2,10 @@ import { createContext } from 'react';
 
 type IconContextState = {
   path?: string;
+  prefix?: string;
 };
 
-const IconContext = createContext<IconContextState>({ path: undefined });
+const IconContext = createContext<IconContextState>({ path: undefined, prefix: undefined });
 
 export { IconContext };
 export type { IconContextState };

--- a/packages/icons/src/context.ts
+++ b/packages/icons/src/context.ts
@@ -2,10 +2,9 @@ import { createContext } from 'react';
 
 type IconContextState = {
   path?: string;
-  prefix?: string;
 };
 
-const IconContext = createContext<IconContextState>({ path: undefined, prefix: undefined });
+const IconContext = createContext<IconContextState>({ path: undefined });
 
 export { IconContext };
 export type { IconContextState };

--- a/packages/icons/src/img/sprite.svg
+++ b/packages/icons/src/img/sprite.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <defs>
-    <symbol viewBox="0 0 24 24" id="account-clock-outline">
+    <symbol viewBox="0 0 24 24" id="lp-icon-account-clock-outline">
       <g clip-path="url(#Account Clock 1__a)">
         <path
           d="M10.63 14.1a6.998 6.998 0 0 1 9.27-3.47 6.998 6.998 0 0 1 3.47 9.27A6.98 6.98 0 0 1 17 24c-2.7 0-5.17-1.56-6.33-4H1v-2c.06-1.14.84-2.07 2.34-2.82S6.72 14.04 9 14c.57 0 1.11.05 1.63.1ZM9 4c1.12.03 2.06.42 2.81 1.17S12.93 6.86 12.93 8c0 1.14-.37 2.08-1.12 2.83-.75.75-1.69 1.12-2.81 1.12s-2.06-.37-2.81-1.12C5.44 10.08 5.07 9.14 5.07 8c0-1.14.37-2.08 1.12-2.83C6.94 4.42 7.88 4.03 9 4Zm8 18a5 5 0 1 0 0-10 5 5 0 0 0 0 10Zm-1-8h1.5v2.82l2.44 1.41-.75 1.3L16 17.69V14Z"
@@ -12,136 +12,136 @@
         </clipPath>
       </defs>
     </symbol>
-    <symbol viewBox="0 0 24 24" id="add">
+    <symbol viewBox="0 0 24 24" id="lp-icon-add">
       <path d="M0 0h24v24H0z" fill="none" />
       <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z" />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="alert-rhombus">
+    <symbol viewBox="0 0 24 24" id="lp-icon-alert-rhombus">
       <path
         d="M12 2C11.5 2 11 2.19 10.59 2.59L2.59 10.59C1.8 11.37 1.8 12.63 2.59 13.41L10.59 21.41C11.37 22.2 12.63 22.2 13.41 21.41L21.41 13.41C22.2 12.63 22.2 11.37 21.41 10.59L13.41 2.59C13 2.19 12.5 2 12 2M11 7H13V13H11V7M11 15H13V17H11V15Z"
       />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="approval-applied">
+    <symbol viewBox="0 0 24 24" id="lp-icon-approval-applied">
       <path
         fill-rule="evenodd"
         d="M20.56 9.22 23 12l-2.44 2.78.34 3.68-3.61.82-1.89 3.18L12 21l-3.4 1.47-1.89-3.18-3.61-.82.34-3.69L1 12l2.44-2.79-.34-3.68 3.61-.81L8.6 1.54 12 3l3.4-1.46 1.89 3.18 3.61.82-.34 3.68ZM13 10.59l-2-2V7H8v3h1.59l2 2-2 2H8v3h3v-1.59l2-2 .41-.41h1.404a1.75 1.75 0 1 0 0-2H13.41l-.41-.41Z"
         clip-rule="evenodd"
       />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="approval-denied">
+    <symbol viewBox="0 0 24 24" id="lp-icon-approval-denied">
       <path
         fill-rule="evenodd"
         d="M20.56 9.22 23 12l-2.44 2.78.34 3.68-3.61.82-1.89 3.18L12 21l-3.4 1.47-1.89-3.18-3.61-.82.34-3.69L1 12l2.44-2.79-.34-3.68 3.61-.81L8.6 1.54 12 3l3.4-1.46 1.89 3.18 3.61.82-.34 3.68ZM12 10.59 15.59 7 17 8.41 13.41 12 17 15.59 15.59 17 12 13.41 8.41 17 7 15.59 10.59 12 7 8.41 8.41 7 12 10.59Z"
         clip-rule="evenodd"
       />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="approval-pending">
+    <symbol viewBox="0 0 24 24" id="lp-icon-approval-pending">
       <path
         d="m23 12-2.44-2.78.34-3.68-3.61-.82-1.89-3.18L12 3 8.6 1.54 6.71 4.72l-3.61.81.34 3.68L1 12l2.44 2.78-.34 3.69 3.61.82 1.89 3.18L12 21l3.4 1.46 1.89-3.18 3.61-.82-.34-3.68L23 12Zm-10 5h-2v-2h2v2Zm0-4h-2V7h2v6Z"
       />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="approval">
+    <symbol viewBox="0 0 24 24" id="lp-icon-approval">
       <path
         d="M4 22v-6q0-.825.588-1.413Q5.175 14 6 14h12q.825 0 1.413.587Q20 15.175 20 16v6Zm2-4h12v-2H6Zm6-4L7 7q0-2.075 1.463-3.537Q9.925 2 12 2t3.538 1.463Q17 4.925 17 7Zm0-2.8L15 7q0-1.25-.875-2.125T12 4q-1.25 0-2.125.875T9 7Zm0 0Z"
       />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="area-chart">
+    <symbol viewBox="0 0 24 24" id="lp-icon-area-chart">
       <path fill="none" d="M0 0h24v24H0z" />
       <path
         d="M3 13v7h18v-1.5l-9-7L8 17l-5-4zm0-6 4 3 5-7 5 4h4v8.97l-9.4-7.31-3.98 5.48L3 10.44V7z"
       />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="arrow-down-thin">
+    <symbol viewBox="0 0 24 24" id="lp-icon-arrow-down-thin">
       <path
         d="M7.02979 13.92H11.0298V4.99997L13.0398 4.96997V13.92H17.0298L12.0298 18.92L7.02979 13.92Z"
       />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="arrow-drop-down">
+    <symbol viewBox="0 0 24 24" id="lp-icon-arrow-drop-down">
       <path d="M7 10L12 15L17 10H7Z" />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="arrow-left-thin">
+    <symbol viewBox="0 0 24 24" id="lp-icon-arrow-left-thin">
       <path d="M10.0179 17V13H18.9699L19 10.99H10.0179V7L5 12L10.0179 17Z" />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="arrow-right-thin">
+    <symbol viewBox="0 0 24 24" id="lp-icon-arrow-right-thin">
       <path d="M13.9821 7V11H5.03011L5 13.01H13.9821V17L19 12L13.9821 7Z" />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="arrow-right">
+    <symbol viewBox="0 0 24 24" id="lp-icon-arrow-right">
       <path d="M10 17L15 12L10 7V17Z" />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="arrow-up-thin">
+    <symbol viewBox="0 0 24 24" id="lp-icon-arrow-up-thin">
       <path
         d="M7.02979 9.96997H11.0298V18.89L13.0398 18.92V9.96997H17.0298L12.0298 4.96997L7.02979 9.96997Z"
       />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="article">
+    <symbol viewBox="0 0 24 24" id="lp-icon-article">
       <path
         d="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-5 14H7v-2h7v2zm3-4H7v-2h10v2zm0-4H7V7h10v2z"
       />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="border-all">
+    <symbol viewBox="0 0 24 24" id="lp-icon-border-all">
       <path d="M0 0h24v24H0z" fill="none" />
       <path d="M3 3v18h18V3H3zm8 16H5v-6h6v6zm0-8H5V5h6v6zm8 8h-6v-6h6v6zm0-8h-6V5h6v6z" />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="bullhorn">
+    <symbol viewBox="0 0 24 24" id="lp-icon-bullhorn">
       <path
         d="M12 8H4a2 2 0 00-2 2v4a2 2 0 002 2h1v4a1 1 0 001 1h2a1 1 0 001-1v-4h3l5 4V4l-5 4zm9.5 4c0 1.71-.96 3.26-2.5 4V8c1.53.75 2.5 2.3 2.5 4z"
       />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="bullseye-arrow">
+    <symbol viewBox="0 0 24 24" id="lp-icon-bullseye-arrow">
       <path
         d="M12 2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10a10 10 0 0 0-.607-3.393l-1.606 1.606c.138.586.21 1.185.213 1.787a8 8 0 1 1-8-8 8.001 8.001 0 0 1 1.79.21l1.607-1.607A10 10 0 0 0 12 2Zm7 0-4 4v1.5l-2.553 2.553a2 2 0 1 0 1.5 1.5L16.5 9H18l4-4h-3V2Zm-7 4a6 6 0 1 0 6 6h-2a4 4 0 1 1-4-4V6Z"
       />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="bullseye">
+    <symbol viewBox="0 0 24 24" id="lp-icon-bullseye">
       <path
         d="M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10,10 0 0,0 12,2M12,4A8,8 0 0,1 20,12A8,8 0 0,1 12,20A8,8 0 0,1 4,12A8,8 0 0,1 12,4M12,6A6,6 0 0,0 6,12A6,6 0 0,0 12,18A6,6 0 0,0 18,12A6,6 0 0,0 12,6M12,8A4,4 0 0,1 16,12A4,4 0 0,1 12,16A4,4 0 0,1 8,12A4,4 0 0,1 12,8M12,10A2,2 0 0,0 10,12A2,2 0 0,0 12,14A2,2 0 0,0 14,12A2,2 0 0,0 12,10Z"
       />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="calendar-today">
+    <symbol viewBox="0 0 24 24" id="lp-icon-calendar-today">
       <path
         d="M20 3h-1V1h-2v2H7V1H5v2H4c-1.1 0-2 .9-2 2v16c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 18H4V8h16v13z"
       />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="cancel">
+    <symbol viewBox="0 0 24 24" id="lp-icon-cancel">
       <path d="M0 0h24v24H0z" fill="none" />
       <path
         d="M12 2C6.47 2 2 6.47 2 12s4.47 10 10 10 10-4.47 10-10S17.53 2 12 2zm5 13.59L15.59 17 12 13.41 8.41 17 7 15.59 10.59 12 7 8.41 8.41 7 12 10.59 15.59 7 17 8.41 13.41 12 17 15.59z"
       />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="change-history">
+    <symbol viewBox="0 0 24 24" id="lp-icon-change-history">
       <path d="M12 7.77 18.39 18H5.61L12 7.77ZM12 4 2 20h20L12 4Z" />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="chat-bubble-circle">
+    <symbol viewBox="0 0 24 24" id="lp-icon-chat-bubble-circle">
       <path
         fill-rule="evenodd"
         clip-rule="evenodd"
         d="M2 12C2 6.47 6.47 2 12 2s10 4.47 10 10-4.47 10-10 10S2 17.53 2 12Zm5.293-4.707A1 1 0 0 1 8 7h8a1 1 0 0 1 1 1v6a1 1 0 0 1-1 1H9l-2 2V8a1 1 0 0 1 .293-.707Z"
       />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="check-circle-outline">
+    <symbol viewBox="0 0 24 24" id="lp-icon-check-circle-outline">
       <path d="M0 0h24v24H0V0zm0 0h24v24H0V0z" fill="none" />
       <path
         d="M16.59 7.58 10 14.17l-3.59-3.58L5 12l5 5 8-8zM12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
       />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="check-circle">
+    <symbol viewBox="0 0 24 24" id="lp-icon-check-circle">
       <path d="M0 0h24v24H0z" fill="none" />
       <path
         d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
       />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="check">
+    <symbol viewBox="0 0 24 24" id="lp-icon-check">
       <path d="M9 16.17 4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z" />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="chevron-left">
+    <symbol viewBox="0 0 24 24" id="lp-icon-chevron-left">
       <path d="M0 0h24v24H0z" fill="none" />
       <path d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z" />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="chevron-right">
+    <symbol viewBox="0 0 24 24" id="lp-icon-chevron-right">
       <path d="M0 0h24v24H0z" fill="none" />
       <path d="M10 6 8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z" />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="circle-dashed">
+    <symbol viewBox="0 0 24 24" id="lp-icon-circle-dashed">
       <path
         d="M8.9998 0C7.0398 0.18 5.18981 0.95 3.6698 2.2L5.0998 3.74C6.2198 2.84 7.5698 2.26 8.9998 2.06V0ZM2.2598 3.67C0.999805 5.19 0.239805 7.04 0.0498047 9H2.0498C2.2398 7.58 2.7998 6.23 3.6898 5.1L2.2598 3.67ZM0.0598047 11C0.259805 12.96 1.0298 14.81 2.2698 16.33L3.6898 14.9C2.8098 13.77 2.2398 12.42 2.0598 11H0.0598047ZM5.0598 16.37L3.6698 17.74C5.1798 19 7.0398 19.79 8.9998 20V18C7.5798 17.82 6.2298 17.25 5.0998 16.37H5.0598Z"
       />
@@ -149,21 +149,21 @@
         d="M11 0C12.96 0.18 14.81 0.95 16.33 2.2L14.9 3.74C13.78 2.84 12.43 2.26 11 2.06V0ZM17.74 3.67C19 5.19 19.76 7.04 19.95 9H17.95C17.76 7.58 17.2 6.23 16.31 5.1L17.74 3.67ZM19.94 11C19.74 12.96 18.97 14.81 17.73 16.33L16.31 14.9C17.19 13.77 17.76 12.42 17.94 11H19.94ZM14.94 16.37L16.33 17.74C14.82 19 12.96 19.79 11 20V18C12.42 17.82 13.77 17.25 14.9 16.37H14.94Z"
       />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="circle-outline">
+    <symbol viewBox="0 0 24 24" id="lp-icon-circle-outline">
       <path
         d="M12 2C6.47 2 2 6.47 2 12s4.47 10 10 10 10-4.47 10-10S17.53 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
       />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="circle">
+    <symbol viewBox="0 0 24 24" id="lp-icon-circle">
       <path d="M0 0h24v24H0z" fill="none" />
       <path d="M12 2C6.47 2 2 6.47 2 12s4.47 10 10 10 10-4.47 10-10S17.53 2 12 2z" />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="click-metric">
+    <symbol viewBox="0 0 24 24" id="lp-icon-click-metric">
       <path
         d="M5 3h14c1.1 0 2 .9 2 2v14c0 1.1-.9 2-2 2H5c-1.1 0-2-.9-2-2V5c0-1.1.9-2 2-2Zm3.2 5v7.1l2.1-2.1 3.8 3.9L17 14l-3.8-3.9L15.3 8H8.2Z"
       />
     </symbol>
-    <symbol viewBox="0 0 12 12" id="clipboard-copy">
+    <symbol viewBox="0 0 12 12" id="lp-icon-clipboard-copy">
       <path
         fill-rule="evenodd"
         clip-rule="evenodd"
@@ -182,330 +182,330 @@
         d="M12 6.9375C12 7.24816 11.7482 7.5 11.4375 7.5H8.2955L9.21025 8.41475C9.42992 8.63442 9.42992 8.99058 9.21025 9.21025C8.99058 9.42992 8.63442 9.42992 8.41475 9.21025L6.5402 7.33569C6.43471 7.2302 6.375 7.08668 6.375 6.9375C6.375 6.78832 6.43426 6.64524 6.53975 6.53975L8.41475 4.66475C8.63442 4.44508 8.99058 4.44508 9.21025 4.66475C9.42992 4.88442 9.42992 5.24058 9.21025 5.46025L8.2955 6.375H11.4375C11.7482 6.375 12 6.62684 12 6.9375Z"
       />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="clipboard">
+    <symbol viewBox="0 0 24 24" id="lp-icon-clipboard">
       <path
         d="M18.04 11.13c.14 0 .27.06.38.17l1.28 1.28c.22.21.22.56 0 .77l-1 1-2.05-2.05 1-1c.11-.11.25-.17.39-.17Zm-1.97 1.75 2.05 2.05L12.06 21H10v-2.06l6.07-6.06ZM8 18l-2 2H2c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h4.18C6.6.84 7.7 0 9 0c1.3 0 2.4.84 2.82 2H16c1.1 0 2 .9 2 2v4l-2 2V4h-2v2H4V4H2v14h6ZM9 2c-.55 0-1 .45-1 1s.45 1 1 1 1-.45 1-1-.45-1-1-1Z"
       />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="clock-alert-outline">
+    <symbol viewBox="0 0 24 24" id="lp-icon-clock-alert-outline">
       <path
         d="M20 12h2v6h-2v-6Zm0 8h2v2h-2v-2ZM12 2C6.5 2 2 6.5 2 12s4.5 10 10 10c2.3 0 4.3-.8 6-2V10h3.8c-.9-4.6-5-8-9.8-8Zm4.2 14.2L11 13V7h1.5v5.2l4.5 2.7-.8 1.3Z"
       />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="close">
+    <symbol viewBox="0 0 24 24" id="lp-icon-close">
       <path d="M0 0h24v24H0V0z" fill="none" />
       <path
         d="M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12 19 6.41z"
       />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="connection">
+    <symbol viewBox="0 0 24 24" id="lp-icon-connection">
       <path
         d="M18 11h-3.18C14.4 9.84 13.3 9 12 9c-1.3 0-2.4.84-2.82 2H6c-.33 0-2-.1-2-2V8c0-1.83 1.54-2 2-2h10.18C16.6 7.16 17.7 8 19 8a3 3 0 0 0 0-6c-1.3 0-2.4.84-2.82 2H6C4.39 4 2 5.06 2 8v1c0 2.94 2.39 4 4 4h3.18c.42 1.16 1.52 2 2.82 2 1.3 0 2.4-.84 2.82-2H18c.33 0 2 .1 2 2v1c0 1.83-1.54 2-2 2H7.82C7.4 16.84 6.3 16 5 16a3 3 0 0 0 0 6c1.3 0 2.4-.84 2.82-2H18c1.61 0 4-1.07 4-4v-1c0-2.93-2.39-4-4-4Zm1-7a1 1 0 1 1 0 2 1 1 0 0 1 0-2ZM5 20a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"
       />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="contact-page">
+    <symbol viewBox="0 0 24 24" id="lp-icon-contact-page">
       <path
         d="M14 2H6C4.9 2 4 2.9 4 4V20C4 21.1 4.9 22 6 22H18C19.1 22 20 21.1 20 20V8L14 2ZM12 10C13.1 10 14 10.9 14 12C14 13.1 13.1 14 12 14C10.9 14 10 13.1 10 12C10 10.9 10.9 10 12 10ZM16 18H8V17.43C8 16.62 8.48 15.9 9.22 15.58C10.07 15.21 11.01 15 12 15C12.99 15 13.93 15.21 14.78 15.58C15.52 15.9 16 16.62 16 17.43V18Z"
       />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="content-copy">
+    <symbol viewBox="0 0 24 24" id="lp-icon-content-copy">
       <path d="M0 0h24v24H0z" fill="none" />
       <path
         d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
       />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="credit-card">
+    <symbol viewBox="0 0 24 24" id="lp-icon-credit-card">
       <path
         d="M20 4H4c-1.11 0-1.99.89-1.99 2L2 18c0 1.11.89 2 2 2h16c1.11 0 2-.89 2-2V6c0-1.11-.89-2-2-2zm0 14H4v-6h16v6zm0-10H4V6h16v2z"
       />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="custom-metric">
+    <symbol viewBox="0 0 24 24" id="lp-icon-custom-metric">
       <path
         fill-rule="evenodd"
         d="M4 4a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V6a2 2 0 0 0-2-2H4Zm5.59 11.59L11 14.17 8.83 12 11 9.83 9.59 8.41 6 12l3.59 3.59ZM13 14.17l1.41 1.42L18 12l-3.59-3.59L13 9.83 15.17 12 13 14.17Z"
         clip-rule="evenodd"
       />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="dark-mode">
+    <symbol viewBox="0 0 24 24" id="lp-icon-dark-mode">
       <path
         d="M12 21Q8.25 21 5.625 18.375Q3 15.75 3 12Q3 8.25 5.625 5.625Q8.25 3 12 3Q12.35 3 12.688 3.025Q13.025 3.05 13.35 3.1Q12.325 3.825 11.713 4.987Q11.1 6.15 11.1 7.5Q11.1 9.75 12.675 11.325Q14.25 12.9 16.5 12.9Q17.875 12.9 19.025 12.287Q20.175 11.675 20.9 10.65Q20.95 10.975 20.975 11.312Q21 11.65 21 12Q21 15.75 18.375 18.375Q15.75 21 12 21ZM12 19Q14.2 19 15.95 17.788Q17.7 16.575 18.5 14.625Q18 14.75 17.5 14.825Q17 14.9 16.5 14.9Q13.425 14.9 11.262 12.738Q9.1 10.575 9.1 7.5Q9.1 7 9.175 6.5Q9.25 6 9.375 5.5Q7.425 6.3 6.213 8.05Q5 9.8 5 12Q5 14.9 7.05 16.95Q9.1 19 12 19ZM11.75 12.25Q11.75 12.25 11.75 12.25Q11.75 12.25 11.75 12.25Q11.75 12.25 11.75 12.25Q11.75 12.25 11.75 12.25Q11.75 12.25 11.75 12.25Q11.75 12.25 11.75 12.25Q11.75 12.25 11.75 12.25Q11.75 12.25 11.75 12.25Q11.75 12.25 11.75 12.25Q11.75 12.25 11.75 12.25Q11.75 12.25 11.75 12.25Q11.75 12.25 11.75 12.25Z"
       />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="delete">
+    <symbol viewBox="0 0 24 24" id="lp-icon-delete">
       <path d="M0 0h24v24H0z" fill="none" />
       <path d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z" />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="download">
+    <symbol viewBox="0 0 24 24" id="lp-icon-download">
       <path d="M5 20h14v-2H5v2zM19 9h-4V3H9v6H5l7 7 7-7z" />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="edit">
+    <symbol viewBox="0 0 24 24" id="lp-icon-edit">
       <path
         d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04a.996.996 0 0 0 0-1.41l-2.34-2.34a.996.996 0 0 0-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"
       />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="equal-circle">
+    <symbol viewBox="0 0 24 24" id="lp-icon-equal-circle">
       <path
         fill-rule="evenodd"
         clip-rule="evenodd"
         d="M2 12C2 6.47 6.47 2 12 2s10 4.47 10 10-4.47 10-10 10S2 17.53 2 12Zm5-3.5v2h10v-2H7Zm0 5v2h10v-2H7Z"
       />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="error-circle">
+    <symbol viewBox="0 0 24 24" id="lp-icon-error-circle">
       <path
         d="M12 2C6.48 2 2 6.48 2 12C2 17.52 6.48 22 12 22C17.52 22 22 17.52 22 12C22 6.48 17.52 2 12 2ZM17 13.5H7V10.5H17V13.5Z"
       />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="event-busy">
+    <symbol viewBox="0 0 24 24" id="lp-icon-event-busy">
       <path
         d="M19 20H5V9h14m0-5h-1V2h-2v2H8V2H6v2H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V6a2 2 0 0 0-2-2ZM9.31 18l2.44-2.44L14.19 18l1.06-1.06-2.44-2.44 2.44-2.44L14.19 11l-2.44 2.44L9.31 11l-1.06 1.06 2.44 2.44-2.44 2.44L9.31 18Z"
       />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="expand-less">
+    <symbol viewBox="0 0 24 24" id="lp-icon-expand-less">
       <path d="M0 0h24v24H0z" fill="none" />
       <path d="m12 8-6 6 1.41 1.41L12 10.83l4.59 4.58L18 14z" />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="expand-more">
+    <symbol viewBox="0 0 24 24" id="lp-icon-expand-more">
       <path d="M0 0h24v24H0z" fill="none" />
       <path d="M16.59 8.59 12 13.17 7.41 8.59 6 10l6 6 6-6z" />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="extension">
+    <symbol viewBox="0 0 24 24" id="lp-icon-extension">
       <path d="M0 0h24v24H0z" fill="none" />
       <path
         d="M20.5 11H19V7c0-1.1-.9-2-2-2h-4V3.5a2.5 2.5 0 0 0-5 0V5H4c-1.1 0-1.99.9-1.99 2v3.8H3.5c1.49 0 2.7 1.21 2.7 2.7s-1.21 2.7-2.7 2.7H2V20c0 1.1.9 2 2 2h3.8v-1.5c0-1.49 1.21-2.7 2.7-2.7 1.49 0 2.7 1.21 2.7 2.7V22H17c1.1 0 2-.9 2-2v-4h1.5a2.5 2.5 0 0 0 0-5z"
       />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="file-document-edit-circle">
+    <symbol viewBox="0 0 24 24" id="lp-icon-file-document-edit-circle">
       <path
         fill-rule="evenodd"
         clip-rule="evenodd"
         d="M12 22a10 10 0 1 0 0-20 10 10 0 0 0 0 20ZM7.46 7.143C7.46 6.508 7.969 6 8.602 6h4.572l3.428 3.429v1.194l-1.09 1.09h-6.91v1.145h5.767L13.225 14H8.602v1.143h3.48l-1.193 1.194v1.092H8.602a1.142 1.142 0 0 1-1.142-1.143V7.142ZM15.745 10l-3.143-3.143V10h3.143Zm.717 2.379a.32.32 0 0 1 .226-.093c.082 0 .162.03.222.093l.742.742a.315.315 0 0 1 0 .448l-.583.581-1.19-1.19.583-.581Zm-4.43 4.43 3.51-3.513 1.19 1.19L13.223 18h-1.19v-1.191Z"
       />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="filter-alt">
+    <symbol viewBox="0 0 24 24" id="lp-icon-filter-alt">
       <path d="M0 0h24m0 24H0" fill="none" />
       <path
         d="M4.25 5.61C6.27 8.2 10 13 10 13v6c0 .55.45 1 1 1h2c.55 0 1-.45 1-1v-6s3.72-4.8 5.74-7.39A.998.998 0 0 0 18.95 4H5.04c-.83 0-1.3.95-.79 1.61z"
       />
       <path d="M0 0h24v24H0V0z" fill="none" />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="filter-tune">
+    <symbol viewBox="0 0 24 24" id="lp-icon-filter-tune">
       <path
         d="M0 14V16H6V14H0ZM0 2V4H10V2H0ZM10 18V16H18V14H10V12H8V18H10ZM4 6V8H0V10H4V12H6V6H4ZM18 10V8H8V10H18ZM12 6H14V4H18V2H14V0H12V6Z"
       />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="flag-circle">
+    <symbol viewBox="0 0 24 24" id="lp-icon-flag-circle">
       <path
         fill-rule="evenodd"
         clip-rule="evenodd"
         d="M2 12C2 6.47 6.47 2 12 2s10 4.47 10 10-4.47 10-10 10S2 17.53 2 12Zm11.4-5 .24 1.294H17v6.47h-4.2l-.24-1.293H9.2V18H8V7h5.4Z"
       />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="flag">
+    <symbol viewBox="0 0 24 24" id="lp-icon-flag">
       <path d="M0 0h24v24H0z" fill="none" />
       <path d="M14.4 6 14 4H5v17h2v-7h5.6l.4 2h7V6z" />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="forward">
+    <symbol viewBox="0 0 24 24" id="lp-icon-forward">
       <path d="M0 0h24v24H0z" fill="none" />
       <path d="M12 8V4l8 8-8 8v-4H4V8z" />
     </symbol>
-    <symbol viewBox="0 0 16 16" id="grid-3x3">
+    <symbol viewBox="0 0 16 16" id="lp-icon-grid-3x3">
       <path
         d="M0 4H4V0H0V4ZM6 16H10V12H6V16ZM0 16H4V12H0V16ZM0 10H4V6H0V10ZM6 10H10V6H6V10ZM12 0V4H16V0H12ZM6 4H10V0H6V4ZM12 10H16V6H12V10ZM12 16H16V12H12V16Z"
       />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="group">
+    <symbol viewBox="0 0 24 24" id="lp-icon-group">
       <path fill="none" d="M0 0h24v24H0z" />
       <path
         d="M16 11c1.66 0 2.99-1.34 2.99-3S17.66 5 16 5c-1.66 0-3 1.34-3 3s1.34 3 3 3zm-8 0c1.66 0 2.99-1.34 2.99-3S9.66 5 8 5C6.34 5 5 6.34 5 8s1.34 3 3 3zm0 2c-2.33 0-7 1.17-7 3.5V19h14v-2.5c0-2.33-4.67-3.5-7-3.5zm8 0c-.29 0-.62.02-.97.05 1.16.84 1.97 1.97 1.97 3.45V19h6v-2.5c0-2.33-4.67-3.5-7-3.5z"
       />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="half-circle">
+    <symbol viewBox="0 0 24 24" id="lp-icon-half-circle">
       <path
         d="M2 12c0 5.5 4.5 10 10 10s10-4.5 10-10S17.5 2 12 2 2 6.5 2 12zm2 0c0-4.4 3.6-8 8-8s8 3.6 8 8H4z"
       />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="hamburger-menu">
+    <symbol viewBox="0 0 24 24" id="lp-icon-hamburger-menu">
       <path d="M0 0h24v24H0z" fill="none" />
       <path d="M3 18h18v-2H3v2zm0-5h18v-2H3v2zm0-7v2h18V6H3z" />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="help">
+    <symbol viewBox="0 0 24 24" id="lp-icon-help">
       <path d="M0 0h24v24H0z" fill="none" />
       <path
         d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 17h-2v-2h2v2zm2.07-7.75-.9.92C13.45 12.9 13 13.5 13 15h-2v-.5c0-1.1.45-2.1 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41 0-1.1-.9-2-2-2s-2 .9-2 2H8c0-2.21 1.79-4 4-4s4 1.79 4 4c0 .88-.36 1.68-.93 2.25z"
       />
     </symbol>
-    <symbol viewBox="0 96 960 960" id="home">
+    <symbol viewBox="0 96 960 960" id="lp-icon-home">
       <path
         d="M240 856h120V616h240v240h120V496L480 316 240 496v360Zm0 80q-33 0-56.5-23.5T160 856V496q0-19 8.5-36t23.5-28l240-180q11-8 23-12t25-4q13 0 25 4t23 12l240 180q15 11 23.5 28t8.5 36v360q0 33-23.5 56.5T720 936H520V696h-80v240H240Zm240-350Z"
       />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="horizontal-rule">
+    <symbol viewBox="0 0 24 24" id="lp-icon-horizontal-rule">
       <path fill-rule="evenodd" d="M4 11h16v2H4z" />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="inbox">
+    <symbol viewBox="0 0 24 24" id="lp-icon-inbox">
       <path
         d="M5 21q-.825 0-1.413-.587Q3 19.825 3 19V5q0-.825.587-1.413Q4.175 3 5 3h14q.825 0 1.413.587Q21 4.175 21 5v14q0 .825-.587 1.413Q19.825 21 19 21Zm7-5q.95 0 1.725-.55Q14.5 14.9 14.8 14H19V5H5v9h4.2q.3.9 1.075 1.45Q11.05 16 12 16Z"
       />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="info">
+    <symbol viewBox="0 0 24 24" id="lp-icon-info">
       <path d="M13.5 9h-3V6h3v3Zm0 8.5h-3v-6h3v6ZM12 2a10 10 0 1 0 0 20 10 10 0 0 0 0-20Z" />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="keyboard-double-arrow-left">
+    <symbol viewBox="0 0 24 24" id="lp-icon-keyboard-double-arrow-left">
       <path fill="none" d="M0 0h24v24H0z" />
       <path d="M17.59 18 19 16.59 14.42 12 19 7.41 17.59 6l-6 6z" />
       <path d="m11 18 1.41-1.41L7.83 12l4.58-4.59L11 6l-6 6z" />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="keyboard-double-arrow-right">
+    <symbol viewBox="0 0 24 24" id="lp-icon-keyboard-double-arrow-right">
       <path fill="none" d="M0 0h24v24H0z" />
       <path d="M6.41 6 5 7.41 9.58 12 5 16.59 6.41 18l6-6z" />
       <path d="m13 6-1.41 1.41L16.17 12l-4.58 4.59L13 18l6-6z" />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="language">
+    <symbol viewBox="0 0 24 24" id="lp-icon-language">
       <path d="M0 0h24v24H0z" fill="none" />
       <path
         d="M11.99 2C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zm6.93 6h-2.95c-.32-1.25-.78-2.45-1.38-3.56 1.84.63 3.37 1.91 4.33 3.56zM12 4.04c.83 1.2 1.48 2.53 1.91 3.96h-3.82c.43-1.43 1.08-2.76 1.91-3.96zM4.26 14C4.1 13.36 4 12.69 4 12s.1-1.36.26-2h3.38c-.08.66-.14 1.32-.14 2 0 .68.06 1.34.14 2H4.26zm.82 2h2.95c.32 1.25.78 2.45 1.38 3.56-1.84-.63-3.37-1.9-4.33-3.56zm2.95-8H5.08c.96-1.66 2.49-2.93 4.33-3.56C8.81 5.55 8.35 6.75 8.03 8zM12 19.96c-.83-1.2-1.48-2.53-1.91-3.96h3.82c-.43 1.43-1.08 2.76-1.91 3.96zM14.34 14H9.66c-.09-.66-.16-1.32-.16-2 0-.68.07-1.35.16-2h4.68c.09.65.16 1.32.16 2 0 .68-.07 1.34-.16 2zm.25 5.56c.6-1.11 1.06-2.31 1.38-3.56h2.95c-.96 1.65-2.49 2.93-4.33 3.56zM16.36 14c.08-.66.14-1.32.14-2 0-.68-.06-1.34-.14-2h3.38c.16.64.26 1.31.26 2s-.1 1.36-.26 2h-3.38z"
       />
     </symbol>
-    <symbol viewBox="0 96 960 960" id="left-panel-close">
+    <symbol viewBox="0 96 960 960" id="lp-icon-left-panel-close">
       <path
         d="M660 688V464q0-14-12-19t-22 5l-98 98q-12 12-12 28t12 28l98 98q10 10 22 5t12-19ZM200 936q-33 0-56.5-23.5T120 856V296q0-33 23.5-56.5T200 216h560q33 0 56.5 23.5T840 296v560q0 33-23.5 56.5T760 936H200Zm120-80V296H200v560h120Zm80 0h360V296H400v560Zm-80 0H200h120Z"
       />
     </symbol>
-    <symbol viewBox="0 96 960 960" id="left-panel-open">
+    <symbol viewBox="0 96 960 960" id="lp-icon-left-panel-open">
       <path
         d="M500 464v224q0 14 12 19t22-5l98-98q12-12 12-28t-12-28l-98-98q-10-10-22-5t-12 19ZM200 936q-33 0-56.5-23.5T120 856V296q0-33 23.5-56.5T200 216h560q33 0 56.5 23.5T840 296v560q0 33-23.5 56.5T760 936H200Zm120-80V296H200v560h120Zm80 0h360V296H400v560Zm-80 0H200h120Z"
       />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="light-mode">
+    <symbol viewBox="0 0 24 24" id="lp-icon-light-mode">
       <path
         d="M12 15Q13.25 15 14.125 14.125Q15 13.25 15 12Q15 10.75 14.125 9.875Q13.25 9 12 9Q10.75 9 9.875 9.875Q9 10.75 9 12Q9 13.25 9.875 14.125Q10.75 15 12 15ZM12 17Q9.925 17 8.463 15.537Q7 14.075 7 12Q7 9.925 8.463 8.462Q9.925 7 12 7Q14.075 7 15.538 8.462Q17 9.925 17 12Q17 14.075 15.538 15.537Q14.075 17 12 17ZM2 13Q1.575 13 1.288 12.712Q1 12.425 1 12Q1 11.575 1.288 11.287Q1.575 11 2 11H4Q4.425 11 4.713 11.287Q5 11.575 5 12Q5 12.425 4.713 12.712Q4.425 13 4 13ZM20 13Q19.575 13 19.288 12.712Q19 12.425 19 12Q19 11.575 19.288 11.287Q19.575 11 20 11H22Q22.425 11 22.712 11.287Q23 11.575 23 12Q23 12.425 22.712 12.712Q22.425 13 22 13ZM12 5Q11.575 5 11.288 4.712Q11 4.425 11 4V2Q11 1.575 11.288 1.287Q11.575 1 12 1Q12.425 1 12.713 1.287Q13 1.575 13 2V4Q13 4.425 12.713 4.712Q12.425 5 12 5ZM12 23Q11.575 23 11.288 22.712Q11 22.425 11 22V20Q11 19.575 11.288 19.288Q11.575 19 12 19Q12.425 19 12.713 19.288Q13 19.575 13 20V22Q13 22.425 12.713 22.712Q12.425 23 12 23ZM5.65 7.05 4.575 6Q4.275 5.725 4.287 5.3Q4.3 4.875 4.575 4.575Q4.875 4.275 5.3 4.275Q5.725 4.275 6 4.575L7.05 5.65Q7.325 5.95 7.325 6.35Q7.325 6.75 7.05 7.05Q6.775 7.35 6.363 7.337Q5.95 7.325 5.65 7.05ZM18 19.425 16.95 18.35Q16.675 18.05 16.675 17.638Q16.675 17.225 16.95 16.95Q17.225 16.65 17.638 16.663Q18.05 16.675 18.35 16.95L19.425 18Q19.725 18.275 19.713 18.7Q19.7 19.125 19.425 19.425Q19.125 19.725 18.7 19.725Q18.275 19.725 18 19.425ZM16.95 7.05Q16.65 6.775 16.663 6.362Q16.675 5.95 16.95 5.65L18 4.575Q18.275 4.275 18.7 4.287Q19.125 4.3 19.425 4.575Q19.725 4.875 19.725 5.3Q19.725 5.725 19.425 6L18.35 7.05Q18.05 7.325 17.65 7.325Q17.25 7.325 16.95 7.05ZM4.575 19.425Q4.275 19.125 4.275 18.7Q4.275 18.275 4.575 18L5.65 16.95Q5.95 16.675 6.363 16.675Q6.775 16.675 7.05 16.95Q7.35 17.225 7.338 17.638Q7.325 18.05 7.05 18.35L6 19.425Q5.725 19.725 5.3 19.712Q4.875 19.7 4.575 19.425ZM12 12Q12 12 12 12Q12 12 12 12Q12 12 12 12Q12 12 12 12Q12 12 12 12Q12 12 12 12Q12 12 12 12Q12 12 12 12Z"
       />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="link">
+    <symbol viewBox="0 0 24 24" id="lp-icon-link">
       <path d="M0 0h24v24H0z" fill="none" />
       <path
         d="M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z"
       />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="lock">
+    <symbol viewBox="0 0 24 24" id="lp-icon-lock">
       <path d="M0 0h24v24H0z" fill="none" />
       <path
         d="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2zm-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2zm3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1 1.71 0 3.1 1.39 3.1 3.1v2z"
       />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="merge">
+    <symbol viewBox="0 0 24 24" id="lp-icon-merge">
       <path
         d="m8 17 4-4h3.2c.4 1.2 1.5 2 2.8 2 1.7 0 3-1.3 3-3s-1.3-3-3-3c-1.3 0-2.4.8-2.8 2H12L8 7V3H3v5h3l4.2 4L6 16H3v5h5v-4Z"
       />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="minus-circle">
+    <symbol viewBox="0 0 24 24" id="lp-icon-minus-circle">
       <path
         fill-rule="evenodd"
         clip-rule="evenodd"
         d="M2 12C2 6.47 6.47 2 12 2s10 4.47 10 10-4.47 10-10 10S2 17.53 2 12Zm5 1h10v-2H7v2Z"
       />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="more-horiz">
+    <symbol viewBox="0 0 24 24" id="lp-icon-more-horiz">
       <path
         d="M6 10c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm12 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm-6 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"
       />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="more-vert">
+    <symbol viewBox="0 0 24 24" id="lp-icon-more-vert">
       <path d="M0 0h24v24H0z" fill="none" />
       <path
         d="M12 8c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"
       />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="notifications">
+    <symbol viewBox="0 0 24 24" id="lp-icon-notifications">
       <path
         d="M12 22c1.1 0 2-.9 2-2h-4a2 2 0 0 0 2 2zm6-6v-5c0-3.07-1.64-5.64-4.5-6.32V4c0-.83-.67-1.5-1.5-1.5s-1.5.67-1.5 1.5v.68C7.63 5.36 6 7.92 6 11v5l-2 2v1h16v-1l-2-2z"
       />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="open-in-new">
+    <symbol viewBox="0 0 24 24" id="lp-icon-open-in-new">
       <path d="M0 0h24v24H0z" fill="none" />
       <path
         d="M19 19H5V5h7V3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14c1.1 0 2-.9 2-2v-7h-2v7zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z"
       />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="pause">
+    <symbol viewBox="0 0 24 24" id="lp-icon-pause">
       <path d="M0 0h24v24H0z" fill="none" />
       <path d="M6 19h4V5H6v14zm8-14v14h4V5h-4z" />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="person-add">
+    <symbol viewBox="0 0 24 24" id="lp-icon-person-add">
       <path
         d="M15 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4Zm-9-2V7H4v3H1v2h3v3h2v-3h3v-2H6Zm9 4c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4Z"
       />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="person-off">
+    <symbol viewBox="0 0 24 24" id="lp-icon-person-off">
       <path
         d="M8.65 5.82a3.999 3.999 0 1 1 5.53 5.53L8.65 5.82ZM20 17.17c-.02-1.1-.63-2.11-1.61-2.62-.54-.28-1.13-.54-1.77-.76L20 17.17Zm1.19 4.02L2.81 2.81 1.39 4.22l8.89 8.89c-1.81.23-3.39.79-4.67 1.45A2.97 2.97 0 0 0 4 17.22V20h13.17l2.61 2.61 1.41-1.42Z"
       />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="person-remove-alt">
+    <symbol viewBox="0 0 24 24" id="lp-icon-person-remove-alt">
       <path
         d="M15 14c-2.67 0-8 1.33-8 4v2h16v-2c0-2.67-5.33-4-8-4ZM1 10v2h7v-2H1Zm14 2a4 4 0 1 0 0-8 4 4 0 0 0 0 8Z"
       />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="person">
+    <symbol viewBox="0 0 24 24" id="lp-icon-person">
       <path d="M0 0h24v24H0z" fill="none" />
       <path
         d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z"
       />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="pie-chart">
+    <symbol viewBox="0 0 24 24" id="lp-icon-pie-chart">
       <path
         d="M11 2v20c-5.07-.5-9-4.79-9-10s3.93-9.5 9-10zm2.03 0v8.99H22c-.47-4.74-4.24-8.52-8.97-8.99zm0 11.01V22c4.74-.47 8.5-4.25 8.97-8.99h-8.97z"
       />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="play-arrow">
+    <symbol viewBox="0 0 24 24" id="lp-icon-play-arrow">
       <path d="M8 5v14l11-7L8 5Z" />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="play-circle">
+    <symbol viewBox="0 0 24 24" id="lp-icon-play-circle">
       <path fill="none" d="M0 0h24v24H0z" />
       <path
         d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zM9.5 16.5v-9l7 4.5-7 4.5z"
       />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="plus-circle-fill">
+    <symbol viewBox="0 0 24 24" id="lp-icon-plus-circle-fill">
       <path d="M17 13h-4v4h-2v-4H7v-2h4V7h2v4h4m-5-9a10 10 0 1 0 0 20 10 10 0 0 0 0-20Z" />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="plus-circle-outline">
+    <symbol viewBox="0 0 24 24" id="lp-icon-plus-circle-outline">
       <path
         d="M12 20c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8Zm0-18a10 10 0 1 0 0 20 10 10 0 0 0 0-20Zm1 5h-2v4H7v2h4v4h2v-4h4v-2h-4V7Z"
       />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="power">
+    <symbol viewBox="0 0 24 24" id="lp-icon-power">
       <path fill="none" d="M0 0h24v24H0z" />
       <path
         d="M16.01 7 16 3h-2v4h-4V3H8v4h-.01C7 6.99 6 7.99 6 8.99v5.49L9.5 18v3h5v-3l3.5-3.51v-5.5c0-1-1-2-1.99-1.99z"
       />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="preview">
+    <symbol viewBox="0 0 24 24" id="lp-icon-preview">
       <path fill="none" d="M0 0h24v24H0z" />
       <path
         d="M19 3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14c1.1 0 2-.9 2-2V5a2 2 0 0 0-2-2zm0 16H5V7h14v12zm-5.5-6c0 .83-.67 1.5-1.5 1.5s-1.5-.67-1.5-1.5.67-1.5 1.5-1.5 1.5.67 1.5 1.5zM12 9c-2.73 0-5.06 1.66-6 4 .94 2.34 3.27 4 6 4s5.06-1.66 6-4c-.94-2.34-3.27-4-6-4zm0 6.5a2.5 2.5 0 0 1 0-5 2.5 2.5 0 0 1 0 5z"
       />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="progress-check">
+    <symbol viewBox="0 0 24 24" id="lp-icon-progress-check">
       <path
         d="M13 2.03v2.02c4.39.54 7.5 4.53 6.96 8.92-.46 3.64-3.32 6.53-6.96 6.96v2c5.5-.55 9.5-5.43 8.95-10.93-.45-4.75-4.22-8.5-8.95-8.97zm-2 .03c-1.95.19-3.81.94-5.33 2.2L7.1 5.74c1.12-.9 2.47-1.48 3.9-1.68v-2zM4.26 5.67A9.885 9.885 0 002.05 11h2c.19-1.42.75-2.77 1.64-3.9L4.26 5.67zM15.5 8.5l-4.88 4.88-2.12-2.12-1.06 1.06 3.18 3.18 5.94-5.94L15.5 8.5zM2.06 13c.2 1.96.97 3.81 2.21 5.33l1.42-1.43A8.002 8.002 0 014.06 13h-2zm5.04 5.37l-1.43 1.37A9.994 9.994 0 0011 22v-2a8.002 8.002 0 01-3.9-1.63z"
       />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="pulse-active">
+    <symbol viewBox="0 0 24 24" id="lp-icon-pulse-active">
       <path
         d="M2 11.7C2.1 6.3 6.6 2 12 2s9.8 4.3 10 9.7h-8.9c-.5 0-.9.3-1 .6l-.7 1.6-2.2-5.8c-.4-1-1.7-.9-2.1 0l-1.4 3.6H2zm11.5 1.7-1 2.5c-.4 1.1-1.7 1-2.1 0l-2.3-5.8L7 12.6c-.2.4-.5.7-1 .7H2.1C2.8 18.2 6.9 22 12 22c5.1 0 9.2-3.8 9.9-8.6h-8.4z"
       />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="quick-start">
+    <symbol viewBox="0 0 24 24" id="lp-icon-quick-start">
       <path d="M13 2h-2v3H3l2.5 5L3 15h8v7h2v-7h5l3-5-3-5h-5V2z" />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="radio-button-checked">
+    <symbol viewBox="0 0 24 24" id="lp-icon-radio-button-checked">
       <path fill="none" d="M0 0h24v24H0z" />
       <path
         d="M12 7c-2.76 0-5 2.24-5 5s2.24 5 5 5 5-2.24 5-5-2.24-5-5-5zm0-5C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
       />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="release-path">
+    <symbol viewBox="0 0 24 24" id="lp-icon-release-path">
       <path d="M6 11H11V13H6V11Z" />
       <path d="M14 11H19V13H14V11Z" />
       <path
@@ -520,94 +520,94 @@
         d="M22 10.5L19 10.5V13.5H22V10.5ZM19 9.5C18.4477 9.5 18 9.94772 18 10.5V13.5C18 14.0523 18.4477 14.5 19 14.5H22C22.5523 14.5 23 14.0523 23 13.5V10.5C23 9.94772 22.5523 9.5 22 9.5H19Z"
       />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="remove">
+    <symbol viewBox="0 0 24 24" id="lp-icon-remove">
       <path d="M19 13H5v-2h14v2Z" />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="robot">
+    <symbol viewBox="0 0 24 24" id="lp-icon-robot">
       <path
         d="M12 2a2 2 0 011 3.73V7h1a7 7 0 017 7h1a1 1 0 011 1v3a1 1 0 01-1 1h-1v1a2 2 0 01-2 2H5a2 2 0 01-2-2v-1H2a1 1 0 01-1-1v-3a1 1 0 011-1h1a7 7 0 017-7h1V5.73A2 2 0 0112 2zM7.5 13a2.5 2.5 0 100 5 2.5 2.5 0 000-5zm9 0a2.5 2.5 0 100 5 2.5 2.5 0 000-5z"
       />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="schedule">
+    <symbol viewBox="0 0 24 24" id="lp-icon-schedule">
       <path d="M0 0h24v24H0z" fill="none" />
       <path
         d="M11.99 2C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
       />
       <path d="M12.5 7H11v6l5.25 3.15.75-1.23-4.5-2.67z" />
     </symbol>
-    <symbol viewBox="0 96 960 960" id="science">
+    <symbol viewBox="0 96 960 960" id="lp-icon-science">
       <path
         d="M200 936q-51 0-72.5-45.5T138 806l222-270V296h-40q-17 0-28.5-11.5T280 256q0-17 11.5-28.5T320 216h320q17 0 28.5 11.5T680 256q0 17-11.5 28.5T640 296h-40v240l222 270q32 39 10.5 84.5T760 936H200Zm0-80h560L520 564V296h-80v268L200 856Zm280-280Z"
       />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="search">
+    <symbol viewBox="0 0 24 24" id="lp-icon-search">
       <path
         d="M15.5 14h-.79l-.28-.27A6.471 6.471 0 0016 9.5 6.5 6.5 0 109.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
       />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="shield-account">
+    <symbol viewBox="0 0 24 24" id="lp-icon-shield-account">
       <path
         d="m12 1-9 4v6c0 5.55 3.84 10.74 9 12 5.16-1.26 9-6.45 9-12v-6zm0 4c.7956 0 1.5587.31607 2.1213.87868s.8787 1.32567.8787 2.12132-.3161 1.55871-.8787 2.1213c-.5626.5626-1.3257.8787-2.1213.8787s-1.5587-.3161-2.12132-.8787c-.56261-.56259-.87868-1.32565-.87868-2.1213s.31607-1.55871.87868-2.12132c.56262-.56261 1.32572-.87868 2.12132-.87868zm5.13 12c-1.21 1.85-3.02 3.24-5.13 3.92-2.11-.68-3.92-2.07-5.13-3.92-.34-.5-.63-1-.87-1.53 0-1.65 2.71-3 6-3s6 1.32 6 3c-.24.53-.53 1.03-.87 1.53z"
       />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="shield-key">
+    <symbol viewBox="0 0 24 24" id="lp-icon-shield-key">
       <path
         d="M12 8C12.2652 8 12.5196 8.10536 12.7071 8.29289C12.8946 8.48043 13 8.73478 13 9C13 9.26522 12.8946 9.51957 12.7071 9.70711C12.5196 9.89464 12.2652 10 12 10C11.7348 10 11.4804 9.89464 11.2929 9.70711C11.1054 9.51957 11 9.26522 11 9C11 8.73478 11.1054 8.48043 11.2929 8.29289C11.4804 8.10536 11.7348 8 12 8V8ZM21 11C21 16.55 17.16 21.74 12 23C6.84 21.74 3 16.55 3 11V5L12 1L21 5V11ZM12 6C11.2044 6 10.4413 6.31607 9.87868 6.87868C9.31607 7.44129 9 8.20435 9 9C9 10.31 9.83 11.42 11 11.83V18H13V16H15V14H13V11.83C14.17 11.42 15 10.31 15 9C15 8.20435 14.6839 7.44129 14.1213 6.87868C13.5587 6.31607 12.7956 6 12 6Z"
       />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="star-outline">
+    <symbol viewBox="0 0 24 24" id="lp-icon-star-outline">
       <path
         d="m22 9.24-7.19-.62L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21 12 17.27 18.18 21l-1.63-7.03L22 9.24zM12 15.4l-3.76 2.27 1-4.28-3.32-2.88 4.38-.38L12 6.1l1.71 4.04 4.38.38-3.32 2.88 1 4.28L12 15.4z"
       />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="star">
+    <symbol viewBox="0 0 24 24" id="lp-icon-star">
       <path d="M0 0h24v24H0z" fill="none" />
       <path d="M0 0h24v24H0z" fill="none" />
       <path
         d="M12 17.27 18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"
       />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="stars">
+    <symbol viewBox="0 0 24 24" id="lp-icon-stars">
       <path
         d="M11.99 2C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zm4.24 16L12 15.45 7.77 18l1.12-4.81-3.73-3.23 4.92-.42L12 5l1.92 4.53 4.92.42-3.73 3.23L16.23 18z"
       />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="status-active">
+    <symbol viewBox="0 0 24 24" id="lp-icon-status-active">
       <path
         d="M7.76 16.24A5.944 5.944 0 0 1 6 12c0-1.66.67-3.16 1.76-4.24l1.42 1.42A3.95 3.95 0 0 0 8 12c0 1.1.45 2.1 1.17 2.83l-1.41 1.41Zm8.48 0A5.944 5.944 0 0 0 18 12c0-1.66-.67-3.16-1.76-4.24l-1.42 1.42A3.95 3.95 0 0 1 16 12c0 1.1-.45 2.1-1.17 2.83l1.41 1.41ZM12 10c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2Zm8 2c0 2.21-.9 4.21-2.35 5.65l1.42 1.42A9.969 9.969 0 0 0 22 12c0-2.76-1.12-5.26-2.93-7.07l-1.42 1.42A7.94 7.94 0 0 1 20 12ZM6.35 6.35 4.93 4.93A9.969 9.969 0 0 0 2 12c0 2.76 1.12 5.26 2.93 7.07l1.42-1.42A7.94 7.94 0 0 1 4 12c0-2.21.9-4.21 2.35-5.65Z"
       />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="status-inactive">
+    <symbol viewBox="0 0 24 24" id="lp-icon-status-inactive">
       <path
         d="M20 12c0 2.21-.9 4.21-2.35 5.65l1.42 1.42A9.969 9.969 0 0 0 22 12c0-2.76-1.12-5.26-2.93-7.07l-1.42 1.42A7.94 7.94 0 0 1 20 12ZM6.35 6.35 4.93 4.93A9.969 9.969 0 0 0 2 12c0 2.76 1.12 5.26 2.93 7.07l1.42-1.42A7.94 7.94 0 0 1 4 12c0-2.21.9-4.21 2.35-5.65ZM7 11h10v2H7v-2Z"
       />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="status-launched">
+    <symbol viewBox="0 0 24 24" id="lp-icon-status-launched">
       <path
         d="M20 12c0 2.21-.9 4.21-2.35 5.65l1.42 1.42A9.969 9.969 0 0 0 22 12c0-2.76-1.12-5.26-2.93-7.07l-1.42 1.42A7.94 7.94 0 0 1 20 12ZM6.35 6.35 4.93 4.93A9.969 9.969 0 0 0 2 12c0 2.76 1.12 5.26 2.93 7.07l1.42-1.42A7.94 7.94 0 0 1 4 12c0-2.21.9-4.21 2.35-5.65ZM16 12a4 4 0 1 1-8 0 4 4 0 0 1 8 0Z"
       />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="status-new">
+    <symbol viewBox="0 0 24 24" id="lp-icon-status-new">
       <path
         d="M20 12c0 2.21-.9 4.21-2.35 5.65l1.42 1.42A9.969 9.969 0 0 0 22 12c0-2.76-1.12-5.26-2.93-7.07l-1.42 1.42A7.94 7.94 0 0 1 20 12ZM6.35 6.35 4.93 4.93A9.969 9.969 0 0 0 2 12c0 2.76 1.12 5.26 2.93 7.07l1.42-1.42A7.94 7.94 0 0 1 4 12c0-2.21.9-4.21 2.35-5.65ZM17 13h-4v4h-2v-4H7v-2h4V7h2v4h4v2Z"
       />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="step-in-progress-outline">
+    <symbol viewBox="0 0 24 24" id="lp-icon-step-in-progress-outline">
       <path
         d="M12.834 3.692v1.683a6.662 6.662 0 0 1 5.8 7.433c-.384 3.034-2.767 5.442-5.8 5.8v1.667a8.313 8.313 0 0 0 7.458-9.108c-.375-3.959-3.517-7.084-7.459-7.475Zm-1.667.025A8.19 8.19 0 0 0 6.725 5.55l1.192 1.233a6.663 6.663 0 0 1 3.25-1.4V3.717ZM5.55 6.725a8.237 8.237 0 0 0-1.841 4.442h1.666a6.68 6.68 0 0 1 1.367-3.25L5.55 6.725Zm-1.833 6.108a8.366 8.366 0 0 0 1.842 4.442l1.183-1.192a6.668 6.668 0 0 1-1.359-3.25H3.717Zm4.2 4.475L6.725 18.45a8.328 8.328 0 0 0 4.442 1.883v-1.666a6.668 6.668 0 0 1-3.25-1.359Z"
       />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="step-in-progress">
+    <symbol viewBox="0 0 24 24" id="lp-icon-step-in-progress">
       <path d="M12 24c6.627 0 12-5.373 12-12S18.627 0 12 0 0 5.373 0 12s5.373 12 12 12Z" />
       <path
         d="M12.834 3.692v1.683a6.662 6.662 0 0 1 5.8 7.433c-.384 3.034-2.767 5.442-5.8 5.8v1.667a8.313 8.313 0 0 0 7.458-9.108c-.375-3.959-3.517-7.084-7.459-7.475Zm-1.667.025A8.19 8.19 0 0 0 6.725 5.55l1.192 1.233a6.663 6.663 0 0 1 3.25-1.4V3.717ZM5.55 6.725a8.237 8.237 0 0 0-1.841 4.442h1.666a6.68 6.68 0 0 1 1.367-3.25L5.55 6.725Zm-1.833 6.108a8.366 8.366 0 0 0 1.842 4.442l1.183-1.192a6.668 6.668 0 0 1-1.359-3.25H3.717Zm4.2 4.475L6.725 18.45a8.328 8.328 0 0 0 4.442 1.883v-1.666a6.668 6.668 0 0 1-3.25-1.359Z"
         fill="#fff"
       />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="stop">
+    <symbol viewBox="0 0 24 24" id="lp-icon-stop">
       <path d="M6 6h12v12H6V6Z" />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="support-agent">
+    <symbol viewBox="0 0 24 24" id="lp-icon-support-agent">
       <path
         d="M21 12.22C21 6.73 16.74 3 12 3C7.31 3 3 6.65 3 12.28C2.4 12.62 2 13.26 2 14V16C2 17.1 2.9 18 4 18H5V11.9C5 8.03 8.13 4.9 12 4.9C15.87 4.9 19 8.03 19 11.9V19H11V21H19C20.1 21 21 20.1 21 19V17.78C21.59 17.47 22 16.86 22 16.14V13.84C22 13.14 21.59 12.53 21 12.22Z"
       />
@@ -621,16 +621,16 @@
         d="M18 11.03C17.52 8.18 15.04 6 12.05 6C9.01997 6 5.75997 8.51 6.01997 12.45C8.48997 11.44 10.35 9.24 10.88 6.56C12.19 9.19 14.88 11 18 11.03Z"
       />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="swap-horiz">
+    <symbol viewBox="0 0 24 24" id="lp-icon-swap-horiz">
       <path d="M0 0h24v24H0z" fill="none" />
       <path d="M6.99 11 3 15l3.99 4v-3H14v-2H6.99v-3zM21 9l-3.99-4v3H10v2h7.01v3L21 9z" />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="swap-vertical">
+    <symbol viewBox="0 0 24 24" id="lp-icon-swap-vertical">
       <path
         d="M16 17.01V10h-2v7.01h-3L15 21l4-3.99h-3ZM9 3 5 6.99h3V14h2V6.99h3L9 3Zm7 14.01V10h-2v7.01h-3L15 21l4-3.99h-3ZM9 3 5 6.99h3V14h2V6.99h3L9 3Z"
       />
     </symbol>
-    <symbol viewBox="0 0 64 64" id="templates-circle">
+    <symbol viewBox="0 0 64 64" id="lp-icon-templates-circle">
       <circle cx="31.5" cy="31.5" r="31.5" />
       <path d="M31.5 10.5833L21.6458 26.7083H41.3542L31.5 10.5833Z" fill="#EFFF63" />
       <path
@@ -639,13 +639,13 @@
       />
       <path d="M15.375 31.1874H29.7083V45.5208H15.375V31.1874Z" fill="#EFFF63" />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="thumb-up">
+    <symbol viewBox="0 0 24 24" id="lp-icon-thumb-up">
       <path d="M0 0h24v24H0V0z" fill="none" />
       <path
         d="M1 21h4V9H1v12zm22-11c0-1.1-.9-2-2-2h-6.31l.95-4.57.03-.32c0-.41-.17-.79-.44-1.06L14.17 1 7.59 7.59C7.22 7.95 7 8.45 7 9v10c0 1.1.9 2 2 2h9c.83 0 1.54-.5 1.84-1.22l3.02-7.05c.09-.23.14-.47.14-.73v-2z"
       />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="toggles">
+    <symbol viewBox="0 0 24 24" id="lp-icon-toggles">
       <path d="M8 8.5c-.83 0-1.5-.67-1.5-1.5S7.17 5.5 8 5.5s1.5.67 1.5 1.5S8.83 8.5 8 8.5z" />
       <path
         fill-rule="evenodd"
@@ -654,57 +654,57 @@
       />
       <path d="M10 7a2 2 0 11-4 0 2 2 0 014 0z" />
     </symbol>
-    <symbol viewBox="0 0 64 64" id="trending-up-circle">
+    <symbol viewBox="0 0 64 64" id="lp-icon-trending-up-circle">
       <circle cx="32" cy="32" r="31" />
       <path
         d="m40 20 4.58 4.58-9.76 9.76-8-8L12 41.18 14.82 44l12-12 8 8 12.6-12.58L52 32V20H40z"
         fill="#EBFF38"
       />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="undo">
+    <symbol viewBox="0 0 24 24" id="lp-icon-undo">
       <path d="M0 0h24v24H0V0z" fill="none" />
       <path
         d="M12.5 8c-2.65 0-5.05.99-6.9 2.6L2 7v9h9l-3.62-3.62c1.39-1.16 3.16-1.88 5.12-1.88 3.54 0 6.55 2.31 7.6 5.5l2.37-.78C21.08 11.03 17.15 8 12.5 8z"
       />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="unfold-less">
+    <symbol viewBox="0 0 24 24" id="lp-icon-unfold-less">
       <path
         d="M7.41 18.59 8.83 20 12 16.83 15.17 20l1.41-1.41L12 14l-4.59 4.59Zm9.18-13.18L15.17 4 12 7.17 8.83 4 7.41 5.41 12 10l4.59-4.59Z"
       />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="unfold-more">
+    <symbol viewBox="0 0 24 24" id="lp-icon-unfold-more">
       <path
         d="M12 5.83 15.17 9l1.41-1.41L12 3 7.41 7.59 8.83 9 12 5.83zm0 12.34L8.83 15l-1.41 1.41L12 21l4.59-4.59L15.17 15 12 18.17z"
       />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="verified">
+    <symbol viewBox="0 0 24 24" id="lp-icon-verified">
       <path
         d="M23 12L20.56 9.22004L20.9 5.54004L17.29 4.72004L15.4 1.54004L12 3.00004L8.6 1.54004L6.71 4.72004L3.1 5.53004L3.44 9.21004L1 12L3.44 14.78L3.1 18.47L6.71 19.29L8.6 22.47L12 21L15.4 22.46L17.29 19.28L20.9 18.46L20.56 14.78L23 12ZM10 17L6 13L7.41 11.59L10 14.17L16.59 7.58004L18 9.00004L10 17Z"
       />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="view-list">
+    <symbol viewBox="0 0 24 24" id="lp-icon-view-list">
       <path
         d="M3 14h4v-4H3v4zm0 5h4v-4H3v4zM3 9h4V5H3v4zm5 5h13v-4H8v4zm0 5h13v-4H8v4zM8 5v4h13V5H8z"
       />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="visibility-off">
+    <symbol viewBox="0 0 24 24" id="lp-icon-visibility-off">
       <path
         d="M12 7c2.76 0 5 2.24 5 5 0 .65-.13 1.26-.36 1.83l2.92 2.92c1.51-1.26 2.7-2.89 3.43-4.75-1.73-4.39-6-7.5-11-7.5-1.4 0-2.74.25-3.98.7l2.16 2.16C10.74 7.13 11.35 7 12 7zM2 4.27l2.28 2.28.46.46A11.804 11.804 0 0 0 1 12c1.73 4.39 6 7.5 11 7.5 1.55 0 3.03-.3 4.38-.84l.42.42L19.73 22 21 20.73 3.27 3 2 4.27zM7.53 9.8l1.55 1.55c-.05.21-.08.43-.08.65 0 1.66 1.34 3 3 3 .22 0 .44-.03.65-.08l1.55 1.55c-.67.33-1.41.53-2.2.53-2.76 0-5-2.24-5-5 0-.79.2-1.53.53-2.2zm4.31-.78 3.15 3.15.02-.16c0-1.66-1.34-3-3-3l-.17.01z"
       />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="visibility">
+    <symbol viewBox="0 0 24 24" id="lp-icon-visibility">
       <path
         d="M12 4C7 4 2.73 7.11 1 11.5 2.73 15.89 7 19 12 19s9.27-3.11 11-7.5C21.27 7.11 17 4 12 4Zm0 12.5c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5Zm0-8c-1.66 0-3 1.34-3 3s1.34 3 3 3 3-1.34 3-3-1.34-3-3-3Z"
       />
     </symbol>
-    <symbol viewBox="0 0 24 24" id="warning">
+    <symbol viewBox="0 0 24 24" id="lp-icon-warning">
       <path
         fill-rule="evenodd"
         clip-rule="evenodd"
         d="M10.29 3.599l-8.47 14.14a2 2 0 001.71 3h16.94a2 2 0 001.71-3l-8.47-14.14a2 2 0 00-3.42 0zm3.362 13.537a1.5 1.5 0 11-3 0 1.5 1.5 0 013 0zm-1.51-11a1.19 1.19 0 00-1.186 1.287l.49 6.07a.7.7 0 001.394 0l.49-6.07a1.19 1.19 0 00-1.187-1.287z"
       />
     </symbol>
-    <symbol viewBox="0 0 121 121" id="workflow-builder">
+    <symbol viewBox="0 0 121 121" id="lp-icon-workflow-builder">
       <path d="m60.5 0 52.395 30.25v60.5L60.5 121 8.105 90.75v-60.5L60.5 0z" />
       <g clip-path="url(#a)" fill="#EBFF38">
         <path


### PR DESCRIPTION
## Summary

For consumers hosting static assets in a cdn or different domain we should allow them to inject the sprite into the document and have `Icon` access it there. Avoid id collisions by adding a `lp-icon` prefix to all symbols.