### PR TITLE
feat: add inline-edit package

### DIFF
--- a/.changeset/chatty-tables-attend.md
+++ b/.changeset/chatty-tables-attend.md
@@ -13,3 +13,4 @@ Add `inline-edit` package to display and allow inline editing of a form elements
 - Add handlers for edit, cancel, and confirm actions
 - Use prop `isEditing` to allow full control over the read and edit modes
 - Add `@vanilla-extract/css` as a peer dependency for prop `layout` variant types
+- Use `useFocusWithin` to cancel edit on blur

--- a/.changeset/chatty-tables-attend.md
+++ b/.changeset/chatty-tables-attend.md
@@ -1,0 +1,12 @@
+---
+'@launchpad-ui/inline-edit': minor
+'@launchpad-ui/core': patch
+---
+
+Add `inline-edit` package to display and allow inline editing of a form elements:
+
+- Use props `defaultValue` and `onSave` to handle state management of the value to edit
+- Have children act as the "read" view of the component
+- Hide edit icon button and wrap children with a React Aria button when `hideEdit` is true
+- Implement focus management to ensure focus is directed correctly when toggling between read and edit mode
+- Use `input` prop to allow passing a custom `TextField` or `TextArea` component

--- a/.changeset/chatty-tables-attend.md
+++ b/.changeset/chatty-tables-attend.md
@@ -9,4 +9,4 @@ Add `inline-edit` package to display and allow inline editing of a form elements
 - Have children act as the "read" view of the component
 - Hide edit icon button and wrap children with a React Aria button when `hideEdit` is true
 - Implement focus management to ensure focus is directed correctly when toggling between read and edit mode
-- Use `input` prop to allow passing a custom `TextField` or `TextArea` component
+- Use `renderInput` prop to allow passing a custom `TextField` or `TextArea` component

--- a/.changeset/chatty-tables-attend.md
+++ b/.changeset/chatty-tables-attend.md
@@ -5,8 +5,11 @@
 
 Add `inline-edit` package to display and allow inline editing of a form elements:
 
-- Use props `defaultValue` and `onSave` to handle state management of the value to edit
+- Use props `defaultValue` and `onConfirm` to handle state management of the value to edit
 - Have children act as the "read" view of the component
 - Hide edit icon button and wrap children with a React Aria button when `hideEdit` is true
 - Implement focus management to ensure focus is directed correctly when toggling between read and edit mode
 - Use `renderInput` prop to allow passing a custom `TextField` or `TextArea` component
+- Add handlers for edit, cancel, and confirm actions
+- Use prop `isEditing` to allow full control over the read and edit modes
+- Add `@vanilla-extract/css` as a peer dependency for prop `layout` variant types

