### PR TITLE
chore: exit prerelease mode

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,5 +1,5 @@
 {
-  "mode": "pre",
+  "mode": "exit",
   "tag": "alpha",
   "initialVersions": {
     "@launchpad-ui/remix": "0.0.1",


### PR DESCRIPTION
## Summary

Exit prerelease mode to merge icon updates to `main`.