### PR TITLE
chore: revert "chore: version packages (alpha)"

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -52,8 +52,6 @@
     "cyan-donkeys-change",
     "quick-apples-happen",
     "quick-rockets-sit",
-    "selfish-pens-mate",
-    "thick-radios-report",
-    "wise-buckets-deliver"
+    "selfish-pens-mate"
   ]
 }

--- a/packages/card/CHANGELOG.md
+++ b/packages/card/CHANGELOG.md
@@ -1,12 +1,5 @@
 # @launchpad-ui/card
 
-## 0.2.1-alpha.1
-
-### Patch Changes
-
-- Updated dependencies []:
-  - @launchpad-ui/form@0.10.1-alpha.1
-
 ## 0.2.1-alpha.0
 
 ### Patch Changes

--- a/packages/card/package.json
+++ b/packages/card/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@launchpad-ui/card",
-  "version": "0.2.1-alpha.1",
+  "version": "0.2.1-alpha.0",
   "status": "alpha",
   "publishConfig": {
     "access": "public"

--- a/packages/clipboard/CHANGELOG.md
+++ b/packages/clipboard/CHANGELOG.md
@@ -1,12 +1,5 @@
 # @launchpad-ui/clipboard
 
-## 0.11.1-alpha.1
-
-### Patch Changes
-
-- Updated dependencies []:
-  - @launchpad-ui/tooltip@0.8.1-alpha.1
-
 ## 0.11.1-alpha.0
 
 ### Patch Changes

--- a/packages/clipboard/package.json
+++ b/packages/clipboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@launchpad-ui/clipboard",
-  "version": "0.11.1-alpha.1",
+  "version": "0.11.1-alpha.0",
   "status": "beta",
   "publishConfig": {
     "access": "public"

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,29 +1,5 @@
 # @launchpad-ui/core
 
-## 0.47.1-alpha.1
-
-### Patch Changes
-
-- [#1046](https://github.com/launchdarkly/launchpad-ui/pull/1046) [`36b47d4c`](https://github.com/launchdarkly/launchpad-ui/commit/36b47d4c0dad59849db23d0e112e3b4b36b53f5e) Thanks [@Niznikr](https://github.com/Niznikr)! - [Menu] Use CSS modules
-
-- [#1043](https://github.com/launchdarkly/launchpad-ui/pull/1043) [`6cc6da28`](https://github.com/launchdarkly/launchpad-ui/commit/6cc6da28f200f101664d8d6730cbc83893917290) Thanks [@matthewferry](https://github.com/matthewferry)! - Refresh menu styles
-
-- Updated dependencies [[`36b47d4c`](https://github.com/launchdarkly/launchpad-ui/commit/36b47d4c0dad59849db23d0e112e3b4b36b53f5e), [`6cc6da28`](https://github.com/launchdarkly/launchpad-ui/commit/6cc6da28f200f101664d8d6730cbc83893917290)]:
-  - @launchpad-ui/menu@0.12.1-alpha.1
-  - @launchpad-ui/popover@0.11.1-alpha.1
-  - @launchpad-ui/filter@0.6.1-alpha.1
-  - @launchpad-ui/navigation@0.12.1-alpha.1
-  - @launchpad-ui/dropdown@0.6.75-alpha.1
-  - @launchpad-ui/progress-bubbles@0.7.1-alpha.1
-  - @launchpad-ui/select@0.4.1-alpha.1
-  - @launchpad-ui/split-button@0.9.1-alpha.1
-  - @launchpad-ui/tooltip@0.8.1-alpha.1
-  - @launchpad-ui/clipboard@0.11.1-alpha.1
-  - @launchpad-ui/form@0.10.1-alpha.1
-  - @launchpad-ui/tag@0.3.1-alpha.1
-  - @launchpad-ui/card@0.2.1-alpha.1
-  - @launchpad-ui/inline-edit@0.2.1-alpha.1
-
 ## 0.47.1-alpha.0
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@launchpad-ui/core",
-  "version": "0.47.1-alpha.1",
+  "version": "0.47.1-alpha.0",
   "status": "beta",
   "publishConfig": {
     "access": "public"

--- a/packages/dropdown/CHANGELOG.md
+++ b/packages/dropdown/CHANGELOG.md
@@ -1,12 +1,5 @@
 # @launchpad-ui/dropdown
 
-## 0.6.75-alpha.1
-
-### Patch Changes
-
-- Updated dependencies [[`6cc6da28`](https://github.com/launchdarkly/launchpad-ui/commit/6cc6da28f200f101664d8d6730cbc83893917290)]:
-  - @launchpad-ui/popover@0.11.1-alpha.1
-
 ## 0.6.75-alpha.0
 
 ### Patch Changes

--- a/packages/dropdown/package.json
+++ b/packages/dropdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@launchpad-ui/dropdown",
-  "version": "0.6.75-alpha.1",
+  "version": "0.6.75-alpha.0",
   "status": "beta",
   "publishConfig": {
     "access": "public"

--- a/packages/filter/CHANGELOG.md
+++ b/packages/filter/CHANGELOG.md
@@ -1,14 +1,5 @@
 # @launchpad-ui/filter
 
-## 0.6.1-alpha.1
-
-### Patch Changes
-
-- Updated dependencies [[`36b47d4c`](https://github.com/launchdarkly/launchpad-ui/commit/36b47d4c0dad59849db23d0e112e3b4b36b53f5e), [`6cc6da28`](https://github.com/launchdarkly/launchpad-ui/commit/6cc6da28f200f101664d8d6730cbc83893917290)]:
-  - @launchpad-ui/menu@0.12.1-alpha.1
-  - @launchpad-ui/dropdown@0.6.75-alpha.1
-  - @launchpad-ui/tooltip@0.8.1-alpha.1
-
 ## 0.6.1-alpha.0
 
 ### Patch Changes

--- a/packages/filter/package.json
+++ b/packages/filter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@launchpad-ui/filter",
-  "version": "0.6.1-alpha.1",
+  "version": "0.6.1-alpha.0",
   "status": "beta",
   "publishConfig": {
     "access": "public"

--- a/packages/form/CHANGELOG.md
+++ b/packages/form/CHANGELOG.md
@@ -1,12 +1,5 @@
 # @launchpad-ui/form
 
-## 0.10.1-alpha.1
-
-### Patch Changes
-
-- Updated dependencies []:
-  - @launchpad-ui/tooltip@0.8.1-alpha.1
-
 ## 0.10.1-alpha.0
 
 ### Patch Changes

--- a/packages/form/package.json
+++ b/packages/form/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@launchpad-ui/form",
-  "version": "0.10.1-alpha.1",
+  "version": "0.10.1-alpha.0",
   "status": "beta",
   "publishConfig": {
     "access": "public"

--- a/packages/inline-edit/CHANGELOG.md
+++ b/packages/inline-edit/CHANGELOG.md
@@ -1,12 +1,5 @@
 # @launchpad-ui/inline-edit
 
-## 0.2.1-alpha.1
-
-### Patch Changes
-
-- Updated dependencies []:
-  - @launchpad-ui/form@0.10.1-alpha.1
-
 ## 0.2.1-alpha.0
 
 ### Patch Changes

--- a/packages/inline-edit/package.json
+++ b/packages/inline-edit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@launchpad-ui/inline-edit",
-  "version": "0.2.1-alpha.1",
+  "version": "0.2.1-alpha.0",
   "status": "alpha",
   "publishConfig": {
     "access": "public"

--- a/packages/menu/CHANGELOG.md
+++ b/packages/menu/CHANGELOG.md
@@ -1,18 +1,5 @@
 # @launchpad-ui/menu
 
-## 0.12.1-alpha.1
-
-### Patch Changes
-
-- [#1046](https://github.com/launchdarkly/launchpad-ui/pull/1046) [`36b47d4c`](https://github.com/launchdarkly/launchpad-ui/commit/36b47d4c0dad59849db23d0e112e3b4b36b53f5e) Thanks [@Niznikr](https://github.com/Niznikr)! - [Menu] Use CSS modules
-
-- [#1043](https://github.com/launchdarkly/launchpad-ui/pull/1043) [`6cc6da28`](https://github.com/launchdarkly/launchpad-ui/commit/6cc6da28f200f101664d8d6730cbc83893917290) Thanks [@matthewferry](https://github.com/matthewferry)! - Refresh menu styles
-
-- Updated dependencies [[`6cc6da28`](https://github.com/launchdarkly/launchpad-ui/commit/6cc6da28f200f101664d8d6730cbc83893917290)]:
-  - @launchpad-ui/popover@0.11.1-alpha.1
-  - @launchpad-ui/tooltip@0.8.1-alpha.1
-  - @launchpad-ui/form@0.10.1-alpha.1
-
 ## 0.12.1-alpha.0
 
 ### Patch Changes

--- a/packages/menu/package.json
+++ b/packages/menu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@launchpad-ui/menu",
-  "version": "0.12.1-alpha.1",
+  "version": "0.12.1-alpha.0",
   "status": "beta",
   "publishConfig": {
     "access": "public"

--- a/packages/navigation/CHANGELOG.md
+++ b/packages/navigation/CHANGELOG.md
@@ -1,15 +1,5 @@
 # @launchpad-ui/navigation
 
-## 0.12.1-alpha.1
-
-### Patch Changes
-
-- Updated dependencies [[`36b47d4c`](https://github.com/launchdarkly/launchpad-ui/commit/36b47d4c0dad59849db23d0e112e3b4b36b53f5e), [`6cc6da28`](https://github.com/launchdarkly/launchpad-ui/commit/6cc6da28f200f101664d8d6730cbc83893917290)]:
-  - @launchpad-ui/menu@0.12.1-alpha.1
-  - @launchpad-ui/popover@0.11.1-alpha.1
-  - @launchpad-ui/dropdown@0.6.75-alpha.1
-  - @launchpad-ui/tooltip@0.8.1-alpha.1
-
 ## 0.12.1-alpha.0
 
 ### Patch Changes

--- a/packages/navigation/package.json
+++ b/packages/navigation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@launchpad-ui/navigation",
-  "version": "0.12.1-alpha.1",
+  "version": "0.12.1-alpha.0",
   "status": "beta",
   "publishConfig": {
     "access": "public"

--- a/packages/popover/CHANGELOG.md
+++ b/packages/popover/CHANGELOG.md
@@ -1,11 +1,5 @@
 # @launchpad-ui/popover
 
-## 0.11.1-alpha.1
-
-### Patch Changes
-
-- [#1043](https://github.com/launchdarkly/launchpad-ui/pull/1043) [`6cc6da28`](https://github.com/launchdarkly/launchpad-ui/commit/6cc6da28f200f101664d8d6730cbc83893917290) Thanks [@matthewferry](https://github.com/matthewferry)! - Refresh menu styles
-
 ## 0.11.1-alpha.0
 
 ### Patch Changes

--- a/packages/popover/package.json
+++ b/packages/popover/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@launchpad-ui/popover",
-  "version": "0.11.1-alpha.1",
+  "version": "0.11.1-alpha.0",
   "status": "beta",
   "publishConfig": {
     "access": "public"

--- a/packages/progress-bubbles/CHANGELOG.md
+++ b/packages/progress-bubbles/CHANGELOG.md
@@ -1,12 +1,5 @@
 # @launchpad-ui/progress-bubbles
 
-## 0.7.1-alpha.1
-
-### Patch Changes
-
-- Updated dependencies [[`6cc6da28`](https://github.com/launchdarkly/launchpad-ui/commit/6cc6da28f200f101664d8d6730cbc83893917290)]:
-  - @launchpad-ui/popover@0.11.1-alpha.1
-
 ## 0.7.1-alpha.0
 
 ### Patch Changes

--- a/packages/progress-bubbles/package.json
+++ b/packages/progress-bubbles/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@launchpad-ui/progress-bubbles",
-  "version": "0.7.1-alpha.1",
+  "version": "0.7.1-alpha.0",
   "status": "beta",
   "publishConfig": {
     "access": "public"

--- a/packages/select/CHANGELOG.md
+++ b/packages/select/CHANGELOG.md
@@ -1,13 +1,5 @@
 # @launchpad-ui/select
 
-## 0.4.1-alpha.1
-
-### Patch Changes
-
-- Updated dependencies [[`6cc6da28`](https://github.com/launchdarkly/launchpad-ui/commit/6cc6da28f200f101664d8d6730cbc83893917290)]:
-  - @launchpad-ui/popover@0.11.1-alpha.1
-  - @launchpad-ui/tooltip@0.8.1-alpha.1
-
 ## 0.4.1-alpha.0
 
 ### Patch Changes

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@launchpad-ui/select",
-  "version": "0.4.1-alpha.1",
+  "version": "0.4.1-alpha.0",
   "status": "alpha",
   "publishConfig": {
     "access": "public"

--- a/packages/split-button/CHANGELOG.md
+++ b/packages/split-button/CHANGELOG.md
@@ -1,14 +1,5 @@
 # @launchpad-ui/split-button
 
-## 0.9.1-alpha.1
-
-### Patch Changes
-
-- Updated dependencies [[`6cc6da28`](https://github.com/launchdarkly/launchpad-ui/commit/6cc6da28f200f101664d8d6730cbc83893917290)]:
-  - @launchpad-ui/popover@0.11.1-alpha.1
-  - @launchpad-ui/dropdown@0.6.75-alpha.1
-  - @launchpad-ui/tooltip@0.8.1-alpha.1
-
 ## 0.9.1-alpha.0
 
 ### Patch Changes

--- a/packages/split-button/package.json
+++ b/packages/split-button/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@launchpad-ui/split-button",
-  "version": "0.9.1-alpha.1",
+  "version": "0.9.1-alpha.0",
   "status": "beta",
   "publishConfig": {
     "access": "public"

--- a/packages/tag/CHANGELOG.md
+++ b/packages/tag/CHANGELOG.md
@@ -1,12 +1,5 @@
 # @launchpad-ui/tag
 
-## 0.3.1-alpha.1
-
-### Patch Changes
-
-- Updated dependencies []:
-  - @launchpad-ui/tooltip@0.8.1-alpha.1
-
 ## 0.3.1-alpha.0
 
 ### Patch Changes

--- a/packages/tag/package.json
+++ b/packages/tag/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@launchpad-ui/tag",
-  "version": "0.3.1-alpha.1",
+  "version": "0.3.1-alpha.0",
   "status": "alpha",
   "publishConfig": {
     "access": "public"

--- a/packages/tooltip/CHANGELOG.md
+++ b/packages/tooltip/CHANGELOG.md
@@ -1,12 +1,5 @@
 # @launchpad-ui/tooltip
 
-## 0.8.1-alpha.1
-
-### Patch Changes
-
-- Updated dependencies [[`6cc6da28`](https://github.com/launchdarkly/launchpad-ui/commit/6cc6da28f200f101664d8d6730cbc83893917290)]:
-  - @launchpad-ui/popover@0.11.1-alpha.1
-
 ## 0.8.1-alpha.0
 
 ### Patch Changes

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@launchpad-ui/tooltip",
-  "version": "0.8.1-alpha.1",
+  "version": "0.8.1-alpha.0",
   "status": "beta",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Reverts launchdarkly/launchpad-ui#1045

We'll merge in `main` and republish.