### PR TITLE
feat(data-table): add column resizing

### DIFF
--- a/.changeset/moody-kiwis-double.md
+++ b/.changeset/moody-kiwis-double.md
@@ -1,0 +1,6 @@
+---
+'@launchpad-ui/data-table': patch
+'@launchpad-ui/core': patch
+---
+
+[DataTable] Enable column resizing via `allowsResizing` prop for `Column`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,6 +133,12 @@ There are just a few things to keep in mind:
 - If there are visual diffs between your branch and main, Chromatic will generate a list of changes that must be approved before the PR should be merged. This can be found in the Github actions list.
 - The team will be automatically assigned to take a look.
 
+Note: if you are creating a pull request from a fork, CI checks will only run when it is `ready for review`. To run Chromatic, you will need to make a build locally in the terminal using the project token found in Chromatic:
+
+```sh
+$ pnpm chromatic --project-token PROJECT_TOKEN --branch-name FORKED_BRANCH --build-script-name storybook:build --exit-once-uploaded --only-changed --externals "packages/icons/src/img/**" --externals "packages/tokens/src/**"
+```
+
 ---
 
 ## Common Tasks

--- a/packages/data-table/__tests__/DataTable.spec.tsx
+++ b/packages/data-table/__tests__/DataTable.spec.tsx
@@ -17,10 +17,16 @@ const ROWS = [
   { first: 'four', second: 'five', third: 'six', key: 2 },
 ];
 