--- a/.storybook/styles.css
+++ b/.storybook/styles.css
@@ -27,6 +27,7 @@ h1,
 h2,
 h3 {
   color: var(--lp-color-text-ui-primary-base);
+  margin: 0;
 }
 
 @font-face {

--- a/apps/remix/app/data.server.ts
+++ b/apps/remix/app/data.server.ts
@@ -18,6 +18,7 @@ export async function getComponents() {
     { to: 'components/icon', name: 'Icon' },
     { to: 'components/icon-button', name: 'IconButton' },
     { to: 'components/inline', name: 'Inline' },
+    { to: 'components/inline-edit', name: 'InlineEdit' },
     { to: 'components/markdown', name: 'Markdown' },
     { to: 'components/menu', name: 'Menu' },
     { to: 'components/modal', name: 'Modal' },

--- a/apps/remix/app/routes/components.inline-edit.tsx
+++ b/apps/remix/app/routes/components.inline-edit.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 export default function Index() {
   const [editValue, setEditValue] = useState('edit me');
   return (
-    <InlineEdit defaultValue={editValue} onSave={setEditValue}>
+    <InlineEdit defaultValue={editValue} onConfirm={setEditValue}>
       <span>{editValue}</span>
     </InlineEdit>
   );

--- a/apps/remix/app/routes/components.inline-edit.tsx
+++ b/apps/remix/app/routes/components.inline-edit.tsx
@@ -1,0 +1,5 @@
+import { InlineEdit } from '@launchpad-ui/core';
+
+export default function Index() {
+  return <InlineEdit>A lovely InlineEdit component.</InlineEdit>;
+}

--- a/apps/remix/app/routes/components.inline-edit.tsx
+++ b/apps/remix/app/routes/components.inline-edit.tsx
@@ -1,5 +1,11 @@
 import { InlineEdit } from '@launchpad-ui/core';
+import { useState } from 'react';
 
 export default function Index() {
-  return <InlineEdit>A lovely InlineEdit component.</InlineEdit>;
+  const [editValue, setEditValue] = useState('edit me');
+  return (
+    <InlineEdit defaultValue={editValue} onSave={setEditValue}>
+      <span>{editValue}</span>
+    </InlineEdit>
+  );
 }

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -19,9 +19,5 @@ export default defineConfig({
   },
   video: false,
   screenshotOnRunFailure: false,
-  env: {
-    codeCoverage: {
-      exclude: ['cypress/**/*.*', 'packages/icons/src/!(Icon.tsx|StatusIcon.tsx|FlairIcon.tsx)'],
-    },
-  },
+  retries: 1,
 });

--- a/nyc.config.js
+++ b/nyc.config.js
@@ -1,3 +1,0 @@
-module.exports = {
-  exclude: ['cypress/', 'packages/icons/src/!(Icon.tsx|StatusIcon.tsx|FlairIcon.tsx)'],
-};

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "@typescript-eslint/eslint-plugin": "^6.1.0",
     "@typescript-eslint/parser": "^6.1.0",
     "@vanilla-extract/css": "^1.12.0",
-    "@vanilla-extract/recipes": "^0.4.0",
+    "@vanilla-extract/recipes": "^0.5.0",
     "@vanilla-extract/vite-plugin": "^3.8.2",
     "@vitejs/plugin-react-swc": "^3.3.1",
     "@vitest/coverage-v8": "^0.33.0",

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "@typescript-eslint/eslint-plugin": "^6.1.0",
     "@typescript-eslint/parser": "^6.1.0",
     "@vanilla-extract/css": "^1.12.0",
+    "@vanilla-extract/recipes": "^0.4.0",
     "@vanilla-extract/vite-plugin": "^3.8.2",
     "@vitejs/plugin-react-swc": "^3.3.1",
     "@vitest/coverage-v8": "^0.33.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -51,6 +51,7 @@
     "@launchpad-ui/focus-trap": "workspace:~",
     "@launchpad-ui/form": "workspace:~",
     "@launchpad-ui/inline": "workspace:~",
+    "@launchpad-ui/inline-edit": "workspace:~",
     "@launchpad-ui/markdown": "workspace:~",
     "@launchpad-ui/menu": "workspace:~",
     "@launchpad-ui/modal": "workspace:~",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -105,6 +105,7 @@ export type { StackProps } from '@launchpad-ui/stack';
 export type { Space } from '@launchpad-ui/types';
 export type { InlineProps } from '@launchpad-ui/inline';
 export type { ColumnProps, ColumnsProps } from '@launchpad-ui/columns';
+export type { InlineEditProps } from '@launchpad-ui/inline-edit';
 // plop end type exports
 
 // plop start module exports
@@ -194,4 +195,5 @@ export { Tooltip, TooltipBase } from '@launchpad-ui/tooltip';
 export { Stack } from '@launchpad-ui/stack';
 export { Inline } from '@launchpad-ui/inline';
 export { Column, Columns } from '@launchpad-ui/columns';
+export { InlineEdit } from '@launchpad-ui/inline-edit';
 // plop end module exports

--- a/packages/inline-edit/README.md
+++ b/packages/inline-edit/README.md
@@ -1,0 +1,14 @@
+# @launchpad-ui/inline-edit
+
+> An element used to display and allow inline editing of a form element value.
+
+[![See it on NPM!](https://img.shields.io/npm/v/@launchpad-ui/inline-edit?style=for-the-badge)](https://www.npmjs.com/package/@launchpad-ui/inline-edit)
+[![How big is this package in your project?](https://img.shields.io/bundlephobia/minzip/@launchpad-ui/inline-edit?style=for-the-badge)](https://bundlephobia.com/result?p=@launchpad-ui/inline-edit)
+
+## Installation
+
+```sh
+$ yarn add @launchpad-ui/inline-edit
+# or
+$ npm install @launchpad-ui/inline-edit
+```

--- a/packages/inline-edit/__tests__/InlineEdit.cy.tsx
+++ b/packages/inline-edit/__tests__/InlineEdit.cy.tsx
@@ -2,12 +2,24 @@ import { InlineEdit } from '../src';
 
 describe('InlineEdit', () => {
   it('renders', () => {
-    cy.mount(<InlineEdit>An important message</InlineEdit>);
+    const editValue = 'test';
+    cy.mount(
+      <InlineEdit defaultValue={editValue} onSave={() => undefined}>
+        <span>{editValue}</span>
+      </InlineEdit>
+    );
     cy.getByTestId('inline-edit').should('be.visible');
   });
 
   it('is accessible', () => {
-    cy.mount(<InlineEdit>An important message</InlineEdit>);
+    const editValue = 'test';
+    cy.mount(
+      <InlineEdit defaultValue={editValue} onSave={() => undefined}>
+        <span>{editValue}</span>
+      </InlineEdit>
+    );
+    cy.checkA11y();
+    cy.getByRole('button').click();
     cy.checkA11y();
   });
 });

--- a/packages/inline-edit/__tests__/InlineEdit.cy.tsx
+++ b/packages/inline-edit/__tests__/InlineEdit.cy.tsx
@@ -1,0 +1,13 @@
+import { InlineEdit } from '../src';
+
+describe('InlineEdit', () => {
+  it('renders', () => {
+    cy.mount(<InlineEdit>An important message</InlineEdit>);
+    cy.getByTestId('inline-edit').should('be.visible');
+  });
+
+  it('is accessible', () => {
+    cy.mount(<InlineEdit>An important message</InlineEdit>);
+    cy.checkA11y();
+  });
+});

--- a/packages/inline-edit/__tests__/InlineEdit.cy.tsx
+++ b/packages/inline-edit/__tests__/InlineEdit.cy.tsx
@@ -4,7 +4,7 @@ describe('InlineEdit', () => {
   it('renders', () => {
     const editValue = 'test';
     cy.mount(
-      <InlineEdit defaultValue={editValue} onSave={() => undefined}>
+      <InlineEdit defaultValue={editValue} onConfirm={() => undefined}>
         <span>{editValue}</span>
       </InlineEdit>
     );
@@ -14,7 +14,7 @@ describe('InlineEdit', () => {
   it('is accessible', () => {
     const editValue = 'test';
     cy.mount(
-      <InlineEdit defaultValue={editValue} onSave={() => undefined} aria-label="edit value">
+      <InlineEdit defaultValue={editValue} onConfirm={() => undefined} aria-label="edit value">
         <span>{editValue}</span>
       </InlineEdit>
     );

--- a/packages/inline-edit/__tests__/InlineEdit.cy.tsx
+++ b/packages/inline-edit/__tests__/InlineEdit.cy.tsx
@@ -14,12 +14,12 @@ describe('InlineEdit', () => {
   it('is accessible', () => {
     const editValue = 'test';
     cy.mount(
-      <InlineEdit defaultValue={editValue} onSave={() => undefined}>
+      <InlineEdit defaultValue={editValue} onSave={() => undefined} aria-label="edit value">
         <span>{editValue}</span>
       </InlineEdit>
     );
     cy.checkA11y();
-    cy.getByRole('button').click();
+    cy.getByTestId('icon-button').click();
     cy.checkA11y();
   });
 });

--- a/packages/inline-edit/__tests__/InlineEdit.spec.tsx
+++ b/packages/inline-edit/__tests__/InlineEdit.spec.tsx
@@ -38,7 +38,7 @@ describe('InlineEdit', () => {
   });
 
   it('renders a custom input', async () => {
-    render(<InlineEditComponent input={<TextArea />} />);
+    render(<InlineEditComponent renderInput={<TextArea />} />);
     screen.getByLabelText('edit').click();
 
     await waitFor(() => {

--- a/packages/inline-edit/__tests__/InlineEdit.spec.tsx
+++ b/packages/inline-edit/__tests__/InlineEdit.spec.tsx
@@ -1,0 +1,11 @@
+import { it, expect, describe } from 'vitest';
+
+import { render, screen } from '../../../test/utils';
+import { InlineEdit } from '../src';
+
+describe('InlineEdit', () => {
+  it('renders', () => {
+    render(<InlineEdit>An important message</InlineEdit>);
+    expect(screen.getByText('An important message')).toBeInTheDocument();
+  });
+});

--- a/packages/inline-edit/__tests__/InlineEdit.spec.tsx
+++ b/packages/inline-edit/__tests__/InlineEdit.spec.tsx
@@ -2,7 +2,7 @@ import type { InlineEditProps } from '../src';
 
 import { TextArea } from '@launchpad-ui/form';
 import { useState } from 'react';
-import { it, expect, describe } from 'vitest';
+import { it, expect, describe, vi } from 'vitest';
 
 import { render, screen, waitFor, userEvent } from '../../../test/utils';
 import { InlineEdit } from '../src';
@@ -11,7 +11,7 @@ const InlineEditComponent = ({ ...props }: Partial<InlineEditProps>) => {
   const [editValue, setEditValue] = useState('');
 
   return (
-    <InlineEdit defaultValue={editValue} {...props} onSave={setEditValue}>
+    <InlineEdit defaultValue={editValue} onSave={setEditValue} {...props}>
       <span>{editValue}</span>
     </InlineEdit>
   );
@@ -137,6 +137,47 @@ describe('InlineEdit', () => {
 
     await waitFor(async () => {
       expect(screen.getByLabelText('edit')).toHaveFocus();
+    });
+  });
+
+  it('calls handlers for edit, cancel, and save', async () => {
+    const editSpy = vi.fn();
+    const cancelSpy = vi.fn();
+    const saveSpy = vi.fn();
+
+    render(<InlineEditComponent onCancel={cancelSpy} onEdit={editSpy} onSave={saveSpy} />);
+
+    screen.getByLabelText('edit').click();
+    expect(editSpy).toHaveBeenCalledTimes(1);
+
+    await waitFor(async () => {
+      screen.getByLabelText('cancel').click();
+    });
+
+    expect(cancelSpy).toHaveBeenCalledTimes(1);
+
+    await waitFor(() => {
+      screen.getByLabelText('edit').click();
+    });
+
+    await waitFor(() => {
+      screen.getByLabelText('save').click();
+    });
+
+    expect(saveSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('allows control over the read and edit modes', async () => {
+    const { rerender } = render(<InlineEditComponent isEditing />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('text-field')).toBeVisible();
+    });
+
+    rerender(<InlineEditComponent isEditing={false} />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('edit')).toBeVisible();
     });
   });
 });

--- a/packages/inline-edit/__tests__/InlineEdit.spec.tsx
+++ b/packages/inline-edit/__tests__/InlineEdit.spec.tsx
@@ -25,7 +25,10 @@ describe('InlineEdit', () => {
 
   it('renders an input in edit mode', async () => {
     render(<InlineEditComponent />);
-    screen.getByLabelText('edit').click();
+
+    await waitFor(() => {
+      screen.getByLabelText('edit').click();
+    });
 
     await waitFor(() => {
       expect(screen.getByTestId('text-field')).toBeVisible();
@@ -39,7 +42,10 @@ describe('InlineEdit', () => {
 
   it('renders a custom input', async () => {
     render(<InlineEditComponent renderInput={<TextArea />} />);
-    screen.getByLabelText('edit').click();
+
+    await waitFor(() => {
+      screen.getByLabelText('edit').click();
+    });
 
     await waitFor(() => {
       expect(screen.getByTestId('text-area')).toBeVisible();
@@ -48,7 +54,10 @@ describe('InlineEdit', () => {
 
   it('enters edit mode when button wrapper is clicked', async () => {
     render(<InlineEditComponent hideEdit />);
-    screen.getByRole('button').click();
+
+    await waitFor(() => {
+      screen.getByRole('button').click();
+    });
 
     await waitFor(() => {
       expect(screen.getByTestId('text-field')).toBeVisible();
@@ -57,7 +66,10 @@ describe('InlineEdit', () => {
 
   it('returns to read mode when cancel is clicked', async () => {
     render(<InlineEditComponent />);
-    screen.getByLabelText('edit').click();
+
+    await waitFor(() => {
+      screen.getByLabelText('edit').click();
+    });
 
     await waitFor(() => {
       screen.getByLabelText('cancel').click();
@@ -71,7 +83,10 @@ describe('InlineEdit', () => {
   it('returns to read mode when the escape key is pressed', async () => {
     const user = userEvent.setup();
     render(<InlineEditComponent />);
-    screen.getByLabelText('edit').click();
+
+    await waitFor(() => {
+      screen.getByLabelText('edit').click();
+    });
 
     await waitFor(async () => {
       expect(screen.getByTestId('text-field')).toHaveFocus();
@@ -86,7 +101,10 @@ describe('InlineEdit', () => {
   it('saves the value and returns to read mode when the enter key is pressed', async () => {
     const user = userEvent.setup();
     render(<InlineEditComponent />);
-    screen.getByLabelText('edit').click();
+
+    await waitFor(() => {
+      screen.getByLabelText('edit').click();
+    });
 
     await waitFor(async () => {
       expect(screen.getByTestId('text-field')).toHaveFocus();
@@ -106,7 +124,10 @@ describe('InlineEdit', () => {
   it('saves the value and returns to read mode when save is clicked', async () => {
     const user = userEvent.setup();
     render(<InlineEditComponent />);
-    screen.getByLabelText('edit').click();
+
+    await waitFor(() => {
+      screen.getByLabelText('edit').click();
+    });
 
     await waitFor(async () => {
       expect(screen.getByTestId('text-field')).toHaveFocus();
@@ -147,7 +168,10 @@ describe('InlineEdit', () => {
 
     render(<InlineEditComponent onCancel={cancelSpy} onEdit={editSpy} onSave={saveSpy} />);
 
-    screen.getByLabelText('edit').click();
+    await waitFor(async () => {
+      screen.getByLabelText('edit').click();
+    });
+
     expect(editSpy).toHaveBeenCalledTimes(1);
 
     await waitFor(async () => {

--- a/packages/inline-edit/__tests__/InlineEdit.spec.tsx
+++ b/packages/inline-edit/__tests__/InlineEdit.spec.tsx
@@ -1,11 +1,24 @@
+import type { InlineEditProps } from '../src';
+
+import { useState } from 'react';
 import { it, expect, describe } from 'vitest';
 
 import { render, screen } from '../../../test/utils';
 import { InlineEdit } from '../src';
 
+const InlineEditComponent = ({ ...props }: Partial<InlineEditProps>) => {
+  const [editValue, setEditValue] = useState('test');
+
+  return (
+    <InlineEdit defaultValue={editValue} {...props} onSave={setEditValue}>
+      <span>{editValue}</span>
+    </InlineEdit>
+  );
+};
+
 describe('InlineEdit', () => {
   it('renders', () => {
-    render(<InlineEdit>An important message</InlineEdit>);
-    expect(screen.getByText('An important message')).toBeInTheDocument();
+    render(<InlineEditComponent />);
+    expect(screen.getByTestId('inline-edit')).toBeInTheDocument();
   });
 });

--- a/packages/inline-edit/__tests__/InlineEdit.spec.tsx
+++ b/packages/inline-edit/__tests__/InlineEdit.spec.tsx
@@ -11,7 +11,7 @@ const InlineEditComponent = ({ ...props }: Partial<InlineEditProps>) => {
   const [editValue, setEditValue] = useState('');
 
   return (
-    <InlineEdit defaultValue={editValue} onSave={setEditValue} {...props}>
+    <InlineEdit defaultValue={editValue} onConfirm={setEditValue} {...props}>
       <span>{editValue}</span>
     </InlineEdit>
   );
@@ -98,7 +98,7 @@ describe('InlineEdit', () => {
     });
   });
 
-  it('saves the value and returns to read mode when the enter key is pressed', async () => {
+  it('confirms the value and returns to read mode when the enter key is pressed', async () => {
     const user = userEvent.setup();
     render(<InlineEditComponent />);
 
@@ -121,7 +121,7 @@ describe('InlineEdit', () => {
     });
   });
 
-  it('saves the value and returns to read mode when save is clicked', async () => {
+  it('confirms the value and returns to read mode when confirm is clicked', async () => {
     const user = userEvent.setup();
     render(<InlineEditComponent />);
 
@@ -132,7 +132,7 @@ describe('InlineEdit', () => {
     await waitFor(async () => {
       expect(screen.getByTestId('text-field')).toHaveFocus();
       await user.keyboard('test');
-      screen.getByLabelText('save').click();
+      screen.getByLabelText('confirm').click();
     });
 
     await waitFor(() => {
@@ -161,12 +161,12 @@ describe('InlineEdit', () => {
     });
   });
 
-  it('calls handlers for edit, cancel, and save', async () => {
+  it('calls handlers for edit, cancel, and confirm', async () => {
     const editSpy = vi.fn();
     const cancelSpy = vi.fn();
-    const saveSpy = vi.fn();
+    const confirmSpy = vi.fn();
 
-    render(<InlineEditComponent onCancel={cancelSpy} onEdit={editSpy} onSave={saveSpy} />);
+    render(<InlineEditComponent onCancel={cancelSpy} onEdit={editSpy} onConfirm={confirmSpy} />);
 
     await waitFor(async () => {
       screen.getByLabelText('edit').click();
@@ -185,10 +185,10 @@ describe('InlineEdit', () => {
     });
 
     await waitFor(() => {
-      screen.getByLabelText('save').click();
+      screen.getByLabelText('confirm').click();
     });
 
-    expect(saveSpy).toHaveBeenCalledTimes(1);
+    expect(confirmSpy).toHaveBeenCalledTimes(1);
   });
 
   it('allows control over the read and edit modes', async () => {

--- a/packages/inline-edit/__tests__/InlineEdit.spec.tsx
+++ b/packages/inline-edit/__tests__/InlineEdit.spec.tsx
@@ -1,13 +1,14 @@
 import type { InlineEditProps } from '../src';
 
+import { TextArea } from '@launchpad-ui/form';
 import { useState } from 'react';
 import { it, expect, describe } from 'vitest';
 
-import { render, screen } from '../../../test/utils';
+import { render, screen, waitFor, userEvent } from '../../../test/utils';
 import { InlineEdit } from '../src';
 
 const InlineEditComponent = ({ ...props }: Partial<InlineEditProps>) => {
-  const [editValue, setEditValue] = useState('test');
+  const [editValue, setEditValue] = useState('');
 
   return (
     <InlineEdit defaultValue={editValue} {...props} onSave={setEditValue}>
@@ -19,6 +20,123 @@ const InlineEditComponent = ({ ...props }: Partial<InlineEditProps>) => {
 describe('InlineEdit', () => {
   it('renders', () => {
     render(<InlineEditComponent />);
-    expect(screen.getByTestId('inline-edit')).toBeInTheDocument();
+    expect(screen.getByTestId('inline-edit')).toBeVisible();
+  });
+
+  it('renders an input in edit mode', async () => {
+    render(<InlineEditComponent />);
+    screen.getByLabelText('edit').click();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('text-field')).toBeVisible();
+    });
+  });
+
+  it('renders a button wrapper in edit mode when hideEdit is passed', async () => {
+    render(<InlineEditComponent hideEdit />);
+    expect(screen.getByRole('button')).toBeVisible();
+  });
+
+  it('renders a custom input', async () => {
+    render(<InlineEditComponent input={<TextArea />} />);
+    screen.getByLabelText('edit').click();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('text-area')).toBeVisible();
+    });
+  });
+
+  it('enters edit mode when button wrapper is clicked', async () => {
+    render(<InlineEditComponent hideEdit />);
+    screen.getByRole('button').click();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('text-field')).toBeVisible();
+    });
+  });
+
+  it('returns to read mode when cancel is clicked', async () => {
+    render(<InlineEditComponent />);
+    screen.getByLabelText('edit').click();
+
+    await waitFor(() => {
+      screen.getByLabelText('cancel').click();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('edit')).toBeVisible();
+    });
+  });
+
+  it('returns to read mode when the escape key is pressed', async () => {
+    const user = userEvent.setup();
+    render(<InlineEditComponent />);
+    screen.getByLabelText('edit').click();
+
+    await waitFor(async () => {
+      expect(screen.getByTestId('text-field')).toHaveFocus();
+      await user.keyboard('{Escape}');
+    });
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('edit')).toBeVisible();
+    });
+  });
+
+  it('saves the value and returns to read mode when the enter key is pressed', async () => {
+    const user = userEvent.setup();
+    render(<InlineEditComponent />);
+    screen.getByLabelText('edit').click();
+
+    await waitFor(async () => {
+      expect(screen.getByTestId('text-field')).toHaveFocus();
+      await user.keyboard('test');
+      await user.keyboard('{Enter}');
+    });
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('edit')).toBeVisible();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('test')).toBeVisible();
+    });
+  });
+
+  it('saves the value and returns to read mode when save is clicked', async () => {
+    const user = userEvent.setup();
+    render(<InlineEditComponent />);
+    screen.getByLabelText('edit').click();
+
+    await waitFor(async () => {
+      expect(screen.getByTestId('text-field')).toHaveFocus();
+      await user.keyboard('test');
+      screen.getByLabelText('save').click();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('edit')).toBeVisible();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('test')).toBeVisible();
+    });
+  });
+
+  it('delegates focus with keyboard nav', async () => {
+    const user = userEvent.setup();
+    render(<InlineEditComponent />);
+    await user.tab();
+    await user.keyboard('{Enter}');
+
+    await waitFor(async () => {
+      expect(screen.getByTestId('text-field')).toHaveFocus();
+      await user.tab();
+      await user.keyboard('{Enter}');
+    });
+
+    await waitFor(async () => {
+      expect(screen.getByLabelText('edit')).toHaveFocus();
+    });
   });
 });

--- a/packages/inline-edit/__tests__/InlineEdit.spec.tsx
+++ b/packages/inline-edit/__tests__/InlineEdit.spec.tsx
@@ -84,9 +84,8 @@ describe('InlineEdit', () => {
     const user = userEvent.setup();
     render(<InlineEditComponent />);
 
-    await waitFor(() => {
-      screen.getByLabelText('edit').click();
-    });
+    await user.tab();
+    await user.keyboard('{Enter}');
 
     await waitFor(async () => {
       expect(screen.getByTestId('text-field')).toHaveFocus();
@@ -102,9 +101,8 @@ describe('InlineEdit', () => {
     const user = userEvent.setup();
     render(<InlineEditComponent />);
 
-    await waitFor(() => {
-      screen.getByLabelText('edit').click();
-    });
+    await user.tab();
+    await user.keyboard('{Enter}');
 
     await waitFor(async () => {
       expect(screen.getByTestId('text-field')).toHaveFocus();
@@ -125,9 +123,8 @@ describe('InlineEdit', () => {
     const user = userEvent.setup();
     render(<InlineEditComponent />);
 
-    await waitFor(() => {
-      screen.getByLabelText('edit').click();
-    });
+    await user.tab();
+    await user.keyboard('{Enter}');
 
     await waitFor(async () => {
       expect(screen.getByTestId('text-field')).toHaveFocus();
@@ -199,6 +196,42 @@ describe('InlineEdit', () => {
     });
 
     rerender(<InlineEditComponent isEditing={false} />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('edit')).toBeVisible();
+    });
+  });
+
+  it('cancels when input is blurred', async () => {
+    const user = userEvent.setup();
+    render(<InlineEditComponent />);
+
+    await user.tab();
+    await user.keyboard('{Enter}');
+
+    await waitFor(async () => {
+      expect(screen.getByTestId('text-field')).toHaveFocus();
+      await user.tab({ shift: true });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('edit')).toBeVisible();
+    });
+  });
+
+  it('cancels when cancel button is blurred', async () => {
+    const user = userEvent.setup();
+    render(<InlineEditComponent />);
+
+    await user.tab();
+    await user.keyboard('{Enter}');
+
+    await waitFor(async () => {
+      expect(screen.getByTestId('text-field')).toHaveFocus();
+      await user.tab();
+      await user.tab();
+      await user.tab();
+    });
 
     await waitFor(() => {
       expect(screen.getByLabelText('edit')).toBeVisible();

--- a/packages/inline-edit/package.json
+++ b/packages/inline-edit/package.json
@@ -32,6 +32,8 @@
     "test": "vitest run --coverage"
   },
   "dependencies": {
+    "@react-aria/focus": "3.13.0",
+    "@react-aria/utils": "3.18.0",
     "@launchpad-ui/tokens": "workspace:~",
     "@launchpad-ui/vars": "workspace:~",
     "@radix-ui/react-slot": "^1.0.0",

--- a/packages/inline-edit/package.json
+++ b/packages/inline-edit/package.json
@@ -28,13 +28,16 @@
   "scripts": {
     "build": "vite build -c ../../vite.config.ts && tsc --project tsconfig.build.json",
     "clean": "rm -rf dist",
-    "lint": "eslint '**/*.{ts,tsx,js}' && stylelint '**/*.css' --ignore-path ../../.stylelintignore",
+    "lint": "eslint '**/*.{ts,tsx,js}'",
     "test": "vitest run --coverage"
   },
   "dependencies": {
     "@react-aria/button": "3.8.0",
     "@react-aria/focus": "3.13.0",
     "@react-aria/utils": "3.18.0",
+    "@launchpad-ui/button": "workspace:~",
+    "@launchpad-ui/form": "workspace:~",
+    "@launchpad-ui/icons": "workspace:~",
     "@launchpad-ui/tokens": "workspace:~",
     "@launchpad-ui/vars": "workspace:~",
     "classix": "2.1.17"

--- a/packages/inline-edit/package.json
+++ b/packages/inline-edit/package.json
@@ -40,9 +40,11 @@
     "@launchpad-ui/icons": "workspace:~",
     "@launchpad-ui/tokens": "workspace:~",
     "@launchpad-ui/vars": "workspace:~",
+    "@vanilla-extract/recipes": "^0.5.0",
     "classix": "2.1.17"
   },
   "peerDependencies": {
+    "@vanilla-extract/css": "^1.12.0",
     "react": "18.2.0",
     "react-dom": "18.2.0"
   },

--- a/packages/inline-edit/package.json
+++ b/packages/inline-edit/package.json
@@ -34,6 +34,7 @@
   "dependencies": {
     "@launchpad-ui/tokens": "workspace:~",
     "@launchpad-ui/vars": "workspace:~",
+    "@radix-ui/react-slot": "^1.0.0",
     "classix": "2.1.17"
   },
   "peerDependencies": {

--- a/packages/inline-edit/package.json
+++ b/packages/inline-edit/package.json
@@ -34,6 +34,7 @@
   "dependencies": {
     "@react-aria/button": "3.8.0",
     "@react-aria/focus": "3.13.0",
+    "@react-aria/interactions": "3.16.0",
     "@react-aria/utils": "3.18.0",
     "@launchpad-ui/button": "workspace:~",
     "@launchpad-ui/form": "workspace:~",

--- a/packages/inline-edit/package.json
+++ b/packages/inline-edit/package.json
@@ -32,11 +32,11 @@
     "test": "vitest run --coverage"
   },
   "dependencies": {
+    "@react-aria/button": "3.8.0",
     "@react-aria/focus": "3.13.0",
     "@react-aria/utils": "3.18.0",
     "@launchpad-ui/tokens": "workspace:~",
     "@launchpad-ui/vars": "workspace:~",
-    "@radix-ui/react-slot": "^1.0.0",
     "classix": "2.1.17"
   },
   "peerDependencies": {

--- a/packages/inline-edit/package.json
+++ b/packages/inline-edit/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "@launchpad-ui/inline-edit",
+  "version": "0.0.1",
+  "status": "alpha",
+  "publishConfig": {
+    "access": "public"
+  },
+  "description": "An element used to display and allow inline editing of a form element value.",
+  "files": [
+    "dist"
+  ],
+  "main": "dist/index.js",
+  "module": "dist/index.es.js",
+  "types": "dist/index.d.ts",
+  "sideEffects": [
+    "**/*.css"
+  ],
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.es.js",
+      "require": "./dist/index.js"
+    },
+    "./package.json": "./package.json",
+    "./style.css": "./dist/style.css"
+  },
+  "source": "src/index.ts",
+  "scripts": {
+    "build": "vite build -c ../../vite.config.ts && tsc --project tsconfig.build.json",
+    "clean": "rm -rf dist",
+    "lint": "eslint '**/*.{ts,tsx,js}' && stylelint '**/*.css' --ignore-path ../../.stylelintignore",
+    "test": "vitest run --coverage"
+  },
+  "dependencies": {
+    "@launchpad-ui/tokens": "workspace:~",
+    "@launchpad-ui/vars": "workspace:~",
+    "classix": "2.1.17"
+  },
+  "peerDependencies": {
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  }
+}

--- a/packages/inline-edit/src/InlineEdit.tsx
+++ b/packages/inline-edit/src/InlineEdit.tsx
@@ -1,6 +1,6 @@
 import type { InlineVariants } from './styles/InlineEdit.css';
 import type { ButtonProps } from '@launchpad-ui/button';
-import type { ComponentProps, Dispatch, SetStateAction } from 'react';
+import type { ComponentProps, Dispatch, KeyboardEventHandler, SetStateAction } from 'react';
 
 import { Button, ButtonGroup, IconButton } from '@launchpad-ui/button';
 import { TextField } from '@launchpad-ui/form';
@@ -52,6 +52,16 @@ const InlineEdit = ({
     setEditing(false);
   };
 
+  const handleKeyDown: KeyboardEventHandler<HTMLInputElement> = (event) => {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      handleSave();
+    } else if (event.key === 'Escape') {
+      event.preventDefault();
+      handleCancel();
+    }
+  };
+
   const ReadComponent = hideEdit ? Button : Slot;
   const buttonProps: Partial<ButtonProps> = hideEdit
     ? {
@@ -63,7 +73,7 @@ const InlineEdit = ({
 
   return isEditing ? (
     <div className={cx(container, inline({ layout }))} data-test-id={testId}>
-      <TextField defaultValue={defaultValue} ref={inputRef} />
+      <TextField defaultValue={defaultValue} ref={inputRef} onKeyDown={handleKeyDown} />
       <ButtonGroup spacing="compact">
         <IconButton
           kind="primary"

--- a/packages/inline-edit/src/InlineEdit.tsx
+++ b/packages/inline-edit/src/InlineEdit.tsx
@@ -26,6 +26,9 @@ type InlineEditProps = ComponentProps<'div'> &
     onSave: Dispatch<SetStateAction<string>>;
     hideEdit?: boolean;
     renderInput?: ReactElement<TextFieldProps | TextAreaProps>;
+    isEditing?: boolean;
+    onCancel?: () => void;
+    onEdit?: () => void;
   };
 
 const InlineEdit = ({
@@ -37,10 +40,20 @@ const InlineEdit = ({
   hideEdit = false,
   renderInput = <TextField />,
   'aria-label': ariaLabel,
+  isEditing: isEditingProp,
+  onCancel,
+  onEdit,
 }: InlineEditProps) => {
-  const [isEditing, setEditing] = useState(false);
+  const [isEditing, setEditing] = useState(isEditingProp ?? false);
   const inputRef = useRef<HTMLInputElement>(null);
   const editRef = useRef<HTMLButtonElement>(null);
+  const controlled = isEditingProp !== undefined;
+
+  useUpdateEffect(() => {
+    if (controlled) {
+      setEditing(isEditingProp);
+    }
+  }, [isEditingProp]);
 
   useUpdateEffect(() => {
     isEditing
@@ -49,16 +62,18 @@ const InlineEdit = ({
   }, [isEditing]);
 
   const handleEdit = () => {
-    setEditing(true);
+    !controlled && setEditing(true);
+    onEdit?.();
   };
 
   const handleCancel = () => {
-    setEditing(false);
+    !controlled && setEditing(false);
+    onCancel?.();
   };
 
   const handleSave = () => {
     onSave(inputRef.current?.value || '');
-    setEditing(false);
+    !controlled && setEditing(false);
   };
 
   const handleKeyDown: KeyboardEventHandler<HTMLInputElement> = (event) => {

--- a/packages/inline-edit/src/InlineEdit.tsx
+++ b/packages/inline-edit/src/InlineEdit.tsx
@@ -74,7 +74,7 @@ const InlineEdit = ({
   const { buttonProps } = useButton(
     {
       'aria-label': 'edit',
-      elementType: 'div',
+      elementType: 'span',
       onPress: handleEdit,
     },
     editRef

--- a/packages/inline-edit/src/InlineEdit.tsx
+++ b/packages/inline-edit/src/InlineEdit.tsx
@@ -25,7 +25,7 @@ type InlineEditProps = ComponentProps<'div'> &
     'data-test-id'?: string;
     onSave: Dispatch<SetStateAction<string>>;
     hideEdit?: boolean;
-    input?: ReactElement<TextFieldProps | TextAreaProps>;
+    renderInput?: ReactElement<TextFieldProps | TextAreaProps>;
   };
 
 const InlineEdit = ({
@@ -35,7 +35,7 @@ const InlineEdit = ({
   defaultValue,
   onSave,
   hideEdit = false,
-  input = <TextField />,
+  renderInput = <TextField />,
   'aria-label': ariaLabel,
 }: InlineEditProps) => {
   const [isEditing, setEditing] = useState(false);
@@ -97,9 +97,9 @@ const InlineEdit = ({
     </>
   );
 
-  const renderInput = cloneElement(
-    input,
-    mergeProps(input.props, {
+  const input = cloneElement(
+    renderInput,
+    mergeProps(renderInput.props, {
       ref: inputRef,
       defaultValue,
       onKeyDown: handleKeyDown,
@@ -109,7 +109,7 @@ const InlineEdit = ({
 
   return isEditing ? (
     <div className={cx(container, inline({ layout }))} data-test-id={testId}>
-      {renderInput}
+      {input}
       <ButtonGroup spacing="compact">
         <IconButton
           kind="primary"

--- a/packages/inline-edit/src/InlineEdit.tsx
+++ b/packages/inline-edit/src/InlineEdit.tsx
@@ -1,35 +1,69 @@
 import type { InlineVariants } from './styles/InlineEdit.css';
-import type { ComponentProps } from 'react';
+import type { ComponentProps, Dispatch, SetStateAction } from 'react';
 
 import { ButtonGroup, IconButton } from '@launchpad-ui/button';
 import { TextField } from '@launchpad-ui/form';
 import { Icon } from '@launchpad-ui/icons';
+import { Slot } from '@radix-ui/react-slot';
 import { cx } from 'classix';
+import { useRef, useState } from 'react';
 
 import { container, cancelButton, inline } from './styles/InlineEdit.css';
 
 type InlineEditProps = ComponentProps<'div'> &
-  InlineVariants & {
+  InlineVariants &
+  Pick<ComponentProps<'input'>, 'defaultValue'> & {
     'data-test-id'?: string;
+    onSave: Dispatch<SetStateAction<string>>;
   };
 
 const InlineEdit = ({
   className,
   'data-test-id': testId = 'inline-edit',
   layout = 'horizontal',
+  children,
+  defaultValue,
+  onSave,
 }: InlineEditProps) => {
-  return (
+  const [isEditing, setEditing] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const handleEdit = () => {
+    setEditing(true);
+  };
+
+  const handleCancel = () => {
+    setEditing(false);
+  };
+
+  const handleSave = () => {
+    onSave(inputRef.current?.value || '');
+    setEditing(false);
+  };
+
+  return isEditing ? (
     <div className={cx(container, inline({ layout }), className)} data-test-id={testId}>
-      <TextField />
+      <TextField defaultValue={defaultValue} autoFocus ref={inputRef} />
       <ButtonGroup spacing="compact">
-        <IconButton kind="primary" icon={<Icon name="check" />} aria-label="save" />
+        <IconButton
+          kind="primary"
+          icon={<Icon name="check" />}
+          aria-label="save"
+          onClick={handleSave}
+        />
         <IconButton
           kind="default"
           icon={<Icon name="close" />}
           aria-label="cancel"
           className={cancelButton}
+          onClick={handleCancel}
         />
       </ButtonGroup>
+    </div>
+  ) : (
+    <div className={container}>
+      <Slot onClick={handleEdit}>{children}</Slot>
+      <IconButton icon={<Icon name="edit" />} aria-label="edit" size="small" onClick={handleEdit} />
     </div>
   );
 };

--- a/packages/inline-edit/src/InlineEdit.tsx
+++ b/packages/inline-edit/src/InlineEdit.tsx
@@ -1,5 +1,12 @@
 import type { InlineVariants } from './styles/InlineEdit.css';
-import type { ComponentProps, Dispatch, KeyboardEventHandler, SetStateAction } from 'react';
+import type { TextAreaProps, TextFieldProps } from '@launchpad-ui/form';
+import type {
+  ComponentProps,
+  Dispatch,
+  KeyboardEventHandler,
+  ReactElement,
+  SetStateAction,
+} from 'react';
 
 import { ButtonGroup, IconButton } from '@launchpad-ui/button';
 import { TextField } from '@launchpad-ui/form';
@@ -8,7 +15,7 @@ import { useButton } from '@react-aria/button';
 import { focusSafely } from '@react-aria/focus';
 import { useUpdateEffect } from '@react-aria/utils';
 import { cx } from 'classix';
-import { useRef, useState } from 'react';
+import { cloneElement, useRef, useState } from 'react';
 
 import { container, cancelButton, inline, readButton } from './styles/InlineEdit.css';
 
@@ -18,6 +25,7 @@ type InlineEditProps = ComponentProps<'div'> &
     'data-test-id'?: string;
     onSave: Dispatch<SetStateAction<string>>;
     hideEdit?: boolean;
+    input?: ReactElement<TextFieldProps | TextAreaProps>;
   };
 
 const InlineEdit = ({
@@ -27,6 +35,7 @@ const InlineEdit = ({
   defaultValue,
   onSave,
   hideEdit = false,
+  input = <TextField />,
 }: InlineEditProps) => {
   const [isEditing, setEditing] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -70,27 +79,32 @@ const InlineEdit = ({
     editRef
   );
 
-  const renderReadContent = () =>
-    hideEdit ? (
-      <span ref={editRef} {...buttonProps} className={readButton}>
-        {children}
-      </span>
-    ) : (
-      <>
-        {children}
-        <IconButton
-          ref={editRef}
-          icon={<Icon name="edit" />}
-          aria-label="edit"
-          size="small"
-          onClick={handleEdit}
-        />
-      </>
-    );
+  const renderReadContent = hideEdit ? (
+    <span ref={editRef} {...buttonProps} className={readButton}>
+      {children}
+    </span>
+  ) : (
+    <>
+      {children}
+      <IconButton
+        ref={editRef}
+        icon={<Icon name="edit" />}
+        aria-label="edit"
+        size="small"
+        onClick={handleEdit}
+      />
+    </>
+  );
+
+  const renderInput = cloneElement(input, {
+    ref: inputRef,
+    defaultValue,
+    onKeyDown: handleKeyDown,
+  });
 
   return isEditing ? (
     <div className={cx(container, inline({ layout }))} data-test-id={testId}>
-      <TextField defaultValue={defaultValue} ref={inputRef} onKeyDown={handleKeyDown} />
+      {renderInput}
       <ButtonGroup spacing="compact">
         <IconButton
           kind="primary"
@@ -109,7 +123,7 @@ const InlineEdit = ({
     </div>
   ) : (
     <div className={cx(!hideEdit && container)} data-test-id={testId}>
-      {renderReadContent()}
+      {renderReadContent}
     </div>
   );
 };

--- a/packages/inline-edit/src/InlineEdit.tsx
+++ b/packages/inline-edit/src/InlineEdit.tsx
@@ -1,17 +1,16 @@
 import type { InlineVariants } from './styles/InlineEdit.css';
-import type { ButtonProps } from '@launchpad-ui/button';
 import type { ComponentProps, Dispatch, KeyboardEventHandler, SetStateAction } from 'react';
 
-import { Button, ButtonGroup, IconButton } from '@launchpad-ui/button';
+import { ButtonGroup, IconButton } from '@launchpad-ui/button';
 import { TextField } from '@launchpad-ui/form';
 import { Icon } from '@launchpad-ui/icons';
-import { Slot } from '@radix-ui/react-slot';
+import { useButton } from '@react-aria/button';
 import { focusSafely } from '@react-aria/focus';
 import { useUpdateEffect } from '@react-aria/utils';
 import { cx } from 'classix';
 import { useRef, useState } from 'react';
 
-import { container, cancelButton, inline, buttonText } from './styles/InlineEdit.css';
+import { container, cancelButton, inline, readButton } from './styles/InlineEdit.css';
 
 type InlineEditProps = ComponentProps<'div'> &
   InlineVariants &
@@ -62,14 +61,32 @@ const InlineEdit = ({
     }
   };
 
-  const ReadComponent = hideEdit ? Button : Slot;
-  const buttonProps: Partial<ButtonProps> = hideEdit
-    ? {
-        kind: 'minimal',
-        'aria-label': 'edit',
-        className: buttonText,
-      }
-    : {};
+  const { buttonProps } = useButton(
+    {
+      'aria-label': 'edit',
+      elementType: 'div',
+      onPress: handleEdit,
+    },
+    editRef
+  );
+
+  const renderReadContent = () =>
+    hideEdit ? (
+      <span ref={editRef} {...buttonProps} className={readButton}>
+        {children}
+      </span>
+    ) : (
+      <>
+        {children}
+        <IconButton
+          ref={editRef}
+          icon={<Icon name="edit" />}
+          aria-label="edit"
+          size="small"
+          onClick={handleEdit}
+        />
+      </>
+    );
 
   return isEditing ? (
     <div className={cx(container, inline({ layout }))} data-test-id={testId}>
@@ -91,23 +108,8 @@ const InlineEdit = ({
       </ButtonGroup>
     </div>
   ) : (
-    <div className={cx(container)} data-test-id={testId}>
-      <ReadComponent
-        ref={editRef}
-        onClick={hideEdit ? handleEdit : () => undefined}
-        {...buttonProps}
-      >
-        {children}
-      </ReadComponent>
-      {!hideEdit && (
-        <IconButton
-          ref={editRef}
-          icon={<Icon name="edit" />}
-          aria-label="edit"
-          size="small"
-          onClick={handleEdit}
-        />
-      )}
+    <div className={cx(!hideEdit && container)} data-test-id={testId}>
+      {renderReadContent()}
     </div>
   );
 };

--- a/packages/inline-edit/src/InlineEdit.tsx
+++ b/packages/inline-edit/src/InlineEdit.tsx
@@ -13,7 +13,7 @@ import { TextField } from '@launchpad-ui/form';
 import { Icon } from '@launchpad-ui/icons';
 import { useButton } from '@react-aria/button';
 import { focusSafely } from '@react-aria/focus';
-import { useUpdateEffect } from '@react-aria/utils';
+import { mergeProps, useUpdateEffect } from '@react-aria/utils';
 import { cx } from 'classix';
 import { cloneElement, useRef, useState } from 'react';
 
@@ -36,6 +36,7 @@ const InlineEdit = ({
   onSave,
   hideEdit = false,
   input = <TextField />,
+  'aria-label': ariaLabel,
 }: InlineEditProps) => {
   const [isEditing, setEditing] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -96,11 +97,15 @@ const InlineEdit = ({
     </>
   );
 
-  const renderInput = cloneElement(input, {
-    ref: inputRef,
-    defaultValue,
-    onKeyDown: handleKeyDown,
-  });
+  const renderInput = cloneElement(
+    input,
+    mergeProps(input.props, {
+      ref: inputRef,
+      defaultValue,
+      onKeyDown: handleKeyDown,
+      'aria-label': ariaLabel,
+    })
+  );
 
   return isEditing ? (
     <div className={cx(container, inline({ layout }))} data-test-id={testId}>

--- a/packages/inline-edit/src/InlineEdit.tsx
+++ b/packages/inline-edit/src/InlineEdit.tsx
@@ -11,7 +11,7 @@ import { useUpdateEffect } from '@react-aria/utils';
 import { cx } from 'classix';
 import { useRef, useState } from 'react';
 
-import { container, cancelButton, inline } from './styles/InlineEdit.css';
+import { container, cancelButton, inline, buttonText } from './styles/InlineEdit.css';
 
 type InlineEditProps = ComponentProps<'div'> &
   InlineVariants &
@@ -57,7 +57,7 @@ const InlineEdit = ({
     ? {
         kind: 'minimal',
         'aria-label': 'edit',
-        style: { fontSize: 'inherit', fontWeight: 'inherit', lineHeight: 'inherit' },
+        className: buttonText,
       }
     : {};
 

--- a/packages/inline-edit/src/InlineEdit.tsx
+++ b/packages/inline-edit/src/InlineEdit.tsx
@@ -1,0 +1,38 @@
+import type { InlineVariants } from './styles/InlineEdit.css';
+import type { ComponentProps } from 'react';
+
+import { ButtonGroup, IconButton } from '@launchpad-ui/button';
+import { TextField } from '@launchpad-ui/form';
+import { Icon } from '@launchpad-ui/icons';
+import { cx } from 'classix';
+
+import { container, cancelButton, inline } from './styles/InlineEdit.css';
+
+type InlineEditProps = ComponentProps<'div'> &
+  InlineVariants & {
+    'data-test-id'?: string;
+  };
+
+const InlineEdit = ({
+  className,
+  'data-test-id': testId = 'inline-edit',
+  layout = 'horizontal',
+}: InlineEditProps) => {
+  return (
+    <div className={cx(container, inline({ layout }), className)} data-test-id={testId}>
+      <TextField />
+      <ButtonGroup spacing="compact">
+        <IconButton kind="primary" icon={<Icon name="check" />} aria-label="save" />
+        <IconButton
+          kind="default"
+          icon={<Icon name="close" />}
+          aria-label="cancel"
+          className={cancelButton}
+        />
+      </ButtonGroup>
+    </div>
+  );
+};
+
+export { InlineEdit };
+export type { InlineEditProps };

--- a/packages/inline-edit/src/InlineEdit.tsx
+++ b/packages/inline-edit/src/InlineEdit.tsx
@@ -13,6 +13,7 @@ import { TextField } from '@launchpad-ui/form';
 import { Icon } from '@launchpad-ui/icons';
 import { useButton } from '@react-aria/button';
 import { focusSafely } from '@react-aria/focus';
+import { useFocusWithin } from '@react-aria/interactions';
 import { mergeProps, useUpdateEffect } from '@react-aria/utils';
 import { cx } from 'classix';
 import { cloneElement, useRef, useState } from 'react';
@@ -51,6 +52,7 @@ const InlineEdit = ({
   confirmButtonLabel = 'confirm',
 }: InlineEditProps) => {
   const [isEditing, setEditing] = useState(isEditingProp ?? false);
+  const [isFocusWithin, setFocusWithin] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
   const editRef = useRef<HTMLButtonElement>(null);
   const controlled = isEditingProp !== undefined;
@@ -62,9 +64,11 @@ const InlineEdit = ({
   }, [isEditingProp]);
 
   useUpdateEffect(() => {
-    isEditing
-      ? inputRef.current && focusSafely(inputRef.current)
-      : editRef.current && focusSafely(editRef.current);
+    if (isFocusWithin) {
+      isEditing
+        ? inputRef.current && focusSafely(inputRef.current)
+        : editRef.current && focusSafely(editRef.current);
+    }
   }, [isEditing]);
 
   const handleEdit = () => {
@@ -91,6 +95,11 @@ const InlineEdit = ({
       handleCancel();
     }
   };
+
+  const { focusWithinProps } = useFocusWithin({
+    onBlurWithin: () => isEditing && handleCancel(),
+    onFocusWithinChange: (isFocusWithin) => setFocusWithin(isFocusWithin),
+  });
 
   const { buttonProps } = useButton(
     {
@@ -129,7 +138,7 @@ const InlineEdit = ({
   );
 
   return isEditing ? (
-    <div className={cx(container, inline({ layout }))} data-test-id={testId}>
+    <div className={cx(container, inline({ layout }))} data-test-id={testId} {...focusWithinProps}>
       {input}
       <ButtonGroup spacing="compact">
         <IconButton
@@ -148,7 +157,7 @@ const InlineEdit = ({
       </ButtonGroup>
     </div>
   ) : (
-    <div className={cx(!hideEdit && container)} data-test-id={testId}>
+    <div className={cx(!hideEdit && container)} data-test-id={testId} {...focusWithinProps}>
       {renderReadContent}
     </div>
   );

--- a/packages/inline-edit/src/InlineEdit.tsx
+++ b/packages/inline-edit/src/InlineEdit.tsx
@@ -23,12 +23,15 @@ type InlineEditProps = ComponentProps<'div'> &
   InlineVariants &
   Pick<ComponentProps<'input'>, 'defaultValue'> & {
     'data-test-id'?: string;
-    onSave: Dispatch<SetStateAction<string>>;
+    onConfirm: Dispatch<SetStateAction<string>>;
     hideEdit?: boolean;
     renderInput?: ReactElement<TextFieldProps | TextAreaProps>;
     isEditing?: boolean;
     onCancel?: () => void;
     onEdit?: () => void;
+    cancelButtonLabel?: string;
+    editButtonLabel?: string;
+    confirmButtonLabel?: string;
   };
 
 const InlineEdit = ({
@@ -36,13 +39,16 @@ const InlineEdit = ({
   layout = 'horizontal',
   children,
   defaultValue,
-  onSave,
+  onConfirm,
   hideEdit = false,
   renderInput = <TextField />,
   'aria-label': ariaLabel,
   isEditing: isEditingProp,
   onCancel,
   onEdit,
+  cancelButtonLabel = 'cancel',
+  editButtonLabel = 'edit',
+  confirmButtonLabel = 'confirm',
 }: InlineEditProps) => {
   const [isEditing, setEditing] = useState(isEditingProp ?? false);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -71,15 +77,15 @@ const InlineEdit = ({
     onCancel?.();
   };
 
-  const handleSave = () => {
-    onSave(inputRef.current?.value || '');
+  const handleConfirm = () => {
+    onConfirm(inputRef.current?.value || '');
     !controlled && setEditing(false);
   };
 
   const handleKeyDown: KeyboardEventHandler<HTMLInputElement> = (event) => {
     if (event.key === 'Enter') {
       event.preventDefault();
-      handleSave();
+      handleConfirm();
     } else if (event.key === 'Escape') {
       event.preventDefault();
       handleCancel();
@@ -88,7 +94,7 @@ const InlineEdit = ({
 
   const { buttonProps } = useButton(
     {
-      'aria-label': 'edit',
+      'aria-label': editButtonLabel,
       elementType: 'span',
       onPress: handleEdit,
     },
@@ -105,7 +111,7 @@ const InlineEdit = ({
       <IconButton
         ref={editRef}
         icon={<Icon name="edit" />}
-        aria-label="edit"
+        aria-label={editButtonLabel}
         size="small"
         onClick={handleEdit}
       />
@@ -129,13 +135,13 @@ const InlineEdit = ({
         <IconButton
           kind="primary"
           icon={<Icon name="check" />}
-          aria-label="save"
-          onClick={handleSave}
+          aria-label={confirmButtonLabel}
+          onClick={handleConfirm}
         />
         <IconButton
           kind="default"
           icon={<Icon name="close" />}
-          aria-label="cancel"
+          aria-label={cancelButtonLabel}
           className={cancelButton}
           onClick={handleCancel}
         />

--- a/packages/inline-edit/src/index.ts
+++ b/packages/inline-edit/src/index.ts
@@ -1,0 +1,2 @@
+export type { InlineEditProps } from './InlineEdit';
+export { InlineEdit } from './InlineEdit';

--- a/packages/inline-edit/src/styles/InlineEdit.css.ts
+++ b/packages/inline-edit/src/styles/InlineEdit.css.ts
@@ -36,6 +36,12 @@ const readButton = style({
     background: vars.color.bg.interactive.tertiary.hover,
     cursor: 'pointer',
   },
+  ':focus-visible': {
+    borderRadius: vars.border.radius.medium,
+    boxShadow: `0 0 0 2px ${vars.color.bg.ui.primary}, 0 0 0 4px ${vars.color.shadow.interactive.focus}`,
+    outline: 0,
+    zIndex: 2,
+  },
 });
 
 type InlineVariants = RecipeVariants<typeof inline>;

--- a/packages/inline-edit/src/styles/InlineEdit.css.ts
+++ b/packages/inline-edit/src/styles/InlineEdit.css.ts
@@ -4,19 +4,19 @@ import { vars } from '@launchpad-ui/vars';
 import { style } from '@vanilla-extract/css';
 import { recipe } from '@vanilla-extract/recipes';
 
-const inline = recipe({
-  variants: {
-    layout: {
-      vertical: { flexDirection: 'column' },
-      horizontal: { flexDirection: 'row' },
-    },
-  },
-});
-
 const container = style({
   display: 'flex',
   gap: vars.spacing[300],
   alignItems: 'center',
+});
+
+const inline = recipe({
+  variants: {
+    layout: {
+      vertical: { flexDirection: 'column', alignItems: 'flex-start' },
+      horizontal: { flexDirection: 'row' },
+    },
+  },
 });
 
 const cancelButton = style({

--- a/packages/inline-edit/src/styles/InlineEdit.css.ts
+++ b/packages/inline-edit/src/styles/InlineEdit.css.ts
@@ -16,6 +16,7 @@ const inline = recipe({
 const container = style({
   display: 'flex',
   gap: vars.spacing[300],
+  alignItems: 'center',
 });
 
 const cancelButton = style({

--- a/packages/inline-edit/src/styles/InlineEdit.css.ts
+++ b/packages/inline-edit/src/styles/InlineEdit.css.ts
@@ -29,7 +29,7 @@ const cancelButton = style({
 });
 
 const readButton = style({
-  display: 'block',
+  display: 'inline-block',
   padding: `${vars.spacing[200]} ${vars.spacing[300]}`,
   borderRadius: vars.border.radius.regular,
   ':hover': {

--- a/packages/inline-edit/src/styles/InlineEdit.css.ts
+++ b/packages/inline-edit/src/styles/InlineEdit.css.ts
@@ -1,0 +1,33 @@
+import type { RecipeVariants } from '@vanilla-extract/recipes';
+
+import { vars } from '@launchpad-ui/vars';
+import { style } from '@vanilla-extract/css';
+import { recipe } from '@vanilla-extract/recipes';
+
+const inline = recipe({
+  variants: {
+    layout: {
+      vertical: { flexDirection: 'column' },
+      horizontal: { flexDirection: 'row' },
+    },
+  },
+});
+
+const container = style({
+  display: 'flex',
+  gap: vars.spacing[300],
+});
+
+const cancelButton = style({
+  selectors: {
+    '.Button--icon&': {
+      height: '3rem',
+      width: '3rem',
+    },
+  },
+});
+
+type InlineVariants = RecipeVariants<typeof inline>;
+
+export { container, cancelButton, inline };
+export type { InlineVariants };

--- a/packages/inline-edit/src/styles/InlineEdit.css.ts
+++ b/packages/inline-edit/src/styles/InlineEdit.css.ts
@@ -28,13 +28,17 @@ const cancelButton = style({
   },
 });
 
-const buttonText = style({
-  fontSize: 'inherit',
-  fontWeight: 'inherit',
-  lineHeight: 'inherit',
+const readButton = style({
+  display: 'block',
+  padding: `${vars.spacing[200]} ${vars.spacing[300]}`,
+  borderRadius: vars.border.radius.regular,
+  ':hover': {
+    background: vars.color.bg.interactive.tertiary.hover,
+    cursor: 'pointer',
+  },
 });
 
 type InlineVariants = RecipeVariants<typeof inline>;
 
-export { container, cancelButton, inline, buttonText };
+export { container, cancelButton, inline, readButton };
 export type { InlineVariants };

--- a/packages/inline-edit/src/styles/InlineEdit.css.ts
+++ b/packages/inline-edit/src/styles/InlineEdit.css.ts
@@ -28,7 +28,13 @@ const cancelButton = style({
   },
 });
 
+const buttonText = style({
+  fontSize: 'inherit',
+  fontWeight: 'inherit',
+  lineHeight: 'inherit',
+});
+
 type InlineVariants = RecipeVariants<typeof inline>;
 
-export { container, cancelButton, inline };
+export { container, cancelButton, inline, buttonText };
 export type { InlineVariants };

--- a/packages/inline-edit/stories/InlineEdit.stories.tsx
+++ b/packages/inline-edit/stories/InlineEdit.stories.tsx
@@ -24,9 +24,11 @@ export const Example: Story = {
     const [editValue, setEditValue] = useState('edit me');
 
     return (
-      <InlineEdit defaultValue={editValue} {...args} onSave={setEditValue}>
-        <span>{editValue}</span>
-      </InlineEdit>
+      <div style={{ width: '500px' }}>
+        <InlineEdit defaultValue={editValue} {...args} onSave={setEditValue}>
+          <span>{editValue}</span>
+        </InlineEdit>
+      </div>
     );
   },
 };
@@ -36,7 +38,7 @@ export const Title: Story = {
     const [editValue, setEditValue] = useState('This is a title');
 
     return (
-      <div style={{ width: 'max-content' }}>
+      <div style={{ width: '500px' }}>
         <InlineEdit defaultValue={editValue} {...args} onSave={setEditValue} hideEdit>
           <h3>{editValue}</h3>
         </InlineEdit>

--- a/packages/inline-edit/stories/InlineEdit.stories.tsx
+++ b/packages/inline-edit/stories/InlineEdit.stories.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable react-hooks/rules-of-hooks */
 import type { StoryObj } from '@storybook/react';
 
+import { CopyToClipboard } from '@launchpad-ui/clipboard';
 import { useState } from '@storybook/client-api';
 
 import { InlineEdit } from '../src';
@@ -35,9 +36,27 @@ export const Title: Story = {
     const [editValue, setEditValue] = useState('This is a title');
 
     return (
-      <InlineEdit defaultValue={editValue} {...args} onSave={setEditValue}>
-        <h2>{editValue}</h2>
-      </InlineEdit>
+      <div style={{ width: 'max-content' }}>
+        <InlineEdit defaultValue={editValue} {...args} onSave={setEditValue} hideEdit>
+          <h3>{editValue}</h3>
+        </InlineEdit>
+      </div>
+    );
+  },
+};
+
+export const Copy: Story = {
+  render: (args) => {
+    const [editValue, setEditValue] = useState('auto-generated-key');
+
+    return (
+      <div style={{ width: 'max-content' }}>
+        <InlineEdit defaultValue={editValue} {...args} onSave={setEditValue}>
+          <CopyToClipboard text={editValue} kind="basic">
+            {editValue}
+          </CopyToClipboard>
+        </InlineEdit>
+      </div>
     );
   },
 };

--- a/packages/inline-edit/stories/InlineEdit.stories.tsx
+++ b/packages/inline-edit/stories/InlineEdit.stories.tsx
@@ -2,7 +2,7 @@
 import type { StoryObj } from '@storybook/react';
 
 import { CopyToClipboard } from '@launchpad-ui/clipboard';
-import { TextArea } from '@launchpad-ui/form';
+import { Form, FormField, TextArea, TextField } from '@launchpad-ui/form';
 import { useState } from '@storybook/client-api';
 import { userEvent, within } from '@storybook/testing-library';
 
@@ -39,9 +39,9 @@ export const Example: Story = {
   },
 };
 
-export const Title: Story = {
+export const EditTitle: Story = {
   render: (args) => {
-    const [editValue, setEditValue] = useState('This is a title');
+    const [editValue, setEditValue] = useState('Unnamed title');
 
     return (
       <div style={{ width: '500px' }}>
@@ -53,7 +53,7 @@ export const Title: Story = {
   },
 };
 
-export const Copy: Story = {
+export const EditCopy: Story = {
   render: (args) => {
     const [editValue, setEditValue] = useState('auto-generated-key');
 
@@ -69,14 +69,41 @@ export const Copy: Story = {
   },
 };
 
-export const Textarea: Story = {
+export const WithTextarea: Story = {
   render: (args) => {
-    const [editValue, setEditValue] = useState('edit me');
+    const [editValue, setEditValue] = useState('edit description');
 
     return (
       <InlineEdit defaultValue={editValue} {...args} onSave={setEditValue} input={<TextArea />}>
         <span>{editValue}</span>
       </InlineEdit>
+    );
+  },
+};
+
+export const InForm: Story = {
+  render: (args) => {
+    const [editValue, setEditValue] = useState('');
+
+    return (
+      <Form>
+        <FormField
+          name="Name"
+          label="Name"
+          htmlFor="inline-edit"
+          isRequired
+          errorMessage={editValue ? undefined : 'No value entered'}
+        >
+          <InlineEdit
+            defaultValue={editValue}
+            {...args}
+            onSave={setEditValue}
+            input={<TextField id="inline-edit" />}
+          >
+            <span>{editValue || 'Enter a value'}</span>
+          </InlineEdit>
+        </FormField>
+      </Form>
     );
   },
 };

--- a/packages/inline-edit/stories/InlineEdit.stories.tsx
+++ b/packages/inline-edit/stories/InlineEdit.stories.tsx
@@ -74,7 +74,12 @@ export const WithTextarea: Story = {
     const [editValue, setEditValue] = useState('edit description');
 
     return (
-      <InlineEdit defaultValue={editValue} {...args} onSave={setEditValue} input={<TextArea />}>
+      <InlineEdit
+        defaultValue={editValue}
+        {...args}
+        onSave={setEditValue}
+        renderInput={<TextArea />}
+      >
         <span>{editValue}</span>
       </InlineEdit>
     );
@@ -98,7 +103,7 @@ export const InForm: Story = {
             defaultValue={editValue}
             {...args}
             onSave={setEditValue}
-            input={<TextField id="inline-edit" />}
+            renderInput={<TextField id="inline-edit" />}
           >
             <span>{editValue || 'Enter a value'}</span>
           </InlineEdit>

--- a/packages/inline-edit/stories/InlineEdit.stories.tsx
+++ b/packages/inline-edit/stories/InlineEdit.stories.tsx
@@ -24,11 +24,9 @@ export const Example: Story = {
     const [editValue, setEditValue] = useState('edit me');
 
     return (
-      <div style={{ width: '500px' }}>
-        <InlineEdit defaultValue={editValue} {...args} onSave={setEditValue}>
-          <span>{editValue}</span>
-        </InlineEdit>
-      </div>
+      <InlineEdit defaultValue={editValue} {...args} onSave={setEditValue}>
+        <span>{editValue}</span>
+      </InlineEdit>
     );
   },
 };

--- a/packages/inline-edit/stories/InlineEdit.stories.tsx
+++ b/packages/inline-edit/stories/InlineEdit.stories.tsx
@@ -2,6 +2,7 @@
 import type { StoryObj } from '@storybook/react';
 
 import { CopyToClipboard } from '@launchpad-ui/clipboard';
+import { TextArea } from '@launchpad-ui/form';
 import { useState } from '@storybook/client-api';
 
 import { InlineEdit } from '../src';
@@ -57,6 +58,18 @@ export const Copy: Story = {
           </CopyToClipboard>
         </InlineEdit>
       </div>
+    );
+  },
+};
+
+export const Textarea: Story = {
+  render: (args) => {
+    const [editValue, setEditValue] = useState('edit me');
+
+    return (
+      <InlineEdit defaultValue={editValue} {...args} onSave={setEditValue} input={<TextArea />}>
+        <span>{editValue}</span>
+      </InlineEdit>
     );
   },
 };

--- a/packages/inline-edit/stories/InlineEdit.stories.tsx
+++ b/packages/inline-edit/stories/InlineEdit.stories.tsx
@@ -30,7 +30,6 @@ export const Example: Story = {
         <InlineEdit defaultValue={editValue} {...args} onConfirm={setEditValue}>
           <span>{editValue}</span>
         </InlineEdit>
-        <button>wow</button>
       </>
     );
   },

--- a/packages/inline-edit/stories/InlineEdit.stories.tsx
+++ b/packages/inline-edit/stories/InlineEdit.stories.tsx
@@ -26,9 +26,12 @@ export const Example: Story = {
     const [editValue, setEditValue] = useState('edit me');
 
     return (
-      <InlineEdit defaultValue={editValue} {...args} onConfirm={setEditValue}>
-        <span>{editValue}</span>
-      </InlineEdit>
+      <>
+        <InlineEdit defaultValue={editValue} {...args} onConfirm={setEditValue}>
+          <span>{editValue}</span>
+        </InlineEdit>
+        <button>wow</button>
+      </>
     );
   },
   play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {

--- a/packages/inline-edit/stories/InlineEdit.stories.tsx
+++ b/packages/inline-edit/stories/InlineEdit.stories.tsx
@@ -112,3 +112,26 @@ export const InForm: Story = {
     );
   },
 };
+
+export const Controlled: Story = {
+  render: (args) => {
+    const [editValue, setEditValue] = useState('edit me');
+    const [isEditing, setEditing] = useState(true);
+
+    return (
+      <InlineEdit
+        defaultValue={editValue}
+        isEditing={isEditing}
+        onCancel={() => setEditing(false)}
+        onEdit={() => setEditing(true)}
+        {...args}
+        onSave={(value) => {
+          setEditValue(value);
+          setEditing(false);
+        }}
+      >
+        <span>{editValue}</span>
+      </InlineEdit>
+    );
+  },
+};

--- a/packages/inline-edit/stories/InlineEdit.stories.tsx
+++ b/packages/inline-edit/stories/InlineEdit.stories.tsx
@@ -1,4 +1,7 @@
+/* eslint-disable react-hooks/rules-of-hooks */
 import type { StoryObj } from '@storybook/react';
+
+import { useState } from '@storybook/client-api';
 
 import { InlineEdit } from '../src';
 
@@ -16,5 +19,25 @@ export default {
 type Story = StoryObj<typeof InlineEdit>;
 
 export const Example: Story = {
-  args: {},
+  render: (args) => {
+    const [editValue, setEditValue] = useState('edit me');
+
+    return (
+      <InlineEdit defaultValue={editValue} {...args} onSave={setEditValue}>
+        <span>{editValue}</span>
+      </InlineEdit>
+    );
+  },
+};
+
+export const Title: Story = {
+  render: (args) => {
+    const [editValue, setEditValue] = useState('This is a title');
+
+    return (
+      <InlineEdit defaultValue={editValue} {...args} onSave={setEditValue}>
+        <h2>{editValue}</h2>
+      </InlineEdit>
+    );
+  },
 };

--- a/packages/inline-edit/stories/InlineEdit.stories.tsx
+++ b/packages/inline-edit/stories/InlineEdit.stories.tsx
@@ -26,7 +26,7 @@ export const Example: Story = {
     const [editValue, setEditValue] = useState('edit me');
 
     return (
-      <InlineEdit defaultValue={editValue} {...args} onSave={setEditValue}>
+      <InlineEdit defaultValue={editValue} {...args} onConfirm={setEditValue}>
         <span>{editValue}</span>
       </InlineEdit>
     );
@@ -45,7 +45,7 @@ export const EditTitle: Story = {
 
     return (
       <div style={{ width: '500px' }}>
-        <InlineEdit defaultValue={editValue} {...args} onSave={setEditValue} hideEdit>
+        <InlineEdit defaultValue={editValue} {...args} onConfirm={setEditValue} hideEdit>
           <h3>{editValue}</h3>
         </InlineEdit>
       </div>
@@ -59,7 +59,7 @@ export const EditCopy: Story = {
 
     return (
       <div style={{ width: 'max-content' }}>
-        <InlineEdit defaultValue={editValue} {...args} onSave={setEditValue}>
+        <InlineEdit defaultValue={editValue} {...args} onConfirm={setEditValue}>
           <CopyToClipboard text={editValue} kind="basic">
             {editValue}
           </CopyToClipboard>
@@ -77,7 +77,7 @@ export const WithTextarea: Story = {
       <InlineEdit
         defaultValue={editValue}
         {...args}
-        onSave={setEditValue}
+        onConfirm={setEditValue}
         renderInput={<TextArea />}
       >
         <span>{editValue}</span>
@@ -102,7 +102,7 @@ export const InForm: Story = {
           <InlineEdit
             defaultValue={editValue}
             {...args}
-            onSave={setEditValue}
+            onConfirm={setEditValue}
             renderInput={<TextField id="inline-edit" />}
           >
             <span>{editValue || 'Enter a value'}</span>
@@ -125,7 +125,7 @@ export const Controlled: Story = {
         onCancel={() => setEditing(false)}
         onEdit={() => setEditing(true)}
         {...args}
-        onSave={(value) => {
+        onConfirm={(value) => {
           setEditValue(value);
           setEditing(false);
         }}

--- a/packages/inline-edit/stories/InlineEdit.stories.tsx
+++ b/packages/inline-edit/stories/InlineEdit.stories.tsx
@@ -4,6 +4,7 @@ import type { StoryObj } from '@storybook/react';
 import { CopyToClipboard } from '@launchpad-ui/clipboard';
 import { TextArea } from '@launchpad-ui/form';
 import { useState } from '@storybook/client-api';
+import { userEvent, within } from '@storybook/testing-library';
 
 import { InlineEdit } from '../src';
 
@@ -29,6 +30,12 @@ export const Example: Story = {
         <span>{editValue}</span>
       </InlineEdit>
     );
+  },
+  play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+    const canvas = within(canvasElement);
+
+    const edit = canvas.getAllByRole('button');
+    userEvent.click(edit[0]);
   },
 };
 

--- a/packages/inline-edit/stories/InlineEdit.stories.tsx
+++ b/packages/inline-edit/stories/InlineEdit.stories.tsx
@@ -1,0 +1,20 @@
+import type { StoryObj } from '@storybook/react';
+
+import { InlineEdit } from '../src';
+
+export default {
+  component: InlineEdit,
+  title: 'Components/InlineEdit',
+  description: 'An element used to display and allow inline editing of a form element value.',
+  parameters: {
+    status: {
+      type: import.meta.env.STORYBOOK_PACKAGE_STATUS__INLINE_EDIT,
+    },
+  },
+};
+
+type Story = StoryObj<typeof InlineEdit>;
+
+export const Example: Story = {
+  args: {},
+};

--- a/packages/inline-edit/tsconfig.build.json
+++ b/packages/inline-edit/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src/*.ts", "src/*.tsx", "../../types/declarations.d.ts"],
+  "compilerOptions": {
+    "outDir": "./dist"
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -809,9 +809,9 @@ importers:
       '@launchpad-ui/vars':
         specifier: workspace:~
         version: link:../vars
-      '@radix-ui/react-slot':
-        specifier: ^1.0.0
-        version: 1.0.0(react@18.2.0)
+      '@react-aria/button':
+        specifier: 3.8.0
+        version: 3.8.0(react@18.2.0)
       '@react-aria/focus':
         specifier: 3.13.0
         version: 3.13.0(react@18.2.0)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,8 +108,8 @@ importers:
         specifier: ^1.12.0
         version: 1.12.0
       '@vanilla-extract/recipes':
-        specifier: ^0.4.0
-        version: 0.4.0(@vanilla-extract/css@1.12.0)
+        specifier: ^0.5.0
+        version: 0.5.0(@vanilla-extract/css@1.12.0)
       '@vanilla-extract/vite-plugin':
         specifier: ^3.8.2
         version: 3.8.2(@types/node@18.17.0)(ts-node@10.9.1)(vite@4.4.2)
@@ -7955,8 +7955,8 @@ packages:
     resolution: {integrity: sha512-17kVyLq3ePTKOkveHxXuIJZtGYs+cSoev7BlP+Lf4916qfDhk/HBjvlYDe8egrea7LNPHKwSZJK/bzZC+Q6AwQ==}
     dev: true
 
-  /@vanilla-extract/recipes@0.4.0(@vanilla-extract/css@1.12.0):
-    resolution: {integrity: sha512-gFgB7BofUYbtbxINHK6DhMv1JDFDXp/YI/Xm+cqKar+1I/2dfxPepeDxSexL6YB4ftfeaDw8Kn5zydMvHcGOEQ==}
+  /@vanilla-extract/recipes@0.5.0(@vanilla-extract/css@1.12.0):
+    resolution: {integrity: sha512-NfdZ8XyqCDG2RsO3FmYPALDMKg5045dRD97NbBb0Fog3LMDVXZxYgDOct5FAWob8U6W4GbhVpRZt1X9hNnH6fA==}
     peerDependencies:
       '@vanilla-extract/css': ^1.0.0
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,6 +107,9 @@ importers:
       '@vanilla-extract/css':
         specifier: ^1.12.0
         version: 1.12.0
+      '@vanilla-extract/recipes':
+        specifier: ^0.4.0
+        version: 0.4.0(@vanilla-extract/css@1.12.0)
       '@vanilla-extract/vite-plugin':
         specifier: ^3.8.2
         version: 3.8.2(@types/node@18.17.0)(ts-node@10.9.1)(vite@4.4.2)
@@ -521,6 +524,9 @@ importers:
       '@launchpad-ui/inline':
         specifier: workspace:~
         version: link:../inline
+      '@launchpad-ui/inline-edit':
+        specifier: workspace:~
+        version: link:../inline-edit
       '@launchpad-ui/markdown':
         specifier: workspace:~
         version: link:../markdown
@@ -784,6 +790,25 @@ importers:
       '@launchpad-ui/types':
         specifier: workspace:~
         version: link:../types
+      classix:
+        specifier: 2.1.17
+        version: 2.1.17
+    devDependencies:
+      react:
+        specifier: 18.2.0
+        version: 18.2.0
+      react-dom:
+        specifier: 18.2.0
+        version: 18.2.0(react@18.2.0)
+
+  packages/inline-edit:
+    dependencies:
+      '@launchpad-ui/tokens':
+        specifier: workspace:~
+        version: link:../tokens
+      '@launchpad-ui/vars':
+        specifier: workspace:~
+        version: link:../vars
       classix:
         specifier: 2.1.17
         version: 2.1.17
@@ -7910,6 +7935,14 @@ packages:
 
   /@vanilla-extract/private@1.0.3:
     resolution: {integrity: sha512-17kVyLq3ePTKOkveHxXuIJZtGYs+cSoev7BlP+Lf4916qfDhk/HBjvlYDe8egrea7LNPHKwSZJK/bzZC+Q6AwQ==}
+    dev: true
+
+  /@vanilla-extract/recipes@0.4.0(@vanilla-extract/css@1.12.0):
+    resolution: {integrity: sha512-gFgB7BofUYbtbxINHK6DhMv1JDFDXp/YI/Xm+cqKar+1I/2dfxPepeDxSexL6YB4ftfeaDw8Kn5zydMvHcGOEQ==}
+    peerDependencies:
+      '@vanilla-extract/css': ^1.0.0
+    dependencies:
+      '@vanilla-extract/css': 1.12.0
     dev: true
 
   /@vanilla-extract/vite-plugin@3.8.2(@types/node@18.17.0)(ts-node@10.9.1)(vite@4.4.2):

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -809,6 +809,9 @@ importers:
       '@launchpad-ui/vars':
         specifier: workspace:~
         version: link:../vars
+      '@radix-ui/react-slot':
+        specifier: ^1.0.0
+        version: 1.0.0(react@18.2.0)
       classix:
         specifier: 2.1.17
         version: 2.1.17

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -824,6 +824,9 @@ importers:
       '@react-aria/focus':
         specifier: 3.13.0
         version: 3.13.0(react@18.2.0)
+      '@react-aria/interactions':
+        specifier: 3.16.0
+        version: 3.16.0(react@18.2.0)
       '@react-aria/utils':
         specifier: 3.18.0
         version: 3.18.0(react@18.2.0)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -812,6 +812,12 @@ importers:
       '@radix-ui/react-slot':
         specifier: ^1.0.0
         version: 1.0.0(react@18.2.0)
+      '@react-aria/focus':
+        specifier: 3.13.0
+        version: 3.13.0(react@18.2.0)
+      '@react-aria/utils':
+        specifier: 3.18.0
+        version: 3.18.0(react@18.2.0)
       classix:
         specifier: 2.1.17
         version: 2.1.17

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -827,6 +827,12 @@ importers:
       '@react-aria/utils':
         specifier: 3.18.0
         version: 3.18.0(react@18.2.0)
+      '@vanilla-extract/css':
+        specifier: ^1.12.0
+        version: 1.12.0
+      '@vanilla-extract/recipes':
+        specifier: ^0.5.0
+        version: 0.5.0(@vanilla-extract/css@1.12.0)
       classix:
         specifier: 2.1.17
         version: 2.1.17
@@ -3794,7 +3800,6 @@ packages:
 
   /@emotion/hash@0.9.1:
     resolution: {integrity: sha512-gJB6HLm5rYwSLI6PQa+X1t5CFGrv1J1TWG+sOyMCeKz2ojaj6Fnl/rZEspogG+cvqbt4AE/2eIyD2QfLKTBNlQ==}
-    dev: true
 
   /@emotion/is-prop-valid@0.8.8:
     resolution: {integrity: sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==}
@@ -7922,7 +7927,6 @@ packages:
       deepmerge: 4.3.1
       media-query-parser: 2.0.2
       outdent: 0.8.0
-    dev: true
 
   /@vanilla-extract/integration@6.2.1(@types/node@18.17.0):
     resolution: {integrity: sha512-+xYJz07G7TFAMZGrOqArOsURG+xcYvqctujEkANjw2McCBvGEK505RxQqOuNiA9Mi9hgGdNp2JedSa94f3eoLg==}
@@ -7953,7 +7957,6 @@ packages:
 
   /@vanilla-extract/private@1.0.3:
     resolution: {integrity: sha512-17kVyLq3ePTKOkveHxXuIJZtGYs+cSoev7BlP+Lf4916qfDhk/HBjvlYDe8egrea7LNPHKwSZJK/bzZC+Q6AwQ==}
-    dev: true
 
   /@vanilla-extract/recipes@0.5.0(@vanilla-extract/css@1.12.0):
     resolution: {integrity: sha512-NfdZ8XyqCDG2RsO3FmYPALDMKg5045dRD97NbBb0Fog3LMDVXZxYgDOct5FAWob8U6W4GbhVpRZt1X9hNnH6fA==}
@@ -7961,7 +7964,6 @@ packages:
       '@vanilla-extract/css': ^1.0.0
     dependencies:
       '@vanilla-extract/css': 1.12.0
-    dev: true
 
   /@vanilla-extract/vite-plugin@3.8.2(@types/node@18.17.0)(ts-node@10.9.1)(vite@4.4.2):
     resolution: {integrity: sha512-i0vpuBUoh10Obl0hJr0dWQa6M3Udu/irm4tnsg1lUze8DXTbv3ctHmVu/wrRZHKw1EzzW/v+nLoJJRvisApspQ==}
@@ -8351,7 +8353,6 @@ packages:
 
   /ahocorasick@1.0.2:
     resolution: {integrity: sha512-hCOfMzbFx5IDutmWLAt6MZwOUjIfSM9G9FyVxytmE4Rs/5YDPWQrD/+IR1w+FweD9H2oOZEnv36TmkjhNURBVA==}
-    dev: true
 
   /ajv-formats@2.1.1(ajv@8.12.0):
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
@@ -8433,7 +8434,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       color-convert: 2.0.1
-    dev: true
 
   /ansi-styles@5.2.0:
     resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
@@ -9153,7 +9153,6 @@ packages:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
-    dev: true
 
   /chalk@5.2.0:
     resolution: {integrity: sha512-ree3Gqw/nazQAPuJJEy+avdl7QfZMcUvmHIKgEZkGL+xOBzRvup5Hxo6LHuMceSxOabuJLJm5Yp/92R9eMmMvA==}
@@ -9363,7 +9362,6 @@ packages:
     engines: {node: '>=7.0.0'}
     dependencies:
       color-name: 1.1.4
-    dev: true
 
   /color-name@1.1.3:
     resolution: {integrity: sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==}
@@ -9371,7 +9369,6 @@ packages:
 
   /color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
-    dev: true
 
   /colord@2.9.3:
     resolution: {integrity: sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==}
@@ -9665,7 +9662,6 @@ packages:
   /css-what@6.1.0:
     resolution: {integrity: sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==}
     engines: {node: '>= 6'}
-    dev: true
 
   /css.escape@1.5.1:
     resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
@@ -9679,7 +9675,6 @@ packages:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
     hasBin: true
-    dev: true
 
   /cssstyle@3.0.0:
     resolution: {integrity: sha512-N4u2ABATi3Qplzf0hWbVCdjenim8F3ojEXpBDF5hBpjzW182MjNGLqfmQ0SkSPeQ+V86ZXgeH8aXj6kayd4jgg==}
@@ -9689,7 +9684,6 @@ packages:
 
   /csstype@3.1.2:
     resolution: {integrity: sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==}
-    dev: true
 
   /csv-generate@3.4.3:
     resolution: {integrity: sha512-w/T+rqR0vwvHqWs/1ZyMDWtHHSJaN06klRqJXBEpDJaM/+dZkso0OKh1VcuuYvK3XM53KysVNq8Ko/epCK8wOw==}
@@ -9939,7 +9933,6 @@ packages:
 
   /deep-object-diff@1.1.9:
     resolution: {integrity: sha512-Rn+RuwkmkDwCi2/oXOFS9Gsr5lJZu/yTGpK7wAaAIE75CC+LCGEZHpY6VQJa/RoJcrmaA/docWJZvYohlNkWPA==}
-    dev: true
 
   /deepmerge-ts@4.3.0:
     resolution: {integrity: sha512-if3ZYdkD2dClhnXR5reKtG98cwyaRT1NeugQoAPTTfsOpV9kqyeiBF9Qa5RHjemb3KzD5ulqygv6ED3t5j9eJw==}
@@ -9949,7 +9942,6 @@ packages:
   /deepmerge@4.3.1:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
     engines: {node: '>=0.10.0'}
-    dev: true
 
   /default-browser-id@3.0.0:
     resolution: {integrity: sha512-OZ1y3y0SqSICtE8DE4S8YOE9UZOJ8wO16fKWVP5J1Qz42kV9jcnMVFrEE/noXb/ss3Q4pZIH79kxofzyNNtUNA==}
@@ -13900,7 +13892,6 @@ packages:
     resolution: {integrity: sha512-1N4qp+jE0pL5Xv4uEcwVUhIkwdUO3S/9gML90nqKA7v7FcOS5vUtatfzok9S9U1EJU8dHWlcv95WLnKmmxZI9w==}
     dependencies:
       '@babel/runtime': 7.22.3
-    dev: true
 
   /media-typer@0.3.0:
     resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
@@ -14931,7 +14922,6 @@ packages:
 
   /outdent@0.8.0:
     resolution: {integrity: sha512-KiOAIsdpUTcAXuykya5fnVVT+/5uS0Q1mrkRHcF89tpieSmY33O/tmc54CqwA+bfhbtEfZUNLHaPUiB9X3jt1A==}
-    dev: true
 
   /p-cancelable@2.1.1:
     resolution: {integrity: sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==}
@@ -17484,7 +17474,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       has-flag: 4.0.0
-    dev: true
 
   /supports-color@8.1.1:
     resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -803,6 +803,15 @@ importers:
 
   packages/inline-edit:
     dependencies:
+      '@launchpad-ui/button':
+        specifier: workspace:~
+        version: link:../button
+      '@launchpad-ui/form':
+        specifier: workspace:~
+        version: link:../form
+      '@launchpad-ui/icons':
+        specifier: workspace:~
+        version: link:../icons
       '@launchpad-ui/tokens':
         specifier: workspace:~
         version: link:../tokens

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,6 +20,7 @@
       "@launchpad-ui/form": ["./packages/form/src"],
       "@launchpad-ui/icons": ["./packages/icons/src"],
       "@launchpad-ui/inline": ["./packages/inline/src"],
+      "@launchpad-ui/inline-edit": ["./packages/inline-edit/src"],
       "@launchpad-ui/markdown": ["./packages/markdown/src"],
       "@launchpad-ui/menu": ["./packages/menu/src"],
       "@launchpad-ui/modal": ["./packages/modal/src"],

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -56,6 +56,7 @@ export default defineConfig({
         ...Object.keys(packageJSON.dependencies || {}),
         ...Object.keys(packageJSON.peerDependencies || {}),
         'react/jsx-runtime',
+        '@vanilla-extract/recipes/createRuntimeFn',
       ],
     },
     sourcemap: true,


### PR DESCRIPTION
## Summary

Add `inline-edit` package to display and allow inline editing of a form elements:

- Use props `defaultValue` and `onConfirm` to handle state management of the value to edit
- Have children act as the "read" view of the component
- Hide edit icon button and wrap children with a React Aria button when `hideEdit` is true
- Implement focus management to ensure focus is directed correctly when toggling between read and edit mode
- Use `renderInput` prop to allow passing a custom `TextField` or `TextArea` component
- Add handlers for edit, cancel, and confirm actions
- Use prop `isEditing` to allow full control over the read and edit modes
- Add `@vanilla-extract/css` as a peer dependency for prop `layout` variant types
- Use `useFocusWithin` to cancel edit on blur

## Testing approaches

https://626696a2018c1f004a1cde86-biuafqdqpl.chromatic.com/
