### PR TITLE
refactor: use storybook modes for chromatic

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -32,6 +32,7 @@ const config: StorybookConfig = {
     'storybook-addon-pseudo-states',
     '@etchteam/storybook-addon-status',
     '@storybook/addon-designs',
+    '@storybook/addon-themes',
   ],
   framework: '@storybook/react-vite',
   core: {

--- a/.storybook/modes.ts
+++ b/.storybook/modes.ts
@@ -1,0 +1,10 @@
+export const allModes = {
+  default: {
+    backgrounds: 'default',
+    theme: 'default',
+  },
+  dark: {
+    backgrounds: 'dark',
+    theme: 'dark',
+  },
+};

--- a/.storybook/modes.ts
+++ b/.storybook/modes.ts
@@ -7,4 +7,7 @@ export const allModes = {
     backgrounds: 'dark',
     theme: 'dark',
   },
+  mobile: {
+    viewport: 320,
+  },
 };

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,6 +1,8 @@
-import isChromatic from 'chromatic';
+import { withThemeByDataAttribute } from '@storybook/addon-themes';
 import { MotionConfig } from 'framer-motion';
 import React from 'react';
+
+import { allModes } from './modes';
 
 import '../packages/tokens/dist/index.css';
 import '../packages/tokens/dist/themes.css';
@@ -16,6 +18,19 @@ export const parameters = {
       method: 'alphabetical',
       order: ['Components', 'Tokens'],
       locales: 'en-US',
+    },
+  },
+  backgrounds: {
+    default: 'default',
+    values: [
+      { name: 'default', value: 'var(--lp-color-bg-ui-primary)' },
+      { name: 'dark', value: 'var(--lp-color-bg-ui-primary)' },
+    ],
+  },
+  chromatic: {
+    modes: {
+      default: allModes.default,
+      dark: allModes.dark,
     },
   },
   status: {
@@ -41,53 +56,19 @@ export const parameters = {
   },
 };
 
-export const globalTypes = {
-  theme: {
-    name: 'Theme',
-    description: 'Global theme for components',
-    defaultValue: isChromatic() ? 'side-by-side' : 'default',
-    toolbar: {
-      icon: 'circlehollow',
-      title: 'Theme',
-      items: [
-        { value: 'default', icon: 'circlehollow', title: 'default' },
-        { value: 'dark', icon: 'circle', title: 'dark' },
-        { value: 'side-by-side', icon: 'sidebar', title: 'side by side' },
-      ],
-    },
-  },
-};
-
 export const decorators = [
-  (StoryFn, context) => {
-    const theme = context.parameters.theme || context.globals.theme;
-
-    switch (theme) {
-      case 'side-by-side': {
-        document.documentElement.setAttribute('data-theme', 'default');
-        return (
-          <MotionConfig reducedMotion="user">
-            <div style={{ display: 'flex', flexDirection: 'row', minHeight: '100vh' }}>
-              <div style={{ width: '50vw', padding: '0.625rem' }}>
-                <StoryFn />
-              </div>
-              <div data-theme="dark" style={{ width: '50vw', padding: '0.625rem' }}>
-                <StoryFn />
-              </div>
-            </div>
-          </MotionConfig>
-        );
-      }
-      default: {
-        document.documentElement.setAttribute('data-theme', theme);
-        return (
-          <MotionConfig reducedMotion="user">
-            <div style={{ padding: '0.625rem' }}>
-              <StoryFn />
-            </div>
-          </MotionConfig>
-        );
-      }
-    }
-  },
+  (StoryFn) => (
+    <MotionConfig reducedMotion="user">
+      <div style={{ padding: '0.625rem' }}>
+        <StoryFn />
+      </div>
+    </MotionConfig>
+  ),
+  withThemeByDataAttribute({
+    themes: {
+      default: 'default',
+      dark: 'dark',
+    },
+    defaultTheme: 'default',
+  }),
 ];

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@storybook/addon-designs": "^7.0.5",
     "@storybook/addon-essentials": "^7.6.3",
     "@storybook/addon-interactions": "^7.6.3",
