### PR TITLE
feat(inline-edit): allow to render `IconField`

### DIFF
--- a/.changeset/dull-elephants-wink.md
+++ b/.changeset/dull-elephants-wink.md
@@ -1,0 +1,9 @@
+---
+'@launchpad-ui/inline-edit': patch
+'@launchpad-ui/form': patch
+'@launchpad-ui/core': patch
+---
+
+[InlineEdit] Allow to render `IconField`:
+
+- Add `tooltip` and `renderIconLast` props to `IconField`

--- a/packages/form/package.json
+++ b/packages/form/package.json
@@ -32,8 +32,10 @@
     "test": "vitest run --coverage"
   },
   "dependencies": {
+    "@launchpad-ui/button": "workspace:~",
     "@launchpad-ui/icons": "workspace:~",
     "@launchpad-ui/tokens": "workspace:~",
+    "@launchpad-ui/tooltip": "workspace:~",
     "@react-aria/button": "3.8.1",
     "@react-aria/i18n": "3.8.1",
     "@react-aria/numberfield": "3.7.0",

--- a/packages/form/src/IconField.tsx
+++ b/packages/form/src/IconField.tsx
@@ -30,10 +30,9 @@ const IconField = ({
   const iconElement = cloneElement(icon, {
     size: 'small',
     className: cx(styles.iconFieldIcon, styles.iconFieldIconFill),
-    style: renderIconLast ? { right: '1rem' } : { left: '1rem' },
   });
 
-  const classes = cx(styles.iconField, renderIconLast && 'IconAfter', className);
+  const classes = cx(styles.iconField, renderIconLast ? 'IconAfter' : 'IconBefore', className);
 
   const renderIcon = tooltip ? (
     <Tooltip content={tooltip} targetClassName={styles.iconFieldButton}>

--- a/packages/form/src/IconField.tsx
+++ b/packages/form/src/IconField.tsx
@@ -1,6 +1,8 @@
 import type { IconProps } from '@launchpad-ui/icons';
 import type { ComponentProps, ReactElement } from 'react';
 
+import { IconButton } from '@launchpad-ui/button';
+import { Tooltip } from '@launchpad-ui/tooltip';
 import { cx } from 'classix';
 import { cloneElement } from 'react';
 
@@ -10,6 +12,9 @@ type IconFieldProps = ComponentProps<'div'> & {
   icon: ReactElement<IconProps>;
   children: JSX.Element | JSX.Element[];
   'data-test-id'?: string;
+  tooltip?: string | JSX.Element;
+  renderIconLast?: boolean;
+  ariaLabel?: string;
 };
 
 const IconField = ({
@@ -17,16 +22,40 @@ const IconField = ({
   children,
   className,
   'data-test-id': testId = 'icon-field',
+  tooltip,
+  renderIconLast = false,
+  ariaLabel = 'More info',
   ...rest
 }: IconFieldProps) => {
-  const renderIcon = cloneElement(icon, { size: 'small', className: styles.iconFieldIcon });
+  const iconElement = cloneElement(icon, {
+    size: 'small',
+    className: cx(styles.iconFieldIcon, styles.iconFieldIconFill),
+    style: renderIconLast ? { right: '1rem' } : { left: '1rem' },
+  });
 
-  const classes = cx(styles.iconField, className);
+  const classes = cx(styles.iconField, renderIconLast && 'IconAfter', className);
+
+  const renderIcon = tooltip ? (
+    <Tooltip content={tooltip} targetClassName={styles.iconFieldButton}>
+      <IconButton
+        icon={cloneElement(icon, {
+          className: styles.iconFieldIconFill,
+        })}
+        size="small"
+        className={styles.iconFieldIcon}
+        style={renderIconLast ? { right: '0.5rem' } : { left: '0.5rem' }}
+        aria-label={ariaLabel}
+      />
+    </Tooltip>
+  ) : (
+    iconElement
+  );
 
   return (
     <div className={classes} data-test-id={testId} {...rest}>
+      {!renderIconLast && renderIcon}
       {children}
-      {renderIcon}
+      {renderIconLast && renderIcon}
     </div>
   );
 };

--- a/packages/form/src/styles/Form.module.css
+++ b/packages/form/src/styles/Form.module.css
@@ -84,12 +84,26 @@ select.formInput {
   border-color: var(--lp-color-border-field-error);
 }
 
-.iconField:not:global(.IconAfter) .formInput {
+.iconField:global(.IconBefore) .formInput {
   padding-left: 3rem;
 }
 
 .iconField:global(.IconAfter) .formInput {
   padding-right: 3rem;
+}
+
+.iconFieldIcon {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+}
+
+.iconField:global(.IconBefore) .iconFieldIcon {
+  left: 1rem;
+}
+
+.iconField:global(.IconAfter) .iconFieldIcon {
+  right: 1rem;
 }
 
 .suffixContainer .formInput:focus {
@@ -334,12 +348,6 @@ input[type='checkbox']:disabled {
 /* Firefox */
 .suffix[type='number'] {
   appearance: textfield;
-}
-
-.iconFieldIcon {
-  position: absolute;
-  top: 50%;
-  transform: translateY(-50%);
 }
 
 .iconFieldIconFill {

--- a/packages/form/src/styles/Form.module.css
+++ b/packages/form/src/styles/Form.module.css
@@ -72,10 +72,6 @@ select.formInput {
   padding-right: 2rem;
 }
 
-.iconField .formInput {
-  padding-left: 3rem;
-}
-
 .suffixContainer .formInput {
   border: none;
   border-radius: var(--lp-border-radius-regular) 0 0 var(--lp-border-radius-regular);
@@ -86,6 +82,14 @@ select.formInput {
 .form .isInvalid :global(.CustomSelect) > div,
 .form .isInvalid .formInput {
   border-color: var(--lp-color-border-field-error);
+}
+
+.iconField:not:global(.IconAfter) .formInput {
+  padding-left: 3rem;
+}
+
+.iconField:global(.IconAfter) .formInput {
+  padding-right: 3rem;
 }
 
 .suffixContainer .formInput:focus {
@@ -334,10 +338,16 @@ input[type='checkbox']:disabled {
 
 .iconFieldIcon {
   position: absolute;
-  fill: var(--lp-color-fill-field-base);
   top: 50%;
   transform: translateY(-50%);
-  left: 1rem;
+}
+
+.iconFieldIconFill {
+  fill: var(--lp-color-fill-field-base);
+}
+
+[class*='_Popover-target_'].iconFieldButton {
+  display: block;
 }
 
 .formInputTiny {

--- a/packages/inline-edit/src/InlineEdit.tsx
+++ b/packages/inline-edit/src/InlineEdit.tsx
@@ -1,5 +1,5 @@
 import type { InlineVariants } from './styles/InlineEdit.css';
-import type { TextAreaProps, TextFieldProps } from '@launchpad-ui/form';
+import type { IconFieldProps, TextAreaProps, TextFieldProps } from '@launchpad-ui/form';
 import type { ComponentProps, KeyboardEventHandler, ReactElement } from 'react';
 
 import { ButtonGroup, IconButton } from '@launchpad-ui/button';
@@ -10,7 +10,7 @@ import { focusSafely } from '@react-aria/focus';
 import { useFocusWithin } from '@react-aria/interactions';
 import { mergeProps, mergeRefs, useUpdateEffect } from '@react-aria/utils';
 import { cx } from 'classix';
-import { cloneElement, forwardRef, useRef, useState } from 'react';
+import { Children, cloneElement, forwardRef, useRef, useState } from 'react';
 
 import { container, cancelButton, inline, readButton } from './styles/InlineEdit.css';
 
@@ -20,7 +20,7 @@ type InlineEditProps = ComponentProps<'div'> &
     'data-test-id'?: string;
     onConfirm: (value: string) => void;
     hideEdit?: boolean;
-    renderInput?: ReactElement<TextFieldProps | TextAreaProps>;
+    renderInput?: ReactElement<IconFieldProps | TextFieldProps | TextAreaProps>;
     isEditing?: boolean;
     onCancel?: () => void;
     onEdit?: () => void;
@@ -127,14 +127,24 @@ const InlineEdit = forwardRef<HTMLInputElement, InlineEditProps>(
       </>
     );
 
+    const inputProps = {
+      ref: mergeRefs(inputRef, ref),
+      defaultValue,
+      onKeyDown: handleKeyDown,
+      'aria-label': ariaLabel,
+    };
+
+    const inputChildren = renderInput.props.children;
+
     const input = cloneElement(
       renderInput,
-      mergeProps(renderInput.props, {
-        ref: mergeRefs(inputRef, ref),
-        defaultValue,
-        onKeyDown: handleKeyDown,
-        'aria-label': ariaLabel,
-      })
+      mergeProps(renderInput.props, inputChildren ? {} : inputProps),
+      inputChildren &&
+        Children.map(inputChildren, (child) =>
+          ['TextField', 'TextArea'].includes(child.type.displayName)
+            ? cloneElement(child, mergeProps(child.props, inputProps))
+            : child
+        )
     );
 
     return isEditing ? (

--- a/packages/inline-edit/src/InlineEdit.tsx
+++ b/packages/inline-edit/src/InlineEdit.tsx
@@ -3,7 +3,7 @@ import type { IconFieldProps, TextAreaProps, TextFieldProps } from '@launchpad-u
 import type { ComponentProps, KeyboardEventHandler, ReactElement } from 'react';
 
 import { ButtonGroup, IconButton } from '@launchpad-ui/button';
-import { TextField } from '@launchpad-ui/form';
+import { TextField, TextArea } from '@launchpad-ui/form';
 import { Icon } from '@launchpad-ui/icons';
 import { useButton } from '@react-aria/button';
 import { focusSafely } from '@react-aria/focus';
@@ -141,7 +141,7 @@ const InlineEdit = forwardRef<HTMLInputElement, InlineEditProps>(
       mergeProps(renderInput.props, inputChildren ? {} : inputProps),
       inputChildren &&
         Children.map(inputChildren, (child) =>
-          ['TextField', 'TextArea'].includes(child.type.displayName)
+          child.type === TextField || child.type === TextArea
             ? cloneElement(child, mergeProps(child.props, inputProps))
             : child
         )

--- a/packages/inline-edit/stories/InlineEdit.stories.tsx
+++ b/packages/inline-edit/stories/InlineEdit.stories.tsx
@@ -200,4 +200,14 @@ export const Validation: Story = {
       </InlineEdit>
     );
   },
+  parameters: {
+    a11y: {
+      options: {
+        rules: {
+          // @fixme
+          'duplicate-id-active': { enabled: false },
+        },
+      },
+    },
+  },
 };

--- a/packages/inline-edit/stories/InlineEdit.stories.tsx
+++ b/packages/inline-edit/stories/InlineEdit.stories.tsx
@@ -2,7 +2,8 @@
 import type { StoryObj } from '@storybook/react';
 
 import { CopyToClipboard } from '@launchpad-ui/clipboard';
-import { Form, FormField, TextArea, TextField } from '@launchpad-ui/form';
+import { Form, FormField, IconField, TextArea, TextField } from '@launchpad-ui/form';
+import { Icon } from '@launchpad-ui/icons';
 import { useState } from '@storybook/client-api';
 import { userEvent, within } from '@storybook/testing-library';
 
@@ -159,6 +160,40 @@ export const Controlled: Story = {
           setEditValue(value);
           setEditing(false);
         }}
+      >
+        <span>{editValue}</span>
+      </InlineEdit>
+    );
+  },
+};
+
+export const Validation: Story = {
+  render: () => {
+    const [editValue, setEditValue] = useState('edit me');
+    const [isEditing, setEditing] = useState(true);
+
+    return (
+      <InlineEdit
+        defaultValue={editValue}
+        isEditing={isEditing}
+        aria-label="edit value"
+        onCancel={() => setEditing(false)}
+        onEdit={() => setEditing(true)}
+        onConfirm={(value) => {
+          setEditValue(value);
+          setEditing(false);
+        }}
+        renderInput={
+          <IconField
+            icon={
+              <Icon name="alert-rhombus" style={{ fill: 'var(--lp-color-text-feedback-error)' }} />
+            }
+            tooltip="Value is required"
+            renderIconLast
+          >
+            <TextField id="inline-edit" />
+          </IconField>
+        }
       >
         <span>{editValue}</span>
       </InlineEdit>

--- a/packages/inline-edit/stories/InlineEdit.stories.tsx
+++ b/packages/inline-edit/stories/InlineEdit.stories.tsx
@@ -189,6 +189,7 @@ export const Validation: Story = {
               <Icon name="alert-rhombus" style={{ fill: 'var(--lp-color-text-feedback-error)' }} />
             }
             tooltip="Value is required"
+            ariaLabel="Error"
             renderIconLast
           >
             <TextField id="inline-edit" />

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -793,12 +793,18 @@ importers:
 
   packages/form:
     dependencies:
+      '@launchpad-ui/button':
+        specifier: workspace:~
+        version: link:../button
       '@launchpad-ui/icons':
         specifier: workspace:~
         version: link:../icons
       '@launchpad-ui/tokens':
         specifier: workspace:~
         version: link:../tokens
+      '@launchpad-ui/tooltip':
+        specifier: workspace:~
+        version: link:../tooltip
       '@react-aria/button':
         specifier: 3.8.1
         version: 3.8.1(react@18.2.0)


### PR DESCRIPTION
## Summary

Allow `InlineEdit` to render `IconField`. Add `tooltip` and `renderIconLast` props to `IconField`.

## Screenshots (if appropriate):

<img width="280" alt="Screenshot 2023-09-05 at 4 07 57 PM" src="https://github.com/launchdarkly/launchpad-ui/assets/2147624/db6ae4e3-adbf-4b24-b271-54d424a0b605">
