### PR TITLE
feat: support 'notification' alert + action elements

### DIFF
--- a/.changeset/shaggy-ads-promise.md
+++ b/.changeset/shaggy-ads-promise.md
@@ -1,0 +1,6 @@
+---
+"@launchpad-ui/alert": patch
+"@launchpad-ui/icons": patch
+---
+
+feat: support 'notification' alert + action elements

--- a/packages/alert/__tests__/Alert.spec.tsx
+++ b/packages/alert/__tests__/Alert.spec.tsx
@@ -85,6 +85,40 @@ describe('Alert', () => {
       const component = screen.getByTestId('alert');
       expect(component).toHaveClass(styles['Alert--wide']);
     });
+
+    it('applies flair class when kind is notification', () => {
+      render(createComponent({ kind: 'notification', 'data-test-id': 'alert' }));
+      const component = screen.getByTestId('alert');
+      expect(component).toHaveClass(styles['Alert--flair-default']);
+    });
+
+    it('applies strong flair class when kind is notification and flairLevel is strong', () => {
+      render(
+        createComponent({ kind: 'notification', flairLevel: 'strong', 'data-test-id': 'alert' })
+      );
+      const component = screen.getByTestId('alert');
+      expect(component).toHaveClass(styles['Alert--flair-strong']);
+    });
+  });
+
+  describe('action elements', () => {
+    it('renders a button when primaryButton prop is passed', () => {
+      render(
+        createComponent({
+          primaryButton: { children: 'Primary Button', onClick: vi.fn() },
+        })
+      );
+      expect(screen.getByRole('button', { name: 'Primary Button' })).toBeInTheDocument();
+    });
+
+    it('renders a link when passed', () => {
+      render(
+        createComponent({
+          link: { href: '/', text: 'Link Text', onClick: vi.fn() },
+        })
+      );
+      expect(screen.getByRole('link', { name: 'Link Text' })).toBeInTheDocument();
+    });
   });
 
   describe('a11y', () => {

--- a/packages/alert/src/styles/Alert.module.css
+++ b/packages/alert/src/styles/Alert.module.css
@@ -1,3 +1,21 @@
+:root {
+  --lp-component-alert-notification-flair-strong-color-text: var(--lp-color-white-0);
+  --lp-component-alert-notification-flair-strong-color-fill: var(--lp-color-white-0);
+  --lp-component-alert-notification-flair-strong-button-color-bg: var(--lp-color-white-0);
+  --lp-component-alert-notification-flair-strong-button-color-bg-hover: var(--lp-color-gray-100);
+  --lp-component-alert-notification-flair-strong-button-color-bg-focus: var(--lp-color-gray-200);
+  --lp-component-alert-notification-flair-strong-button-color-bg-active: var(--lp-color-gray-200);
+  --lp-component-alert-notification-flair-strong-button-button-color-border: var(
+    --lp-color-white-0
+  );
+  --lp-component-alert-notification-flair-strong-button-color-text: var(--lp-color-black-300);
+  --lp-component-alert-notification-flair-strong-button-color-text-hover: var(--lp-color-black-300);
+  --lp-component-alert-notification-flair-strong-button-color-text-focus: var(--lp-color-black-300);
+  --lp-component-alert-notification-flair-strong-button-color-text-active: var(
+    --lp-color-black-300
+  );
+}
+
 .Alert {
   position: relative;
   display: flex;
@@ -80,6 +98,70 @@
 
 .Alert.Alert--error .Alert-icon svg {
   fill: var(--lp-color-fill-feedback-error);
+}
+
+.Alert.Alert--notification.Alert--flair-default {
+  background: rgb(163 79 222 / 0.15);
+}
+
+.Alert.Alert--notification.Alert--flair-strong,
+.Alert.Alert--notification.Alert--flair-strong .Alert-heading {
+  color: var(--lp-component-alert-notification-flair-strong-color-text);
+}
+
+.Alert.Alert--notification.Alert--flair-strong .Alert-close svg {
+  fill: var(--lp-component-alert-notification-flair-strong-color-fill);
+}
+
+.Alert.Alert--notification.Alert--flair-strong {
+  background: linear-gradient(41.76deg, #a34fde -17.05%, #3dd6f5 147.06%),
+    linear-gradient(0deg, rgb(255 255 255 / 0.3), rgb(255 255 255 / 0.3));
+}
+
+.Alert.Alert--notification.Alert--flair-default.Alert--bordered::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: 2px;
+  border: 1px solid transparent;
+  background: linear-gradient(131.04deg, #a34fde -15.82%, #405bff 118.85%) border-box;
+  mask:
+    linear-gradient(#fff 0 0) padding-box,
+    linear-gradient(#fff 0 0);
+  mask-composite: xor;
+}
+
+.Alert.Alert--notification.Alert--flair-strong.Alert--bordered {
+  border: 1px solid rgb(255 255 255 / 0.3);
+}
+
+.Alert.Alert--notification.Alert--flair-strong .PrimaryButton {
+  background: var(--lp-component-alert-notification-flair-strong-button-color-bg);
+  border-color: var(--lp-component-alert-notification-flair-strong-button-button-color-border);
+  color: var(--lp-component-alert-notification-flair-strong-button-color-text);
+}
+
+.Alert.Alert--notification.Alert--flair-strong .PrimaryButton:hover {
+  background: var(--lp-component-alert-notification-flair-strong-button-color-bg-hover);
+  color: var(--lp-component-alert-notification-flair-strong-button-color-text-hover);
+}
+
+.Alert.Alert--notification.Alert--flair-strong .PrimaryButton:focus {
+  background: var(--lp-component-alert-notification-flair-strong-button-color-bg-focus);
+  color: var(--lp-component-alert-notification-flair-strong-button-color-text-focus);
+}
+
+.Alert.Alert--notification.Alert--flair-strong .PrimaryButton:active {
+  background: var(--lp-component-alert-notification-flair-strong-button-color-bg-active);
+  color: var(--lp-component-alert-notification-flair-strong-button-color-text-active);
+}
+
+.Alert.Alert--notification .LinkButton {
+  text-decoration: none;
+}
+
+.Alert.Alert--notification.Alert--flair-strong .LinkButton {
+  color: var(--lp-component-alert-notification-flair-strong-color-text);
 }
 
 .Alert.Alert--info.Alert--bordered {

--- a/packages/alert/stories/Alert.stories.tsx
+++ b/packages/alert/stories/Alert.stories.tsx
@@ -45,6 +45,11 @@ export default {
         category: 'Presentation',
       },
     },
+    flairLevel: {
+      table: {
+        category: 'Presentation',
+      },
+    },
     size: {
       table: {
         category: 'Presentation',
@@ -202,5 +207,22 @@ export const WithControlledDismissed: Story = {
     };
 
     return <Component />;
+  },
+};
+
+export const Notification = {
+  args: {
+    kind: 'notification',
+    flairLevel: 'default',
+    header: 'Heading about a cool thing',
+    primaryButton: {
+      children: 'Primary action',
+    },
+    link: {
+      href: 'https://launchdarkly.com',
+      text: 'Link to learn more',
+    },
+    children: <div>Description about the cool thing you want people to know about</div>,
+    dismissible: true,
   },
 };

--- a/packages/icons/src/StatusIcon.tsx
+++ b/packages/icons/src/StatusIcon.tsx
@@ -3,7 +3,7 @@ import type { IconProps } from './Icon';
 import { Icon } from './Icon';
 
 type StatusIconProps = Omit<IconProps, 'name'> & {
-  kind: 'info' | 'success' | 'warning' | 'error';
+  kind: 'info' | 'success' | 'warning' | 'error' | 'notification';
 };
 
 const StatusIcon = ({ kind, size = 'medium', ...rest }: StatusIconProps) => {
@@ -26,6 +26,10 @@ const StatusIcon = ({ kind, size = 'medium', ...rest }: StatusIconProps) => {
     case 'info':
       name = 'info';
       ariaLabel = 'Info';
+      break;
+    case 'notification':
+      name = 'notifications';
+      ariaLabel = 'Notification';
       break;
   }
 


### PR DESCRIPTION
## Summary

<!-- What is changing and why? -->
Supporting "notification" styles on Alert, including flare, with optional action button and link

## Screenshots (if appropriate):
Default flair notification style
![image](https://github.com/launchdarkly/launchpad-ui/assets/6188364/601ad345-f4f5-4f92-aa00-ead0273f35f3)

Strong flair notification style (dark/light are the same)
![image](https://github.com/launchdarkly/launchpad-ui/assets/6188364/33fb662f-7bd7-4890-8988-24e82e34b052)


<!-- Are there any visual changes that would be helpful to the reviewer to see? -->

## Testing approaches

<!-- How are these changes tested? -->
