### PR TITLE
feat: add diamond and diamond-outline icons

### DIFF
--- a/.changeset/unlucky-stingrays-deny.md
+++ b/.changeset/unlucky-stingrays-deny.md
@@ -1,0 +1,6 @@
+---
+'@launchpad-ui/icons': patch
+'@launchpad-ui/core': patch
+---
+
+Add diamond icons

--- a/packages/icons/src/img/sprite.svg
+++ b/packages/icons/src/img/sprite.svg
@@ -559,6 +559,20 @@
       />
       <path d="M17.5 16.73a.9.9 0 0 1 .9.9v.01a.9.9 0 1 1-1.8 0v-.01a.9.9 0 0 1 .9-.9Z" />
     </symbol>
+    <symbol viewBox="0 0 24 24" id="lp-icon-diamond">
+      <path
+        fill-rule="evenodd"
+        d="M10.94 2.788a1.5 1.5 0 0 1 2.12 0l8.152 8.151a1.5 1.5 0 0 1 0 2.122l-8.151 8.151a1.5 1.5 0 0 1-2.122 0l-8.151-8.151a1.5 1.5 0 0 1 0-2.122l8.151-8.151Z"
+        clip-rule="evenodd"
+      />
+    </symbol>
+    <symbol viewBox="0 0 24 24" id="lp-icon-diamond-outline">
+      <path
+        fill-rule="evenodd"
+        d="M10.94 2.788a1.5 1.5 0 0 1 2.12 0l8.152 8.151a1.5 1.5 0 0 1 0 2.122l-8.151 8.151a1.5 1.5 0 0 1-2.122 0l-8.151-8.151a1.5 1.5 0 0 1 0-2.122l8.151-8.151ZM12 4.273 4.273 12 12 19.727 19.727 12 12 4.273Z"
+        clip-rule="evenodd"
+      />
+    </symbol>
     <symbol viewBox="0 0 24 24" id="lp-icon-document-question">
       <path
         fill-rule="evenodd"

--- a/packages/icons/src/types.ts
+++ b/packages/icons/src/types.ts
@@ -77,6 +77,8 @@ const icons = [
   'device-mobile',
   'device-server',
   'devices',
+  'diamond',
+  'diamond-outline',
   'document-question',
   'door-exit',
   'download',


### PR DESCRIPTION
## Summary

Adds diamond and diamond-outline icons

<img width="164" alt="diamond icons" src="https://github.com/launchdarkly/launchpad-ui/assets/895885/776418d6-7661-4507-b432-74bffe6cff3e">

<img width="448" alt="icons in storybook" src="https://github.com/launchdarkly/launchpad-ui/assets/895885/a12899f5-c8ba-4c4f-8342-72d01d353bd5">

