### PR TITLE
refactor(markdown): use es6 imports for isomorphic-dompurify

### DIFF
--- a/.changeset/old-bears-rescue.md
+++ b/.changeset/old-bears-rescue.md
@@ -1,0 +1,6 @@
+---
+'@launchpad-ui/markdown': patch
+'@launchpad-ui/core': patch
+---
+
+[Markdown] Use es6 imports for `isomorphic-dompurify`

--- a/packages/markdown/src/Markdown.tsx
+++ b/packages/markdown/src/Markdown.tsx
@@ -1,12 +1,12 @@
 import type { ElementType, ReactNode, RefObject } from 'react';
 
 import { cx } from 'classix';
-import DOMPurify from 'isomorphic-dompurify';
+import { addHook } from 'isomorphic-dompurify';
 
 import styles from './styles/Markdown.module.css';
 import { isAnchorNode, renderMarkdown } from './utils';
 
-DOMPurify.addHook('afterSanitizeAttributes', (node) => {
+addHook('afterSanitizeAttributes', (node) => {
   // Ensure we add the required rel attribute.
   if (isAnchorNode(node) && node.target.toLowerCase() === '_blank') {
     node.setAttribute('rel', 'noopener noreferrer');

--- a/packages/markdown/src/utils.ts
+++ b/packages/markdown/src/utils.ts
@@ -1,4 +1,6 @@
-import DOMPurify from 'isomorphic-dompurify';
+import type { Config } from 'isomorphic-dompurify';
+
+import { sanitize } from 'isomorphic-dompurify';
 import { marked } from 'marked';
 
 function isAnchorNode(node: Element): node is HTMLAnchorElement {
@@ -33,7 +35,7 @@ function renderMarkdown(
 
   const html = marked(source, { renderer });
 
-  const sanitizationConfig: DOMPurify.Config = {
+  const sanitizationConfig: Config = {
     KEEP_CONTENT: false,
     ADD_ATTR: ['target'],
     FORBID_ATTR: ['style', 'class'],
@@ -45,7 +47,7 @@ function renderMarkdown(
     sanitizationConfig.ALLOWED_TAGS = allowedTags;
   }
 
-  return DOMPurify.sanitize(html, sanitizationConfig);
+  return sanitize(html, sanitizationConfig);
 }
 
 export { isAnchorNode, renderMarkdown };


### PR DESCRIPTION
## Summary

Use es6 imports for `isomorphic-dompurify`.