### PR TITLE
feat(tokens)!: move color primitives to themes.css

### DIFF
--- a/.changeset/quick-apples-happen.md
+++ b/.changeset/quick-apples-happen.md
@@ -1,0 +1,5 @@
+---
+'@launchpad-ui/tokens': minor
+---
+
+Move color primitives to `themes.css`

--- a/packages/tokens/README.md
+++ b/packages/tokens/README.md
@@ -26,7 +26,7 @@ $ npm install @launchpad-ui/tokens
 ### ES Modules
 
 ```js
-import { ColorBlue500 } from '@launchpad-ui/tokens';
+import tokens from '@launchpad-ui/tokens';
 ```
 
 ### CommonJS Modules

--- a/packages/tokens/build.ts
+++ b/packages/tokens/build.ts
@@ -1,7 +1,6 @@
+import JsonToTS from 'json-to-ts';
 import StyleDictionary from 'style-dictionary-utils';
 import yaml from 'yaml';
-
-const { fileHeader } = StyleDictionary.formatHelpers;
 
 type NullableTokens = {
   [key: string]: string | NullableTokens | null;
@@ -29,7 +28,7 @@ StyleDictionary.registerFormat({
     const darkColorCSSVariables = `[data-theme='dark'] {\n${darkTokens}\n}\n`;
     const defaultColorCSSVariables = `:root, [data-theme='default'] {\n${defaultTokens}\n}\n`;
 
-    return `${fileHeader({
+    return `${StyleDictionary.formatHelpers.fileHeader({
       file,
     })}${defaultColorCSSVariables}\n${darkColorCSSVariables}`;
   },
@@ -39,6 +38,17 @@ StyleDictionary.registerFormat({
   name: 'json/nested/contract',
   formatter({ dictionary }) {
     return JSON.stringify(minifyDictionary(dictionary.tokens), null, 2) + '\n';
+  },
+});
+
+StyleDictionary.registerFormat({
+  name: 'typescript/accurate-module-declarations',
+  formatter({ dictionary }) {
+    return (
+      'declare const root: RootObject\n' +
+      'export default root\n' +
+      JsonToTS(StyleDictionary.formatHelpers.minifyDictionary(dictionary.tokens)).join('\n')
+    );
   },
 });
 
@@ -86,15 +96,15 @@ const myStyleDictionary = StyleDictionary.extend({
       buildPath: 'dist/',
       files: [
         {
-          format: 'javascript/es6',
+          format: 'javascript/esm',
           destination: 'index.es.js',
         },
         {
-          format: 'typescript/es6-declarations',
+          format: 'typescript/accurate-module-declarations',
           destination: 'index.d.ts',
         },
         {
-          format: 'javascript/module',
+          format: 'javascript/commonJs',
           destination: 'index.js',
         },
       ],

--- a/packages/tokens/build.ts
+++ b/packages/tokens/build.ts
@@ -1,5 +1,6 @@
 import JsonToTS from 'json-to-ts';
 import StyleDictionary from 'style-dictionary-utils';
+import Color from 'tinycolor2';
 import yaml from 'yaml';
 
 type NullableTokens = {
@@ -52,6 +53,16 @@ StyleDictionary.registerFormat({
   },
 });
 
+StyleDictionary.registerTransform({
+  type: 'attribute',
+  name: 'dark/rgb',
+  matcher: (token) => token.dark,
+  transformer: (token) => {
+    token.dark = Color(token.dark).toRgbString();
+    return token;
+  },
+});
+
 const myStyleDictionary = StyleDictionary.extend({
   parsers: [
     {
@@ -70,6 +81,7 @@ const myStyleDictionary = StyleDictionary.extend({
         'content/icon',
         'size/rem',
         'color/rgb',
+        'dark/rgb',
       ],
       buildPath: 'dist/',
       files: [

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -36,6 +36,7 @@
     "test": "exit 0"
   },
   "devDependencies": {
+    "json-to-ts": "^1.7.0",
     "style-dictionary": "^3.8.0",
     "style-dictionary-utils": "^2.0.1",
     "ts-node": "^10.9.1",

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -36,9 +36,11 @@
     "test": "exit 0"
   },
   "devDependencies": {
+    "@types/tinycolor2": "^1.4.4",
     "json-to-ts": "^1.7.0",
     "style-dictionary": "^3.8.0",
     "style-dictionary-utils": "^2.0.1",
+    "tinycolor2": "^1.6.0",
     "ts-node": "^10.9.1",
     "yaml": "^2.3.1"
   }

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -9,6 +9,7 @@
   "files": [
     "dist"
   ],
+  "type": "module",
   "style": "dist/index.css",
   "main": "dist/index.js",
   "module": "dist/index.es.js",
@@ -29,13 +30,15 @@
     "./dist/contract.json": "./dist/contract.json"
   },
   "scripts": {
-    "build": "style-dictionary build --config ./sd.config.js",
+    "build": "ts-node --esm ./build.ts",
     "clean": "rm -rf dist",
     "lint": "eslint '**/*.{ts,tsx,js}'",
     "test": "exit 0"
   },
   "devDependencies": {
     "style-dictionary": "^3.8.0",
+    "style-dictionary-utils": "^2.0.1",
+    "ts-node": "^10.9.1",
     "yaml": "^2.3.1"
   }
 }

--- a/packages/tokens/src/color-aliases.yaml
+++ b/packages/tokens/src/color-aliases.yaml
@@ -110,7 +110,7 @@ color:
     field:
       base:
         value: '{ color.white.0.value }'
-        dark: 'rgb(0 0 0 / .15)'
+        dark: hsla(0, 0%, 0%, 0.15)
       disabled:
         value: '{ color.gray.100.value }'
         dark: '{ color.black.100.value }'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1530,6 +1530,9 @@ importers:
 
   packages/tokens:
     devDependencies:
+      json-to-ts:
+        specifier: ^1.7.0
+        version: 1.7.0
       style-dictionary:
         specifier: ^3.8.0
         version: 3.8.0
@@ -8968,6 +8971,17 @@ packages:
       es-shim-unscopables: 1.0.0
     dev: true
 
+  /array.prototype.reduce@1.0.6:
+    resolution: {integrity: sha512-UW+Mz8LG/sPSU8jRDCjVr6J/ZKAGpHfwrZ6kWTG5qCxIEiXdVshqGnu5vEZA8S1y6X4aCSbQZ0/EEsfvEvBiSg==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      call-bind: 1.0.2
+      define-properties: 1.2.0
+      es-abstract: 1.22.1
+      es-array-method-boxes-properly: 1.0.0
+      is-string: 1.0.7
+    dev: true
+
   /array.prototype.tosorted@1.1.1:
     resolution: {integrity: sha512-pZYPXPRl2PqWcsUs6LOMn+1f1532nEoPTYowBtqLwAW+W8vSVhkIGnmOX1t/UQjD6YGI0vcD2B1U7ZFGQH9jnQ==}
     dependencies:
@@ -10537,6 +10551,10 @@ packages:
       which-typed-array: 1.1.11
     dev: true
 
+  /es-array-method-boxes-properly@1.0.0:
+    resolution: {integrity: sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA==}
+    dev: true
+
   /es-get-iterator@1.1.3:
     resolution: {integrity: sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==}
     dependencies:
@@ -10600,6 +10618,21 @@ packages:
 
   /es6-object-assign@1.1.0:
     resolution: {integrity: sha512-MEl9uirslVwqQU369iHNWZXsI8yaZYGg/D65aOgZkeyFJwHYSxilf7rQzXKI7DdDuBPrBXbfk3sl9hJhmd5AUw==}
+    dev: true
+
+  /es7-shim@6.0.0:
+    resolution: {integrity: sha512-aiQ/QyJBVJbabtsSediM1S4qI+P3p8F5J5YR5o/bH003BCnnclzxK9pi5Qd2Hg01ktAtZCaQBdejHrkOBGwf5Q==}
+    engines: {node: '>=0.4.0'}
+    dependencies:
+      array-includes: 3.1.6
+      object.entries: 1.1.7
+      object.getownpropertydescriptors: 2.1.7
+      object.values: 1.1.7
+      string-at: 1.1.0
+      string.prototype.padend: 3.1.5
+      string.prototype.padstart: 3.1.5
+      string.prototype.trimleft: 2.1.3
+      string.prototype.trimright: 2.1.3
     dev: true
 
   /esbuild-plugin-alias@0.2.1:
@@ -12203,6 +12236,13 @@ packages:
     dependencies:
       function-bind: 1.1.1
 
+  /hash.js@1.1.7:
+    resolution: {integrity: sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==}
+    dependencies:
+      inherits: 2.0.4
+      minimalistic-assert: 1.0.1
+    dev: true
+
   /hast-util-to-estree@2.3.3:
     resolution: {integrity: sha512-ihhPIUPxN0v0w6M5+IiAZZrn0LH2uZomeWwhn7uP7avZC6TE7lIiEh2yBMPr5+zi1aUCXq6VoYRgs2Bw9xmycQ==}
     dependencies:
@@ -13268,6 +13308,14 @@ packages:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
     dev: true
 
+  /json-to-ts@1.7.0:
+    resolution: {integrity: sha512-uVhcw4SLnf9ucMwFpom/G1/IT+lnoILOyHbFE6xqxvw67oCvHl6iDZzmjyn2lPCRPsAOMSQgG/ZxvbCPySMi1Q==}
+    dependencies:
+      es7-shim: 6.0.0
+      hash.js: 1.1.7
+      pluralize: 3.1.0
+    dev: true
+
   /json5@1.0.2:
     resolution: {integrity: sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==}
     hasBin: true
@@ -14275,6 +14323,10 @@ packages:
     engines: {node: '>=4'}
     dev: true
 
+  /minimalistic-assert@1.0.1:
+    resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
+    dev: true
+
   /minimatch@3.0.5:
     resolution: {integrity: sha512-tUpxzX0VAzJHjLu0xUfFv1gwVp9ba3IOuRAVH2EGuRW8a5emA2FlACLqiT/lDVtS1W+TGNwqz3sWaNyLgDJWuw==}
     dependencies:
@@ -14816,6 +14868,17 @@ packages:
       es-abstract: 1.22.1
     dev: true
 
+  /object.getownpropertydescriptors@2.1.7:
+    resolution: {integrity: sha512-PrJz0C2xJ58FNn11XV2lr4Jt5Gzl94qpy9Lu0JlfEj14z88sqbSBJCBEzdlNUCzY2gburhbrwOZ5BHCmuNUy0g==}
+    engines: {node: '>= 0.8'}
+    dependencies:
+      array.prototype.reduce: 1.0.6
+      call-bind: 1.0.2
+      define-properties: 1.2.0
+      es-abstract: 1.22.1
+      safe-array-concat: 1.0.0
+    dev: true
+
   /object.groupby@1.0.1:
     resolution: {integrity: sha512-HqaQtqLnp/8Bn4GL16cj+CUYbnpe1bh0TtEaWvybszDG4tgxCJuRpV8VGuvNaI1fAnI4lUJzDG55MXcOH4JZcQ==}
     dependencies:
@@ -15298,6 +15361,10 @@ packages:
       node-plop: 0.32.0
       ora: 7.0.1
       v8flags: 4.0.1
+    dev: true
+
+  /pluralize@3.1.0:
+    resolution: {integrity: sha512-2wcybwjwXOzGI1rlxWtlcs0/nSYK0OzNPqsg35TKxJFQlGhFu3cZ1x7EHS4r4bubQlhzyF4YxxlJqQnIhkUQCw==}
     dev: true
 
   /polished@4.2.2:
@@ -17128,6 +17195,15 @@ packages:
     engines: {node: '>=0.6.19'}
     dev: true
 
+  /string-at@1.1.0:
+    resolution: {integrity: sha512-jCpPowWKBn0NFdvtmK2qxK40Ol4jPcgCt8qYnKpPx6B5eDwHMDhRvq9MCsDEgsOTNtbXY6beAMHMRT2qPJXllA==}
+    engines: {node: '>= 0.4'}
+    deprecated: The original `String.prototype.at` proposal has been replaced by a new one; please use v1 or later of `string.prototype.at` instead
+    dependencies:
+      define-properties: 1.2.0
+      es-abstract: 1.22.1
+    dev: true
+
   /string-hash@1.1.3:
     resolution: {integrity: sha512-kJUvRUFK49aub+a7T1nNE66EJbZBMnBgoC1UbCZ5n6bsZKBRga4KgBRTMn/pFkeCZSYtNeSyMxPDM0AXWELk2A==}
     dev: true
@@ -17172,6 +17248,24 @@ packages:
       side-channel: 1.0.4
     dev: true
 
+  /string.prototype.padend@3.1.5:
+    resolution: {integrity: sha512-DOB27b/2UTTD+4myKUFh+/fXWcu/UDyASIXfg+7VzoCNNGOfWvoyU/x5pvVHr++ztyt/oSYI1BcWBBG/hmlNjA==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      call-bind: 1.0.2
+      define-properties: 1.2.0
+      es-abstract: 1.22.1
+    dev: true
+
+  /string.prototype.padstart@3.1.5:
+    resolution: {integrity: sha512-R57IsE3JIfModQWrVXYZ8ZHWMBNDpIoniDwhYCR1nx+iHwDkjjk26a8xM9BYgf7SAXJO7sdNPng5J+0ccr5LFQ==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      call-bind: 1.0.2
+      define-properties: 1.2.0
+      es-abstract: 1.22.1
+    dev: true
+
   /string.prototype.trim@1.2.7:
     resolution: {integrity: sha512-p6TmeT1T3411M8Cgg9wBTMRtY2q9+PNy9EV1i2lIXUN/btt763oIfxwN3RR8VU6wHX8j/1CFy0L+YuThm6bgOg==}
     engines: {node: '>= 0.4'}
@@ -17187,6 +17281,24 @@ packages:
       call-bind: 1.0.2
       define-properties: 1.2.0
       es-abstract: 1.22.1
+    dev: true
+
+  /string.prototype.trimleft@2.1.3:
+    resolution: {integrity: sha512-699Ibssmj/awVzvdNk4g83/Iu8U9vDohzmA/ly2BrQWGhamuY4Tlvs5XKmKliDt3ky6SKbE1bzPhASKCFlx9Sg==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      call-bind: 1.0.2
+      define-properties: 1.2.0
+      string.prototype.trimstart: 1.0.6
+    dev: true
+
+  /string.prototype.trimright@2.1.3:
+    resolution: {integrity: sha512-hoOq56oRFnnfDuXNy2lGHiwT77MehHv9d0zGfRZ8QdC+4zjrkFB9vd5i/zYTd/ymFBd4YxtbdgHt3U6ksGeuBw==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      call-bind: 1.0.2
+      define-properties: 1.2.0
+      string.prototype.trimend: 1.0.6
     dev: true
 
   /string.prototype.trimstart@1.0.6:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1533,6 +1533,12 @@ importers:
       style-dictionary:
         specifier: ^3.8.0
         version: 3.8.0
+      style-dictionary-utils:
+        specifier: ^2.0.1
+        version: 2.0.1(color2k@2.0.2)(json5@2.2.3)(prettier@2.8.8)(style-dictionary@3.8.0)
+      ts-node:
+        specifier: ^10.9.1
+        version: 10.9.1(@types/node@18.17.12)(typescript@5.2.2)
       yaml:
         specifier: ^2.3.1
         version: 2.3.2
@@ -9688,6 +9694,10 @@ packages:
   /color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
+  /color2k@2.0.2:
+    resolution: {integrity: sha512-kJhwH5nAwb34tmyuqq/lgjEKzlFXn1U99NlnB6Ws4qVaERcRUYeYP1cBw6BJ4vxaWStAUEef4WMr7WjOCnBt8w==}
+    dev: true
+
   /colord@2.9.3:
     resolution: {integrity: sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==}
     dev: true
@@ -17268,6 +17278,20 @@ packages:
       duplexer: 0.1.2
       minimist: 1.2.8
       through: 2.3.8
+    dev: true
+
+  /style-dictionary-utils@2.0.1(color2k@2.0.2)(json5@2.2.3)(prettier@2.8.8)(style-dictionary@3.8.0):
+    resolution: {integrity: sha512-+xHcpNojLU83DWQOLINmZ094VT+Xj8Fr/SqpxVHLNHCKO85v0IX244svVh9RClWEwZGNzh5wP4zXgILo743Fzw==}
+    peerDependencies:
+      color2k: ^2.0.0
+      json5: ^2.2.1
+      prettier: ^2.7.1
+      style-dictionary: '>= 3'
+    dependencies:
+      color2k: 2.0.2
+      json5: 2.2.3
+      prettier: 2.8.8
+      style-dictionary: 3.8.0
     dev: true
 
   /style-dictionary@3.8.0:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1530,6 +1530,9 @@ importers:
 
   packages/tokens:
     devDependencies:
+      '@types/tinycolor2':
+        specifier: ^1.4.4
+        version: 1.4.4
       json-to-ts:
         specifier: ^1.7.0
         version: 1.7.0
@@ -1539,6 +1542,9 @@ importers:
       style-dictionary-utils:
         specifier: ^2.0.1
         version: 2.0.1(color2k@2.0.2)(json5@2.2.3)(prettier@2.8.8)(style-dictionary@3.8.0)
+      tinycolor2:
+        specifier: ^1.6.0
+        version: 1.6.0
       ts-node:
         specifier: ^10.9.1
         version: 10.9.1(@types/node@18.17.12)(typescript@5.2.2)
@@ -8078,6 +8084,10 @@ packages:
     resolution: {integrity: sha512-FvnCJljyxhPM3gkRgWmxmDZyAQSiBQQWLI0A0VFL0K7W1oRUrPJSqNO0NvTnLkBcotdlp3lKvaT0JrnyRDkzOg==}
     dependencies:
       '@types/node': 18.18.3
+    dev: true
+
+  /@types/tinycolor2@1.4.4:
+    resolution: {integrity: sha512-FYK4mlLxUUajo/mblv7EUDHku20qT6ThYNsGZsTHilcHRvIkF8WXqtZO+DVTYkpHWCaAT97LueV59H/5Ve3bGA==}
     dev: true
 
   /@types/trusted-types@2.0.3:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1547,7 +1547,7 @@ importers:
         version: 1.6.0
       ts-node:
         specifier: ^10.9.1
-        version: 10.9.1(@types/node@18.17.12)(typescript@5.2.2)
+        version: 10.9.1(@types/node@18.18.3)(typescript@5.2.2)
       yaml:
         specifier: ^2.3.1
         version: 2.3.2


### PR DESCRIPTION
## Summary

Prepare for color refresh changes that require `dark` variants of our global color tokens:

- Move color primitives to `themes.css`
- Update Style Dictionary to use `ts-node` via a `build.ts` file for type safety
- Add support for `dark` field on color primitives