### PR TITLE
fix: annotate pure functions

### DIFF
--- a/.changeset/tricky-coats-lay.md
+++ b/.changeset/tricky-coats-lay.md
@@ -1,0 +1,23 @@
+---
+'@launchpad-ui/avatar': patch
+'@launchpad-ui/button': patch
+'@launchpad-ui/chip': patch
+'@launchpad-ui/clipboard': patch
+'@launchpad-ui/dropdown': patch
+'@launchpad-ui/filter': patch
+'@launchpad-ui/focus-trap': patch
+'@launchpad-ui/form': patch
+'@launchpad-ui/icons': patch
+'@launchpad-ui/inline-edit': patch
+'@launchpad-ui/menu': patch
+'@launchpad-ui/modal': patch
+'@launchpad-ui/navigation': patch
+'@launchpad-ui/popover': patch
+'@launchpad-ui/portal': patch
+'@launchpad-ui/snackbar': patch
+'@launchpad-ui/split-button': patch
+'@launchpad-ui/tooltip': patch
+'@launchpad-ui/core': patch
+---
+
+Annotate pure functions

--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     "prettier": "^3.0.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",
+    "rollup-plugin-pure": "^0.1.1",
     "storybook-addon-pseudo-states": "^2.1.0",
     "stylelint": "^15.10.0",
     "stylelint-config-standard": "^34.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,7 +64,7 @@ importers:
         version: 7.2.0(react-dom@18.2.0)(react@18.2.0)(typescript@5.1.3)
       '@storybook/react-vite':
         specifier: ^7.2.0
-        version: 7.2.0(react-dom@18.2.0)(react@18.2.0)(typescript@5.1.3)(vite@4.4.2)
+        version: 7.2.0(react-dom@18.2.0)(react@18.2.0)(rollup@3.26.2)(typescript@5.1.3)(vite@4.4.2)
       '@storybook/testing-library':
         specifier: ^0.2.0
         version: 0.2.0
@@ -215,6 +215,9 @@ importers:
       react-dom:
         specifier: 18.2.0
         version: 18.2.0(react@18.2.0)
+      rollup-plugin-pure:
+        specifier: ^0.1.1
+        version: 0.1.1(rollup@3.26.2)
       storybook-addon-pseudo-states:
         specifier: ^2.1.0
         version: 2.1.0(@storybook/components@7.2.0)(@storybook/core-events@7.2.0)(@storybook/manager-api@7.2.0)(@storybook/preview-api@7.2.0)(@storybook/theming@7.2.0)(react-dom@18.2.0)(react@18.2.0)
@@ -7420,7 +7423,7 @@ packages:
       picomatch: 2.3.1
     dev: true
 
-  /@rollup/pluginutils@5.0.2:
+  /@rollup/pluginutils@5.0.2(rollup@3.26.2):
     resolution: {integrity: sha512-pTd9rIsP92h+B6wWwFbW8RkZv4hiR/xKsqre4SIuAOaOEQRxi0lqLke9k2/7WegC85GgUs9pjmOjCUi3In4vwA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -7432,6 +7435,7 @@ packages:
       '@types/estree': 1.0.1
       estree-walker: 2.0.2
       picomatch: 2.3.1
+      rollup: 3.26.2
     dev: true
 
   /@rushstack/eslint-patch@1.3.0:
@@ -8312,7 +8316,7 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: true
 
-  /@storybook/react-vite@7.2.0(react-dom@18.2.0)(react@18.2.0)(typescript@5.1.3)(vite@4.4.2):
+  /@storybook/react-vite@7.2.0(react-dom@18.2.0)(react@18.2.0)(rollup@3.26.2)(typescript@5.1.3)(vite@4.4.2):
     resolution: {integrity: sha512-I5MGIyMcEhOy00jTWehqb4T8zLqm1VWWUGU9EU26/J0AV4RB8HSWUZBbWXjbGtQI4SYZpX0GcMVObaVmXytFLw==}
     engines: {node: '>=16'}
     peerDependencies:
@@ -8321,7 +8325,7 @@ packages:
       vite: ^3.0.0 || ^4.0.0
     dependencies:
       '@joshwooding/vite-plugin-react-docgen-typescript': 0.2.1(typescript@5.1.3)(vite@4.4.2)
-      '@rollup/pluginutils': 5.0.2
+      '@rollup/pluginutils': 5.0.2(rollup@3.26.2)
       '@storybook/builder-vite': 7.2.0(typescript@5.1.3)(vite@4.4.2)
       '@storybook/react': 7.2.0(react-dom@18.2.0)(react@18.2.0)(typescript@5.1.3)
       '@vitejs/plugin-react': 3.1.0(vite@4.4.2)
@@ -18419,6 +18423,17 @@ packages:
     hasBin: true
     dependencies:
       glob: 7.2.3
+    dev: true
+
+  /rollup-plugin-pure@0.1.1(rollup@3.26.2):
+    resolution: {integrity: sha512-LjQ4q4jKB6yzedRa3DxQzo6T2CW+WJWmzn8gkgmaNDtBFsL1nm7LIyvxKEROauuorYIk6QnWxWSRb09G9Z5CGg==}
+    peerDependencies:
+      rollup: ^3.0.0
+    dependencies:
+      '@rollup/pluginutils': 5.0.2(rollup@3.26.2)
+      magic-string: 0.30.1
+      rollup: 3.26.2
+      strip-literal: 1.0.1
     dev: true
 
   /rollup@3.26.2:

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,7 @@ import path from 'path';
 
 import { vanillaExtractPlugin } from '@vanilla-extract/vite-plugin';
 import react from '@vitejs/plugin-react-swc';
+import { PluginPure } from 'rollup-plugin-pure';
 import { defineConfig } from 'vite';
 import istanbul from 'vite-plugin-istanbul';
 
@@ -19,11 +20,28 @@ Object.keys(paths).forEach((key) => {
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const packageJSON = require(path.resolve('./package.json'));
 
+// https://github.com/babel/babel/blob/main/packages/babel-plugin-transform-react-pure-annotations/src/index.ts
+const PURE_CALLS = [
+  'cloneElement',
+  'createContext',
+  'createElement',
+  'createFactory',
+  'createRef',
+  'forwardRef',
+  'isValidElement',
+  'memo',
+  'lazy',
+];
+
 export default defineConfig({
   plugins: [
     react(),
     vanillaExtractPlugin(),
     cssImport(),
+    PluginPure({
+      functions: PURE_CALLS,
+      sourcemap: true,
+    }),
     ...(process.env.CYPRESS ? [istanbul({ cypress: true })] : []),
   ],
   resolve: {


### PR DESCRIPTION
## Summary

Vite [does not add](https://github.com/vitejs/vite/issues/5174) pure annotations for some top-level functions due to [esbuild decisions](https://github.com/vitejs/vite-plugin-react/issues/10). We can use a rollup plugin to achieve this and improve tree shaking.

## Testing approaches

Built packages have `/* @__PURE__ */` annotation next to `forwardRef`, `cloneElement`, etc.
