### PR TITLE
ci: include react aria patches for renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,7 +10,8 @@
   "packageRules": [
     {
       "matchUpdateTypes": ["patch"],
-      "enabled": false
+      "enabled": false,
+      "excludePackagePatterns": ["^@react-aria", "^@react-stately", "^@react-types"]
     }
   ],
   "rangeStrategy": "bump",


### PR DESCRIPTION
## Summary

Since [React Aria releases](https://react-spectrum.adobe.com/releases/2023-08-09.html) can include patch updates, we want to include those to ensure all versions specified in package dependencies are compatible.