+    "@storybook/addon-themes": "^7.6.10",
     "@storybook/addons": "^7.6.3",
     "@storybook/api": "^7.6.3",
     "@storybook/blocks": "^7.6.3",

--- a/packages/alert/src/styles/Alert.module.css
+++ b/packages/alert/src/styles/Alert.module.css
@@ -128,8 +128,7 @@
   mask:
     linear-gradient(#fff 0 0) padding-box,
     linear-gradient(#fff 0 0);
-  mask-composite: xor;
-  mask-composite: xor;
+  mask-composite: exclude;
 }
 
 .Alert.Alert--notification.Alert--flair-strong.Alert--bordered {

--- a/packages/alert/src/styles/Alert.module.css
+++ b/packages/alert/src/styles/Alert.module.css
@@ -129,6 +129,7 @@
     linear-gradient(#fff 0 0) padding-box,
     linear-gradient(#fff 0 0);
   mask-composite: xor;
+  mask-composite: xor;
 }
 
 .Alert.Alert--notification.Alert--flair-strong.Alert--bordered {

--- a/packages/clipboard/stories/CopyToClipboard.stories.tsx
+++ b/packages/clipboard/stories/CopyToClipboard.stories.tsx
@@ -50,9 +50,7 @@ export const Default: Story = {
   play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
     const canvas = within(canvasElement);
 
-    const buttons = canvas.getAllByRole('button');
-    userEvent.hover(buttons[0]);
-    userEvent.click(buttons[1]);
+    userEvent.hover(canvas.getByRole('button'));
   },
 };
 
@@ -61,9 +59,7 @@ export const Basic: Story = {
   play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
     const canvas = within(canvasElement);
 
-    const buttons = canvas.getAllByRole('button');
-    userEvent.hover(buttons[0]);
-    userEvent.click(buttons[1]);
+    userEvent.click(canvas.getByRole('button'));
   },
 };
 
@@ -72,9 +68,7 @@ export const Minimal: Story = {
   play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
     const canvas = within(canvasElement);
 
-    const buttons = canvas.getAllByRole('button');
-    userEvent.hover(buttons[0]);
-    userEvent.click(buttons[1]);
+    userEvent.hover(canvas.getByRole('button'));
   },
 };
 

--- a/packages/core/stories/getting-started.stories.mdx
+++ b/packages/core/stories/getting-started.stories.mdx
@@ -3,4 +3,4 @@ import { Figma } from '@storybook/addon-designs/blocks';
 
 <Meta title="Getting started" />
 
-<Figma url="https://www.figma.com/file/ITlrRueSW0eYdUp7acr9Xi/LaunchPad?type=design&node-id=19352-805" />
+<Figma url="https://www.figma.com/file/ITlrRueSW0eYdUp7acr9Xi/LaunchPad?type=design&node-id=21176-42" />

--- a/packages/drawer/stories/Drawer.stories.tsx
+++ b/packages/drawer/stories/Drawer.stories.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react-hooks/rules-of-hooks */
-import type { StoryObj } from '@storybook/react';
+import type { StoryFn, StoryObj } from '@storybook/react';
 
 import { Button } from '@launchpad-ui/button';
 import { Tooltip } from '@launchpad-ui/tooltip';
@@ -20,6 +20,17 @@ export default {
       type: import.meta.env.STORYBOOK_PACKAGE_STATUS__DRAWER,
     },
   },
+  decorators: [
+    (Story: StoryFn) => (
+      <div
+        style={{
+          height: '100vh',
+        }}
+      >
+        <Story />
+      </div>
+    ),
+  ],
 };
 
 type Story = StoryObj<typeof Drawer>;