-const DataTableComponent = <T extends object>(props: Omit<Partial<DataTableProps<T>>, 'ref'>) => {
+type DataTableComponentProps = Omit<Partial<DataTableProps<object>>, 'ref'> & {
+  resizable?: boolean;
+};
+
+const DataTableComponent = ({ resizable, ...props }: DataTableComponentProps) => {
   return (
     <DataTable {...props}>
-      <TableHeader columns={COLUMNS}>{(column) => <Column>{column.name}</Column>}</TableHeader>
+      <TableHeader columns={COLUMNS}>
+        {(column) => <Column allowsResizing={resizable}>{column.name}</Column>}
+      </TableHeader>
       <TableBody items={ROWS}>
         {(item) => <Row>{(columnKey) => <Cell>{item[columnKey as keyof typeof item]}</Cell>}</Row>}
       </TableBody>
@@ -37,5 +43,15 @@ describe('DataTable', () => {
   it('renders checkboxes when selectable', () => {
     render(<DataTableComponent selectionMode="multiple" />);
     expect(screen.getByLabelText('Select All')).toBeVisible();
+  });
+
+  it('renders column resizers when allowsResizing is passed to columns', () => {
+    render(<DataTableComponent resizable />);
+
+    const resizers = screen.getAllByRole('presentation');
+    resizers.forEach((resizer) => expect(resizer).toBeVisible());
+
+    const inputs = screen.getAllByLabelText('Resizer');
+    inputs.forEach((input) => expect(input).toBeInTheDocument());
   });
 });

--- a/packages/data-table/src/styles/DataTable.css.ts
+++ b/packages/data-table/src/styles/DataTable.css.ts
@@ -2,11 +2,13 @@ import { vars } from '@launchpad-ui/vars';
 import { style } from '@vanilla-extract/css';
 import { recipe } from '@vanilla-extract/recipes';
 
+const focusShadow = {
+  boxShadow: `0 0 0 2px ${vars.color.shadow.interactive.primary}, 0 0 0 4px ${vars.color.shadow.interactive.focus}`,
+};
+
 const focusVisible = style({
   outline: 'none',
-  ':focus-visible': {
-    boxShadow: `0 0 0 2px ${vars.color.shadow.interactive.primary}, 0 0 0 4px ${vars.color.shadow.interactive.focus}`,
-  },
+  ':focus-visible': focusShadow,
 });
 
 const border = style({
@@ -57,4 +59,28 @@ const header = style({
   borderBottom: `1px solid ${vars.color.border.ui.primary}`,
 });
 
-export { table, cell, headerCell, selectCell, row, header };
+const resizer = recipe({
+  base: [
+    {
+      cursor: 'col-resize',
+      alignSelf: 'stretch',
+      width: '10px',
+      border: `2px solid ${vars.color.border.interactive.secondary.base}`,
+      touchAction: 'none',
+      flex: '0 0 auto',
+      position: 'absolute',
+      insetInlineEnd: 0,
+      height: '100%',
+    },
+  ],
+  variants: {
+    focus: {
+      true: focusShadow,
+    },
+    active: {
+      true: active,
+    },
+  },
+});
+
+export { table, cell, headerCell, selectCell, row, header, resizer };

--- a/packages/data-table/src/styles/DataTable.css.ts
+++ b/packages/data-table/src/styles/DataTable.css.ts
@@ -64,13 +64,16 @@ const resizer = recipe({
     {
       cursor: 'col-resize',
       alignSelf: 'stretch',
-      width: '10px',
-      border: `2px solid ${vars.color.border.interactive.secondary.base}`,
+      width: '4px',
+      background: vars.color.border.ui.primary,
       touchAction: 'none',
       flex: '0 0 auto',
       position: 'absolute',
       insetInlineEnd: 0,
       height: '100%',
+      ':hover': {
+        background: vars.color.shadow.interactive.focus,
+      },
     },
   ],
   variants: {
@@ -78,7 +81,9 @@ const resizer = recipe({
       true: focusShadow,
     },
     active: {
-      true: active,
+      true: {
+        background: vars.color.shadow.interactive.focus,
+      },
     },
   },
 });

--- a/packages/data-table/stories/DataTable.stories.tsx
+++ b/packages/data-table/stories/DataTable.stories.tsx
@@ -55,6 +55,28 @@ const ROWS = [
   },
 ];
 
+const tableBody = (item: (typeof ROWS)[number]) => (
+  <Row>
+    {(columnKey) => (
+      <Cell>
+        {columnKey === 'name' && (
+          <Stack gap="3">
+            <span>{item[columnKey]}</span>
+            <span>{item.description}</span>
+            <CopyToClipboard text={item.package} kind="basic">
+              {item.package}
+            </CopyToClipboard>
+          </Stack>
+        )}
+        {columnKey === 'type' && <>{item[columnKey]}</>}
+        {columnKey === 'status' && (
+          <Chip kind={item[columnKey] === 'alpha' ? 'new' : 'beta'}>{item[columnKey]}</Chip>
+        )}
+      </Cell>
+    )}
+  </Row>
+);
+
 export const Example: Story = {
   render: (args) => {
     return (
@@ -104,33 +126,28 @@ export const Selection: Story = {
 export const Composition: Story = {
   render: (args) => {
     return (
-      <DataTable aria-label="Selection table" {...args}>
+      <DataTable aria-label="Composition table" {...args}>
         <TableHeader columns={COLUMNS}>{(column) => <Column>{column.name}</Column>}</TableHeader>
-        <TableBody items={ROWS}>
-          {(item) => (
-            <Row>
-              {(columnKey) => (
-                <Cell>
-                  {columnKey === 'name' && (
-                    <Stack gap="3">
-                      <span>{item[columnKey]}</span>
-                      <span>{item.description}</span>
-                      <CopyToClipboard text={item.package} kind="basic">
-                        {item.package}
-                      </CopyToClipboard>
-                    </Stack>
-                  )}
-                  {columnKey === 'type' && <>{item[columnKey]}</>}
-                  {columnKey === 'status' && (
-                    <Chip kind={item[columnKey] === 'alpha' ? 'new' : 'beta'}>
-                      {item[columnKey]}
-                    </Chip>
-                  )}
-                </Cell>
-              )}
-            </Row>
-          )}
-        </TableBody>
+        <TableBody items={ROWS}>{tableBody}</TableBody>
+      </DataTable>
+    );
+  },
+};
+
+export const ResizableColumns: Story = {
+  render: (args) => {
+    return (
+      <DataTable
+        aria-label="Resizable columns table"
+        tableWidth={1000}
+        getDefaultMinWidth={() => 200}
+        getDefaultWidth={(column) => (column.colIndex === 0 ? 500 : undefined)}
+        {...args}
+      >
+        <TableHeader columns={COLUMNS}>
+          {(column) => <Column allowsResizing>{column.name}</Column>}
+        </TableHeader>
+        <TableBody items={ROWS}>{tableBody}</TableBody>
       </DataTable>
     );
   },


### PR DESCRIPTION
## Summary

Enable column resizing via `allowsResizing` prop for `Column` inspired by the [React Aria example](https://react-spectrum.adobe.com/react-aria/useTable.html#resizable-columns).

## Testing approaches

Interact with [Resizable Columns story](https://626696a2018c1f004a1cde86-wtqnahuzso.chromatic.com/?path=/story/components-datatable--resizable-columns)
