### PR TITLE
feat(components): use light-dark function

### DIFF
--- a/.changeset/smart-terms-refuse.md
+++ b/.changeset/smart-terms-refuse.md
@@ -1,0 +1,5 @@
+---
+"@launchpad-ui/components": patch
+---
+
+Use light-dark() color function for theme styles

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -7,6 +7,7 @@ import { themes } from '@storybook/theming';
 
 import { allModes } from './modes';
 
+import '../packages/components/src/styles/themes.css';
 import '../packages/tokens/dist/index.css';
 import '../packages/tokens/dist/media-queries.css';
 import '../packages/tokens/dist/themes.css';

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -1,3 +1,5 @@
+import './styles/themes.css';
+
 export type { ButtonProps } from './Button';
 export type { ButtonGroupProps } from './ButtonGroup';
 export type { CheckboxProps } from './Checkbox';

--- a/packages/components/src/styles/Modal.module.css
+++ b/packages/components/src/styles/Modal.module.css
@@ -1,14 +1,5 @@
 @import '../../../tokens/dist/media-queries.css';
 
-:root,
-[data-theme='default'] {
-  --lp-overlay-bg: #28282880;
-}
-
-[data-theme='dark'] {
-  --lp-overlay-bg: #282828b2;
-}
-
 @keyframes fade {
   from {
     opacity: 0;
@@ -134,7 +125,7 @@
   width: 100vw;
   /* stylelint-disable-next-line csstools/value-no-unknown-custom-properties */
   height: var(--visual-viewport-height);
-  background: var(--lp-overlay-bg);
+  background: light-dark(#28282880, #282828b2);
   display: flex;
   align-items: center;
   justify-content: center;

--- a/packages/components/src/styles/Popover.module.css
+++ b/packages/components/src/styles/Popover.module.css
@@ -1,9 +1,3 @@
-:root,
-[data-theme='default'] {
-  --lp-popover-shadow: 0px 4px 4px 0px rgb(40 40 40 / 0.08), 0px 1px 2px 0px rgb(40 40 40 / 0.1),
-    0px 0px 4px 0px rgb(40 40 40 / 0.12);
-}
-
 @keyframes slide {
   from {
     transform: var(--origin);
@@ -24,7 +18,8 @@
   border-radius: var(--lp-border-radius-regular);
   border: 1px solid var(--lp-color-border-ui-primary);
   background-color: var(--lp-color-bg-overlay-primary);
-  box-shadow: var(--lp-popover-shadow);
+  box-shadow: 0 4px 4px 0 rgb(40 40 40 / 0.08), 0 1px 2px 0 rgb(40 40 40 / 0.1),
+  0 0 4px 0 rgb(40 40 40 / 0.12);
   transform: translate3d(0, 0, 0);
   will-change: transform, opacity;
 

--- a/packages/components/src/styles/Tooltip.module.css
+++ b/packages/components/src/styles/Tooltip.module.css
@@ -1,12 +1,3 @@
-:root,
-[data-theme='default'] {
-  --lp-tooltip-color-text: var(--lp-color-text-overlay-secondary);
-}
-
-[data-theme='dark'] {
-  --lp-tooltip-color-text: var(--lp-color-text-ui-primary-base);
-}
-
 @keyframes slide {
   from {
     transform: var(--origin);
@@ -32,8 +23,9 @@
   border-radius: var(--lp-border-radius-regular);
   border: 1px solid var(--lp-color-border-overlay-secondary);
   background-color: var(--lp-color-bg-overlay-secondary);
-  box-shadow: var(--lp-popover-shadow);
-  color: var(--lp-tooltip-color-text);
+  box-shadow: 0 4px 4px 0 rgb(40 40 40 / 0.08), 0 1px 2px 0 rgb(40 40 40 / 0.1),
+  0 0 4px 0 rgb(40 40 40 / 0.12);
+  color: light-dark(var(--lp-color-text-overlay-secondary), var(--lp-color-text-ui-primary-base));
   transform: translate3d(0, 0, 0);
   will-change: transform, opacity;
 

--- a/packages/components/src/styles/themes.css
+++ b/packages/components/src/styles/themes.css
@@ -1,0 +1,11 @@
+:root {
+  color-scheme: light dark;
+}
+
+:root, [data-theme='default'] {
+  color-scheme: light;
+}
+
+[data-theme='dark'] {
+  color-scheme: dark;
+}


### PR DESCRIPTION
## Summary

Use [light-dark() color function](https://lightningcss.dev/transpilation.html#light-dark()-color-function) to minimize redundancy and avoid custom property bloat.