### PR TITLE
refactor(components): replace pseudo selectors with RAC data attributes

### DIFF
--- a/.changeset/itchy-lions-jog.md
+++ b/.changeset/itchy-lions-jog.md
@@ -1,0 +1,5 @@
+---
+"@launchpad-ui/components": patch
+---
+
+Replace pseudo selectors with RAC data attributes

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -44,8 +44,6 @@ jobs:
       - name: Publish to Chromatic
         id: chromatic
         uses: chromaui/action@v10
-        env:
-          NODE_OPTIONS: '--max_old_space_size=8192'
         with:
           projectToken: ${{ env.CHROMATIC_TOKEN }}
           buildScriptName: 'storybook:build'

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -45,7 +45,7 @@ jobs:
         id: chromatic
         uses: chromaui/action@v10
         env:
-          NODE_OPTIONS: '--max_old_space_size=4096'
+          NODE_OPTIONS: '--max_old_space_size=8192'
         with:
           projectToken: ${{ env.CHROMATIC_TOKEN }}
           buildScriptName: 'storybook:build'

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -27,7 +27,12 @@ const config: StorybookConfig = {
   },
   addons: [
     '@storybook/addon-a11y',
-    '@storybook/addon-essentials',
+    {
+      name: '@storybook/addon-essentials',
+      options: {
+        actions: false,
+      },
+    },
     '@storybook/addon-interactions',
     'storybook-addon-pseudo-states',
     '@etchteam/storybook-addon-status',

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -27,12 +27,7 @@ const config: StorybookConfig = {
   },
   addons: [
     '@storybook/addon-a11y',
-    {
-      name: '@storybook/addon-essentials',
-      options: {
-        actions: false,
-      },
-    },
+    '@storybook/addon-essentials',
     '@storybook/addon-interactions',
     'storybook-addon-pseudo-states',
     '@etchteam/storybook-addon-status',

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -9,7 +9,6 @@ import '../packages/tokens/dist/themes.css';
 import '../packages/tokens/dist/media-queries.css';
 
 export const parameters = {
-  actions: { argTypesRegex: '^on.*' },
   controls: { expanded: true },
   options: {
     showPanel: true,

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -9,6 +9,7 @@ import '../packages/tokens/dist/themes.css';
 import '../packages/tokens/dist/media-queries.css';
 
 export const parameters = {
+  actions: { disable: true },
   controls: { expanded: true },
   options: {
     showPanel: true,

--- a/packages/components/src/Button.tsx
+++ b/packages/components/src/Button.tsx
@@ -4,7 +4,7 @@ import type { ButtonProps as AriaButtonProps } from 'react-aria-components';
 
 import { cva } from 'class-variance-authority';
 import { forwardRef } from 'react';
-import { Button as AriaButton } from 'react-aria-components';
+import { Button as AriaButton, composeRenderProps } from 'react-aria-components';
 
 import styles from './styles/Button.module.css';
 
@@ -35,10 +35,18 @@ type ButtonVariants = VariantProps<typeof button>;
 type ButtonProps = AriaButtonProps & ButtonVariants;
 
 const _Button = (
-  { size = 'medium', variant = 'default', className, ...props }: ButtonProps,
+  { size = 'medium', variant = 'default', ...props }: ButtonProps,
   ref: ForwardedRef<HTMLButtonElement>
 ) => {
-  return <AriaButton {...props} ref={ref} className={button({ size, variant, className })} />;
+  return (
+    <AriaButton
+      {...props}
+      ref={ref}
+      className={composeRenderProps(props.className, (className, renderProps) =>
+        button({ ...renderProps, size, variant, className })
+      )}
+    />
+  );
 };
 
 const Button = forwardRef(_Button);

--- a/packages/components/src/IconButton.tsx
+++ b/packages/components/src/IconButton.tsx
@@ -8,7 +8,7 @@ import type { ButtonProps as AriaButtonProps } from 'react-aria-components';
 import { Icon } from '@launchpad-ui/icons';
 import { cva, cx } from 'class-variance-authority';
 import { forwardRef } from 'react';
-import { Button as AriaButton } from 'react-aria-components';
+import { Button as AriaButton, composeRenderProps } from 'react-aria-components';
 
 import { button } from './Button';
 import styles from './styles/IconButton.module.css';
@@ -33,14 +33,16 @@ type IconButtonProps = Omit<AriaButtonProps, 'children'> &
   };
 
 const _IconButton = (
-  { size = 'medium', variant = 'default', className, icon, ...props }: IconButtonProps,
+  { size = 'medium', variant = 'default', icon, ...props }: IconButtonProps,
   ref: ForwardedRef<HTMLButtonElement>
 ) => {
   return (
     <AriaButton
       {...props}
       ref={ref}
-      className={cx(button({ size, variant }), iconButton({ size, className }))}
+      className={composeRenderProps(props.className, (className, renderProps) =>
+        cx(button({ ...renderProps, size, variant, className }), iconButton({ size }))
+      )}
     >
       <Icon name={icon} size="small" aria-hidden />
     </AriaButton>

--- a/packages/components/src/LinkButton.tsx
+++ b/packages/components/src/LinkButton.tsx
@@ -4,7 +4,7 @@ import type { LinkProps } from 'react-aria-components';
 import type { LinkProps as RouterLinkProps } from 'react-router-dom';
 
 import { forwardRef } from 'react';
-import { Link } from 'react-aria-components';
+import { Link, composeRenderProps } from 'react-aria-components';
 import { useHref, useLinkClickHandler } from 'react-router-dom';
 
 import { button } from './Button';
@@ -12,16 +12,7 @@ import { button } from './Button';
 type LinkButtonProps = LinkProps & RouterLinkProps & ButtonVariants;
 
 const _LinkButton = (
-  {
-    size = 'medium',
-    variant = 'default',
-    className,
-    to,
-    replace,
-    state,
-    target,
-    ...props
-  }: LinkButtonProps,
+  { size = 'medium', variant = 'default', to, replace, state, target, ...props }: LinkButtonProps,
   ref: ForwardedRef<HTMLAnchorElement>
 ) => {
   const href = useHref(to);
@@ -35,7 +26,9 @@ const _LinkButton = (
     <Link
       {...props}
       ref={ref}
-      className={button({ size, variant, className })}
+      className={composeRenderProps(props.className, (className, renderProps) =>
+        button({ ...renderProps, size, variant, className })
+      )}
       href={href}
       onPress={(event) => {
         props.onPress?.(event);

--- a/packages/components/src/ProgressBar.tsx
+++ b/packages/components/src/ProgressBar.tsx
@@ -4,7 +4,7 @@ import type { ProgressBarProps as AriaProgressBarProps } from 'react-aria-compon
 
 import { cva, cx } from 'class-variance-authority';
 import { forwardRef } from 'react';
-import { ProgressBar as AriaProgressBar } from 'react-aria-components';
+import { ProgressBar as AriaProgressBar, composeRenderProps } from 'react-aria-components';
 
 import styles from './styles/ProgressBar.module.css';
 
@@ -24,7 +24,7 @@ const progressBar = cva(styles.base, {
 type ProgressBarProps = AriaProgressBarProps & VariantProps<typeof progressBar>;
 
 const _ProgressBar = (
-  { size = 'small', className, ...props }: ProgressBarProps,
+  { size = 'small', ...props }: ProgressBarProps,
   ref: ForwardedRef<HTMLDivElement>
 ) => {
   const center = 16;
@@ -33,7 +33,13 @@ const _ProgressBar = (
   const c = 2 * r * Math.PI;
 
   return (
-    <AriaProgressBar {...props} ref={ref} className={progressBar({ size, className })}>
+    <AriaProgressBar
+      {...props}
+      ref={ref}
+      className={composeRenderProps(props.className, (className, renderProps) =>
+        progressBar({ ...renderProps, size, className })
+      )}
+    >
       {({ percentage }) => (
         <svg
           width={64}

--- a/packages/components/src/Tooltip.tsx
+++ b/packages/components/src/Tooltip.tsx
@@ -4,11 +4,12 @@ import type {
   TooltipTriggerComponentProps,
 } from 'react-aria-components';
 
-import { cx } from 'class-variance-authority';
+import { cva } from 'class-variance-authority';
 import { forwardRef } from 'react';
 import {
   Tooltip as AriaTooltip,
   TooltipTrigger as AriaTooltipTrigger,
+  composeRenderProps,
 } from 'react-aria-components';
 
 import styles from './styles/Tooltip.module.css';
@@ -16,14 +17,18 @@ import styles from './styles/Tooltip.module.css';
 type TooltipProps = Omit<AriaTooltipProps, 'offset' | 'crossOffset'>;
 type TooltipTriggerProps = Omit<TooltipTriggerComponentProps, 'delay' | 'closeDelay'>;
 
-const _Tooltip = ({ className, ...props }: TooltipProps, ref: ForwardedRef<HTMLDivElement>) => {
+const tooltip = cva(styles.tooltip);
+
+const _Tooltip = (props: TooltipProps, ref: ForwardedRef<HTMLDivElement>) => {
   return (
     <AriaTooltip
       {...props}
       offset={0}
       crossOffset={0}
       ref={ref}
-      className={cx(styles.tooltip, className)}
+      className={composeRenderProps(props.className, (className, renderProps) =>
+        tooltip({ ...renderProps, className })
+      )}
     />
   );
 };

--- a/packages/components/src/styles/Button.module.css
+++ b/packages/components/src/styles/Button.module.css
@@ -14,12 +14,16 @@
 }
 
 .base:focus-visible {
+  outline: none;
+}
+
+.base[data-focus-visible] {
   outline: 2px solid var(--lp-color-shadow-interactive-focus);
   outline-offset: 2px;
   z-index: 1;
 }
 
-.base[disabled][data-disabled] {
+.base[data-disabled] {
   background: transparent none repeat 0 0 / auto auto padding-box border-box scroll;
   background: initial;
   background-color: var(--lp-color-bg-interactive-disabled);
@@ -49,15 +53,15 @@
   color: var(--lp-color-text-ui-primary-base);
 }
 
-.default:hover {
+.default[data-hovered] {
   background-color: var(--lp-color-bg-interactive-secondary-hover);
 }
 
-.default:active {
+.default[data-pressed] {
   background-color: var(--lp-color-bg-interactive-secondary-active);
 }
 
-.default:focus-visible {
+.default[data-focus-visible] {
   background-color: var(--lp-color-bg-interactive-secondary-focus);
 }
 
@@ -67,19 +71,19 @@
   color: var(--lp-color-text-interactive-primary-base);
 }
 
-.primary:hover {
+.primary[data-hovered] {
   background-color: var(--lp-color-bg-interactive-primary-hover);
   border-color: var(--lp-color-border-interactive-primary-hover);
   color: var(--lp-color-text-interactive-primary-hover);
 }
 
-.primary:active {
+.primary[data-pressed] {
   background-color: var(--lp-color-bg-interactive-primary-active);
   border-color: var(--lp-color-border-interactive-primary-active);
   color: var(--lp-color-text-interactive-primary-base);
 }
 
-.primary:focus-visible {
+.primary[data-focus-visible] {
   background-color: var(--lp-color-bg-interactive-primary-focus);
   border-color: var(--lp-color-border-interactive-primary-focus);
 }
@@ -90,15 +94,15 @@
   color: var(--lp-color-text-interactive-destructive);
 }
 
-.destructive:hover {
+.destructive[data-hovered] {
   background-color: var(--lp-color-bg-interactive-destructive-hover);
 }
 
-.destructive:active {
+.destructive[data-pressed] {
   background-color: var(--lp-color-bg-interactive-destructive-active);
 }
 
-.destructive:focus-visible {
+.destructive[data-focus-visible] {
   background-color: var(--lp-color-bg-interactive-destructive-focus);
 }
 
@@ -108,19 +112,19 @@
   color: var(--lp-color-text-ui-primary-base);
 }
 
-.minimal:hover {
+.minimal[data-hovered] {
   background-color: var(--lp-color-bg-interactive-tertiary-hover);
 }
 
-.minimal:active {
+.minimal[data-pressed] {
   background-color: var(--lp-color-bg-interactive-tertiary-active);
 }
 
-.minimal:focus-visible {
+.minimal[data-focus-visible] {
   background-color: var(--lp-color-bg-interactive-tertiary-focus);
 }
 
-.minimal[disabled][data-disabled] {
+.minimal[data-disabled] {
   background-color: var(--lp-color-bg-interactive-tertiary-base);
 }
 
@@ -130,17 +134,17 @@
   color: var(--lp-color-text-interactive-primary-base);
 }
 
-.primaryFlair:hover {
+.primaryFlair[data-hovered] {
   background: linear-gradient(124deg, #9655c3 0%, #4b5fdd 98.05%);
   border-color: var(--lp-color-border-interactive-primary-flair-hover);
 }
 
-.primaryFlair:active {
+.primaryFlair[data-pressed] {
   background: linear-gradient(124deg, #8741b9 0%, #3b50ce 98.05%);
   border-color: var(--lp-color-border-interactive-primary-flair-active);
 }
 
-.primaryFlair:focus-visible {
+.primaryFlair[data-focus-visible] {
   background: linear-gradient(124deg, #8741b9 0%, #3b50ce 98.05%);
   border-color: var(--lp-color-border-interactive-primary-flair-focus);
 }
@@ -151,19 +155,19 @@
   color: var(--lp-color-text-interactive-flair-base);
 }
 
-.defaultFlair:hover {
+.defaultFlair[data-hovered] {
   background-color: var(--lp-color-bg-interactive-secondary-flair-hover);
   border-color: var(--lp-color-border-interactive-secondary-flair-hover);
   color: var(--lp-color-text-interactive-flair-hover);
 }
 
-.defaultFlair:active {
+.defaultFlair[data-pressed] {
   background-color: var(--lp-color-bg-interactive-secondary-flair-active);
   border-color: var(--lp-color-border-interactive-secondary-flair-active);
   color: var(--lp-color-text-interactive-flair-active);
 }
 
-.defaultFlair:focus-visible {
+.defaultFlair[data-focus-visible] {
   background-color: var(--lp-color-bg-interactive-secondary-flair-focus);
   border-color: var(--lp-color-border-interactive-secondary-flair-focus);
   color: var(--lp-color-text-interactive-flair-focus);
@@ -175,17 +179,17 @@
   color: var(--lp-color-text-interactive-flair-base);
 }
 
-.minimalFlair:hover {
+.minimalFlair[data-hovered] {
   background-color: var(--lp-color-bg-interactive-tertiary-flair-hover);
   color: var(--lp-color-text-interactive-flair-hover);
 }
 
-.minimalFlair:active {
+.minimalFlair[data-pressed] {
   background-color: var(--lp-color-bg-interactive-tertiary-flair-active);
   color: var(--lp-color-text-interactive-flair-active);
 }
 
-.minimalFlair:focus-visible {
+.minimalFlair[data-focus-visible] {
   background-color: var(--lp-color-bg-interactive-tertiary-flair-focus);
   color: var(--lp-color-text-interactive-flair-focus);
 }

--- a/packages/components/stories/Button.stories.tsx
+++ b/packages/components/stories/Button.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryFn, StoryObj } from '@storybook/react';
 
 import { Icon } from '@launchpad-ui/icons';
 import { vars } from '@launchpad-ui/vars';
+import { userEvent, within } from '@storybook/test';
 
 import { Button } from '../src';
 
@@ -11,6 +12,9 @@ const meta: Meta<typeof Button> = {
   parameters: {
     status: {
       type: import.meta.env.STORYBOOK_PACKAGE_STATUS__COMPONENTS,
+    },
+    actions: {
+      disable: true,
     },
   },
   decorators: [
@@ -44,15 +48,15 @@ const renderStates = (args: Story['args']) => (
     </>
     <>
       <span style={{ font: vars.body[1].semibold }}>Hover</span>
-      <Button {...args} className="pseudo-hover" />
+      <Button {...args} />
     </>
     <>
       <span style={{ font: vars.body[1].semibold }}>Focus</span>
-      <Button {...args} className="pseudo-focus-visible" />
+      <Button {...args} />
     </>
     <>
       <span style={{ font: vars.body[1].semibold }}>Active</span>
-      <Button {...args} className="pseudo-active" />
+      <Button {...args} />
     </>
     <>
       <span style={{ font: vars.body[1].semibold }}>Disabled</span>
@@ -61,32 +65,53 @@ const renderStates = (args: Story['args']) => (
   </div>
 );
 
+const states = {
+  play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+    const canvas = within(canvasElement);
+
+    const buttons = canvas.getAllByRole('button');
+    await userEvent.hover(buttons[1]);
+    await userEvent.pointer([{ keys: '[TouchA>]', target: buttons[3] }]);
+    await userEvent.tab();
+    await userEvent.tab();
+    await userEvent.tab();
+    await userEvent.tab();
+  },
+};
+
 export const Default: Story = {
   render: (args) => renderStates({ children: 'Default', ...args }),
+  ...states,
 };
 
 export const Primary: Story = {
   render: (args) => renderStates({ children: 'Primary', variant: 'primary', ...args }),
+  ...states,
 };
 
 export const Minimal: Story = {
   render: (args) => renderStates({ children: 'Minimal', variant: 'minimal', ...args }),
+  ...states,
 };
 
 export const Destructive: Story = {
   render: (args) => renderStates({ children: 'Destructive', variant: 'destructive', ...args }),
+  ...states,
 };
 
 export const PrimaryFlair: Story = {
   render: (args) => renderStates({ children: 'Primary flair', variant: 'primaryFlair', ...args }),
+  ...states,
 };
 
 export const DefaultFlair: Story = {
   render: (args) => renderStates({ children: 'Default flair', variant: 'defaultFlair', ...args }),
+  ...states,
 };
 
 export const MinimalFlair: Story = {
   render: (args) => renderStates({ children: 'Minimal flair', variant: 'minimalFlair', ...args }),
+  ...states,
 };
 
 export const WithIcon: Story = {
@@ -101,8 +126,10 @@ export const WithIcon: Story = {
 
 export const Small: Story = {
   render: (args) => renderStates({ children: 'Default', size: 'small', ...args }),
+  ...states,
 };
 
 export const Large: Story = {
   render: (args) => renderStates({ children: 'Default', size: 'large', ...args }),
+  ...states,
 };

--- a/packages/components/stories/Button.stories.tsx
+++ b/packages/components/stories/Button.stories.tsx
@@ -13,9 +13,6 @@ const meta: Meta<typeof Button> = {
     status: {
       type: import.meta.env.STORYBOOK_PACKAGE_STATUS__COMPONENTS,
     },
-    actions: {
-      disable: true,
-    },
   },
   decorators: [
     (Story: StoryFn) => (


### PR DESCRIPTION
## Summary

To [style states consistently](https://react-spectrum.adobe.com/react-aria/styling.html#states) across mouse, touch, and keyboard use the RAC data attributes instead of pseudo selectors. Use [composeRenderProps](https://github.com/adobe/react-spectrum/blob/main/starters/tailwind/src/Button.tsx) from RAC to support classNames with functions which receive states for styling. For button stories with multiple states, replace use of `storybook-addon-pseudo-states` with [Storybook interactions](https://storybook.js.org/docs/essentials/interactions) to trigger states.