### PR TITLE
fix: use proper type for exposing tooltip options on MenuItem

### DIFF
--- a/.changeset/polite-kings-return.md
+++ b/.changeset/polite-kings-return.md
@@ -1,0 +1,5 @@
+---
+"@launchpad-ui/menu": patch
+---
+
+use proper type for exposing tooltip options on MenuItem

--- a/packages/menu/src/MenuItem.tsx
+++ b/packages/menu/src/MenuItem.tsx
@@ -29,7 +29,7 @@ type MenuItemOwnProps = {
   nested?: boolean;
   groupHeader?: boolean;
   tooltip?: string | ReactElement;
-  tooltipOptions?: typeof Tooltip;
+  tooltipOptions?: ComponentPropsWithRef<typeof Tooltip>;
   tooltipPlacement?: PopoverPlacement;
   asChild?: boolean;
   'data-test-id'?: string;


### PR DESCRIPTION
## Summary

<!-- What is changing and why? -->
The current type of `tooltipOptions` on the `MenuItem` component is incorrect - it does not correctly reference the props of the tooltip component.

## Screenshots (if appropriate):

<!-- Are there any visual changes that would be helpful to the reviewer to see? -->

## Testing approaches

<!-- How are these changes tested? -->
