### PR TITLE
feat: add 'circles' icon

### DIFF
--- a/.changeset/strong-spiders-float.md
+++ b/.changeset/strong-spiders-float.md
@@ -1,0 +1,6 @@
+---
+'@launchpad-ui/icons': minor
+'@launchpad-ui/core': minor
+---
+
+Add circles icon

--- a/.changeset/strong-spiders-float.md
+++ b/.changeset/strong-spiders-float.md
@@ -1,6 +1,6 @@
 ---
-'@launchpad-ui/icons': minor
-'@launchpad-ui/core': minor
+'@launchpad-ui/icons': patch
+'@launchpad-ui/core': patch
 ---
 
 Add circles icon

--- a/packages/icons/src/img/sprite.svg
+++ b/packages/icons/src/img/sprite.svg
@@ -456,6 +456,13 @@
         clip-rule="evenodd"
       />
     </symbol>
+    <symbol viewBox="0 0 16 16" id="lp-icon-circles">
+      <path
+        fill-rule="evenodd"
+        d="M3.792 7a2.917 2.917 0 1 1-2.914 3.043l-.003-.126.003-.127A2.917 2.917 0 0 1 3.792 7ZM10.208 7a2.917 2.917 0 1 1-2.913 3.043l-.003-.126.003-.127A2.917 2.917 0 0 1 10.208 7ZM7 1.167A2.917 2.917 0 1 1 4.086 4.21l-.003-.127.003-.126A2.917 2.917 0 0 1 7 1.167Z"
+        clip-rule="evenodd"
+      />
+    </symbol>
     <symbol viewBox="0 0 24 24" id="lp-icon-click">
       <path
         fill-rule="evenodd"

--- a/packages/icons/src/types.ts
+++ b/packages/icons/src/types.ts
@@ -61,6 +61,7 @@ const icons = [
   'circle',
   'circle-dashed',
   'circle-outline',
+  'circles',
   'click',
   'clipboard-edit',
   'clock',


### PR DESCRIPTION
## Summary

Adds the 'circles' icon 

<img width="125" alt="Screenshot 2023-12-20 at 11 57 06 AM" src="https://github.com/launchdarkly/launchpad-ui/assets/23638474/27911efd-554d-4814-9af8-bf5fd96d6537">
<img width="111" alt="Screenshot 2023-12-20 at 11 58 19 AM" src="https://github.com/launchdarkly/launchpad-ui/assets/23638474/2dc8ec34-e8fe-454b-9a0f-b2604a4ef006">