--- a/packages/icons/stories/Icon.stories.tsx
+++ b/packages/icons/stories/Icon.stories.tsx
@@ -15,7 +15,6 @@ export default {
     status: {
       type: import.meta.env.STORYBOOK_PACKAGE_STATUS__ICONS,
     },
-    chromatic: { viewports: [1700] },
   },
   argTypes: {
     name: {

--- a/packages/modal/stories/Modal.stories.tsx
+++ b/packages/modal/stories/Modal.stories.tsx
@@ -8,6 +8,7 @@ import { useState } from '@storybook/client-api';
 import { userEvent, within } from '@storybook/test';
 import { useRef } from 'react';
 
+import { allModes } from '../../../.storybook/modes';
 import { REACT_NODE_TYPE_DOCS } from '../../../.storybook/utils';
 import { AbsoluteModalFooter, Modal, ModalBody, ModalFooter, ModalHeader } from '../src';
 
@@ -251,7 +252,11 @@ export const KitchenSink: Story = {
   },
   parameters: {
     docs: { disable: true },
-    chromatic: { viewports: [320, 1200] },
+    chromatic: {
+      modes: {
+        mobile: allModes.mobile,
+      },
+    },
     a11y: {
       options: {
         rules: {

--- a/packages/modal/stories/Modal.stories.tsx
+++ b/packages/modal/stories/Modal.stories.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react-hooks/rules-of-hooks */
-import type { StoryObj } from '@storybook/react';
+import type { StoryFn, StoryObj } from '@storybook/react';
 
 import { Button } from '@launchpad-ui/button';
 import { Icon } from '@launchpad-ui/icons';
@@ -66,6 +66,17 @@ export default {
   args: {
     size: 'medium',
   },
+  decorators: [
+    (Story: StoryFn) => (
+      <div
+        style={{
+          height: '100vh',
+        }}
+      >
+        <Story />
+      </div>
+    ),
+  ],
 };
 
 type Story = StoryObj<typeof Modal>;

--- a/packages/navigation/stories/Navigation.stories.tsx
+++ b/packages/navigation/stories/Navigation.stories.tsx
@@ -4,6 +4,7 @@ import type { ReactNode } from 'react';
 
 import { MemoryRouter } from 'react-router-dom';
 
+import { allModes } from '../../../.storybook/modes';
 import { Navigation, NavigationItem } from '../src';
 
 export default {
@@ -59,7 +60,11 @@ export const Primary: Story = {
     children: (item) => <NavigationItem key={item.to} {...item} />,
   },
   parameters: {
-    chromatic: { viewports: [320, 1200] },
+    chromatic: {
+      modes: {
+        mobile: allModes.mobile,
+      },
+    },
   },
 };
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       '@storybook/addon-interactions':
         specifier: ^7.6.3
         version: 7.6.7
+      '@storybook/addon-themes':
+        specifier: ^7.6.10
+        version: 7.6.10
       '@storybook/addons':
         specifier: ^7.6.3
         version: 7.6.7(react-dom@18.2.0)(react@18.2.0)
@@ -7073,6 +7076,12 @@ packages:
     resolution: {integrity: sha512-gu2y46ijjMkXlxy1f8Cctgjw5b5y8vSIqNAYlrs5/Qy+hJAWyU6lj2PFGOCCUG4L+F45fAjwWAin6qz43+WnRQ==}
     dependencies:
       '@storybook/global': 5.0.0
+      ts-dedent: 2.2.0
+    dev: true
+
+  /@storybook/addon-themes@7.6.10:
+    resolution: {integrity: sha512-fsWr9FOVMJoD9bsXf1B7uHRajWx2Lruhi3VYGt/AZG6a/g38ja31+lWynpESOGxv4hOCyoNIAdC5JZFbMg7mOA==}
+    dependencies:
       ts-dedent: 2.2.0
     dev: true
 


### PR DESCRIPTION
## Summary

Use [Story modes](https://www.chromatic.com/docs/modes/) and the [themes addon](https://storybook.js.org/addons/@storybook/addon-themes/) to handle snapshots in Chromatic.