### PR TITLE
fix(components): override `forwardRef` to support generics

### DIFF
--- a/.changeset/funny-hotels-serve.md
+++ b/.changeset/funny-hotels-serve.md
@@ -1,0 +1,5 @@
+---
+"@launchpad-ui/components": patch
+---
+
+Override `forwardRef` to support generics

--- a/packages/components/src/Button.tsx
+++ b/packages/components/src/Button.tsx
@@ -3,7 +3,7 @@ import type { ForwardedRef } from 'react';
 import type { ButtonProps as AriaButtonProps } from 'react-aria-components';
 
 import { cva, cx } from 'class-variance-authority';
-import { forwardRef, useContext } from 'react';
+import { useContext } from 'react';
 import {
 	Button as AriaButton,
 	SelectStateContext,
@@ -11,6 +11,7 @@ import {
 } from 'react-aria-components';
 
 import styles from './styles/Button.module.css';
+import { forwardRef } from './utils';
 
 const button = cva(styles.base, {
 	variants: {

--- a/packages/components/src/ButtonGroup.tsx
+++ b/packages/components/src/ButtonGroup.tsx
@@ -2,10 +2,10 @@ import type { VariantProps } from 'class-variance-authority';
 import type { ComponentPropsWithRef, ForwardedRef } from 'react';
 
 import { cva } from 'class-variance-authority';
-import { forwardRef } from 'react';
 import { ButtonContext } from 'react-aria-components';
 
 import styles from './styles/ButtonGroup.module.css';
+import { forwardRef } from './utils';
 
 const buttonGroup = cva(styles.base, {
 	variants: {

--- a/packages/components/src/Checkbox.tsx
+++ b/packages/components/src/Checkbox.tsx
@@ -3,10 +3,10 @@ import type { CheckboxProps } from 'react-aria-components';
 
 import { Icon } from '@launchpad-ui/icons';
 import { cva } from 'class-variance-authority';
-import { forwardRef } from 'react';
 import { Checkbox as AriaCheckbox, composeRenderProps } from 'react-aria-components';
 
 import styles from './styles/Checkbox.module.css';
+import { forwardRef } from './utils';
 
 const checkbox = cva(styles.checkbox);
 const box = cva(styles.box);

--- a/packages/components/src/CheckboxGroup.tsx
+++ b/packages/components/src/CheckboxGroup.tsx
@@ -2,10 +2,10 @@ import type { ForwardedRef } from 'react';
 import type { CheckboxGroupProps } from 'react-aria-components';
 
 import { cva } from 'class-variance-authority';
-import { forwardRef } from 'react';
 import { CheckboxGroup as AriaCheckboxGroup, composeRenderProps } from 'react-aria-components';
 
 import styles from './styles/CheckboxGroup.module.css';
+import { forwardRef } from './utils';
 
 const group = cva(styles.group);
 

--- a/packages/components/src/ComboBox.tsx
+++ b/packages/components/src/ComboBox.tsx
@@ -2,10 +2,10 @@ import type { ForwardedRef } from 'react';
 import type { ComboBoxProps } from 'react-aria-components';
 
 import { cva } from 'class-variance-authority';
-import { forwardRef } from 'react';
 import { ComboBox as AriaComboBox, composeRenderProps } from 'react-aria-components';
 
 import styles from './styles/ComboBox.module.css';
+import { forwardRef } from './utils';
 
 const box = cva(styles.box);
 

--- a/packages/components/src/Dialog.tsx
+++ b/packages/components/src/Dialog.tsx
@@ -2,10 +2,10 @@ import type { ForwardedRef } from 'react';
 import type { DialogProps, DialogTriggerProps } from 'react-aria-components';
 
 import { cva } from 'class-variance-authority';
-import { forwardRef } from 'react';
 import { Dialog as AriaDialog, DialogTrigger } from 'react-aria-components';
 
 import styles from './styles/Dialog.module.css';
+import { forwardRef } from './utils';
 
 const dialog = cva(styles.dialog);
 

--- a/packages/components/src/FieldError.tsx
+++ b/packages/components/src/FieldError.tsx
@@ -2,10 +2,10 @@ import type { ForwardedRef } from 'react';
 import type { FieldErrorProps } from 'react-aria-components';
 
 import { cva } from 'class-variance-authority';
-import { forwardRef } from 'react';
 import { FieldError as AriaFieldError, composeRenderProps } from 'react-aria-components';
 
 import styles from './styles/FieldError.module.css';
+import { forwardRef } from './utils';
 
 const error = cva(styles.error);
 

--- a/packages/components/src/Group.tsx
+++ b/packages/components/src/Group.tsx
@@ -2,10 +2,10 @@ import type { ForwardedRef } from 'react';
 import type { GroupProps } from 'react-aria-components';
 
 import { cva } from 'class-variance-authority';
-import { forwardRef } from 'react';
 import { Group as AriaGroup, composeRenderProps } from 'react-aria-components';
 
 import styles from './styles/Group.module.css';
+import { forwardRef } from './utils';
 
 const group = cva(styles.group);
 

--- a/packages/components/src/IconButton.tsx
+++ b/packages/components/src/IconButton.tsx
@@ -7,11 +7,11 @@ import type { ButtonVariants } from './Button';
 
 import { Icon } from '@launchpad-ui/icons';
 import { cva, cx } from 'class-variance-authority';
-import { forwardRef } from 'react';
 import { Button as AriaButton, composeRenderProps } from 'react-aria-components';
 
 import { button } from './Button';
 import styles from './styles/IconButton.module.css';
+import { forwardRef } from './utils';
 
 const iconButton = cva(styles.base, {
 	variants: {

--- a/packages/components/src/Input.tsx
+++ b/packages/components/src/Input.tsx
@@ -2,10 +2,10 @@ import type { ForwardedRef } from 'react';
 import type { InputProps } from 'react-aria-components';
 
 import { cva } from 'class-variance-authority';
-import { forwardRef } from 'react';
 import { Input as AriaInput, composeRenderProps } from 'react-aria-components';
 
 import styles from './styles/Input.module.css';
+import { forwardRef } from './utils';
 
 const input = cva(styles.input);
 

--- a/packages/components/src/Label.tsx
+++ b/packages/components/src/Label.tsx
@@ -2,10 +2,10 @@ import type { ForwardedRef } from 'react';
 import type { LabelProps } from 'react-aria-components';
 
 import { cva } from 'class-variance-authority';
-import { forwardRef } from 'react';
 import { Label as AriaLabel } from 'react-aria-components';
 
 import styles from './styles/Label.module.css';
+import { forwardRef } from './utils';
 
 const label = cva(styles.label);
 

--- a/packages/components/src/Link.tsx
+++ b/packages/components/src/Link.tsx
@@ -4,11 +4,11 @@ import type { LinkProps as AriaLinkProps } from 'react-aria-components';
 import type { LinkProps as _RouterLinkProps } from 'react-router-dom';
 
 import { cva } from 'class-variance-authority';
-import { forwardRef } from 'react';
 import { Link as AriaLink, composeRenderProps } from 'react-aria-components';
 import { useHref, useLinkClickHandler } from 'react-router-dom';
 
 import styles from './styles/Link.module.css';
+import { forwardRef } from './utils';
 
 const link = cva(styles.base, {
 	variants: {

--- a/packages/components/src/LinkButton.tsx
+++ b/packages/components/src/LinkButton.tsx
@@ -2,11 +2,11 @@ import type { ForwardedRef } from 'react';
 import type { ButtonVariants } from './Button';
 import type { LinkProps } from './Link';
 
-import { forwardRef } from 'react';
 import { composeRenderProps } from 'react-aria-components';
 
 import { button } from './Button';
 import { Link } from './Link';
+import { forwardRef } from './utils';
 
 type LinkButtonProps = LinkProps & ButtonVariants;
 

--- a/packages/components/src/ListBox.tsx
+++ b/packages/components/src/ListBox.tsx
@@ -3,7 +3,6 @@ import type { ListBoxItemProps, ListBoxProps } from 'react-aria-components';
 
 import { Icon } from '@launchpad-ui/icons';
 import { cva } from 'class-variance-authority';
-import { forwardRef } from 'react';
 import {
 	ListBox as AriaListBox,
 	ListBoxItem as AriaListBoxItem,
@@ -11,6 +10,7 @@ import {
 } from 'react-aria-components';
 
 import styles from './styles/ListBox.module.css';
+import { forwardRef } from './utils';
 
 const box = cva(styles.box);
 const item = cva(styles.item);

--- a/packages/components/src/Menu.tsx
+++ b/packages/components/src/Menu.tsx
@@ -9,7 +9,6 @@ import type {
 
 import { Icon } from '@launchpad-ui/icons';
 import { cva } from 'class-variance-authority';
-import { forwardRef } from 'react';
 import {
 	Menu as AriaMenu,
 	MenuItem as AriaMenuItem,
@@ -19,6 +18,7 @@ import {
 } from 'react-aria-components';
 
 import styles from './styles/Menu.module.css';
+import { forwardRef } from './utils';
 
 const menu = cva(styles.menu);
 const item = cva(styles.item, {

--- a/packages/components/src/Modal.tsx
+++ b/packages/components/src/Modal.tsx
@@ -3,7 +3,6 @@ import type { ForwardedRef } from 'react';
 import type { ModalOverlayProps } from 'react-aria-components';
 
 import { cva } from 'class-variance-authority';
-import { forwardRef } from 'react';
 import {
 	Modal as AriaModal,
 	ModalOverlay as AriaModalOverlay,
@@ -11,6 +10,7 @@ import {
 } from 'react-aria-components';
 
 import styles from './styles/Modal.module.css';
+import { forwardRef } from './utils';
 
 const modal = cva(styles.base, {
 	variants: {

--- a/packages/components/src/Popover.tsx
+++ b/packages/components/src/Popover.tsx
@@ -5,7 +5,6 @@ import type {
 } from 'react-aria-components';
 
 import { cva } from 'class-variance-authority';
-import { forwardRef } from 'react';
 import {
 	OverlayArrow as AriaOverlayArrow,
 	Popover as AriaPopover,
@@ -13,6 +12,7 @@ import {
 } from 'react-aria-components';
 
 import styles from './styles/Popover.module.css';
+import { forwardRef } from './utils';
 
 type PopoverProps = Omit<AriaPopoverProps, 'offset' | 'crossOffset'>;
 type OverlayArrowProps = Omit<AriaOverlayArrowProps, 'children'>;

--- a/packages/components/src/ProgressBar.tsx
+++ b/packages/components/src/ProgressBar.tsx
@@ -3,10 +3,10 @@ import type { ForwardedRef } from 'react';
 import type { ProgressBarProps as AriaProgressBarProps } from 'react-aria-components';
 
 import { cva, cx } from 'class-variance-authority';
-import { forwardRef } from 'react';
 import { ProgressBar as AriaProgressBar, composeRenderProps } from 'react-aria-components';
 
 import styles from './styles/ProgressBar.module.css';
+import { forwardRef } from './utils';
 
 const progressBar = cva(styles.progress);
 

--- a/packages/components/src/Radio.tsx
+++ b/packages/components/src/Radio.tsx
@@ -3,10 +3,10 @@ import type { RadioProps } from 'react-aria-components';
 
 import { Icon } from '@launchpad-ui/icons';
 import { cva } from 'class-variance-authority';
-import { forwardRef } from 'react';
 import { Radio as AriaRadio, composeRenderProps } from 'react-aria-components';
 
 import styles from './styles/Radio.module.css';
+import { forwardRef } from './utils';
 
 const radio = cva(styles.radio);
 const circle = cva(styles.circle);

--- a/packages/components/src/RadioGroup.tsx
+++ b/packages/components/src/RadioGroup.tsx
@@ -2,10 +2,10 @@ import type { ForwardedRef } from 'react';
 import type { RadioGroupProps } from 'react-aria-components';
 
 import { cva } from 'class-variance-authority';
-import { forwardRef } from 'react';
 import { RadioGroup as AriaRadioGroup, composeRenderProps } from 'react-aria-components';
 
 import styles from './styles/RadioGroup.module.css';
+import { forwardRef } from './utils';
 
 const group = cva(styles.group);
 

--- a/packages/components/src/SearchField.tsx
+++ b/packages/components/src/SearchField.tsx
@@ -2,10 +2,10 @@ import type { ForwardedRef } from 'react';
 import type { SearchFieldProps } from 'react-aria-components';
 
 import { cva } from 'class-variance-authority';
-import { forwardRef } from 'react';
 import { SearchField as AriaSearchField, composeRenderProps } from 'react-aria-components';
 
 import styles from './styles/SearchField.module.css';
+import { forwardRef } from './utils';
 
 const search = cva(styles.search);
 

--- a/packages/components/src/Select.tsx
+++ b/packages/components/src/Select.tsx
@@ -2,7 +2,6 @@ import type { ForwardedRef } from 'react';
 import type { SelectProps, SelectValueProps } from 'react-aria-components';
 
 import { cva } from 'class-variance-authority';
-import { forwardRef } from 'react';
 import {
 	Select as AriaSelect,
 	SelectValue as AriaSelectValue,
@@ -10,6 +9,7 @@ import {
 } from 'react-aria-components';
 
 import styles from './styles/Select.module.css';
+import { forwardRef } from './utils';
 
 const select = cva(styles.select);
 const value = cva(styles.value);

--- a/packages/components/src/Switch.tsx
+++ b/packages/components/src/Switch.tsx
@@ -2,10 +2,10 @@ import type { ForwardedRef, ReactNode } from 'react';
 import type { SwitchProps as AriaSwitchProps } from 'react-aria-components';
 
 import { cva } from 'class-variance-authority';
-import { forwardRef } from 'react';
 import { Switch as AriaSwitch, composeRenderProps } from 'react-aria-components';
 
 import styles from './styles/Switch.module.css';
+import { forwardRef } from './utils';
 
 const _switch = cva(styles.switch);
 

--- a/packages/components/src/TagGroup.tsx
+++ b/packages/components/src/TagGroup.tsx
@@ -3,7 +3,6 @@ import type { ForwardedRef } from 'react';
 import type { TagGroupProps, TagListProps, TagProps as AriaTagProps } from 'react-aria-components';
 
 import { cva } from 'class-variance-authority';
-import { forwardRef } from 'react';
 import {
 	Tag as AriaTag,
 	TagGroup as AriaTagGroup,
@@ -13,6 +12,7 @@ import {
 
 import { IconButton } from './IconButton';
 import styles from './styles/TagGroup.module.css';
+import { forwardRef } from './utils';
 
 const group = cva(styles.group);
 const list = cva(styles.list);

--- a/packages/components/src/Text.tsx
+++ b/packages/components/src/Text.tsx
@@ -2,10 +2,10 @@ import type { ForwardedRef } from 'react';
 import type { TextProps } from 'react-aria-components';
 
 import { cva } from 'class-variance-authority';
-import { forwardRef } from 'react';
 import { Text as AriaText } from 'react-aria-components';
 
 import styles from './styles/Text.module.css';
+import { forwardRef } from './utils';
 
 const text = cva(styles.text);
 

--- a/packages/components/src/TextArea.tsx
+++ b/packages/components/src/TextArea.tsx
@@ -2,10 +2,10 @@ import type { ForwardedRef } from 'react';
 import type { TextAreaProps } from 'react-aria-components';
 
 import { cva } from 'class-variance-authority';
-import { forwardRef } from 'react';
 import { TextArea as AriaTextArea, composeRenderProps } from 'react-aria-components';
 
 import styles from './styles/Input.module.css';
+import { forwardRef } from './utils';
 
 const input = cva(styles.input);
 

--- a/packages/components/src/TextField.tsx
+++ b/packages/components/src/TextField.tsx
@@ -2,10 +2,10 @@ import type { ForwardedRef } from 'react';
 import type { TextFieldProps } from 'react-aria-components';
 
 import { cva } from 'class-variance-authority';
-import { forwardRef } from 'react';
 import { TextField as AriaTextField, composeRenderProps } from 'react-aria-components';
 
 import styles from './styles/TextField.module.css';
+import { forwardRef } from './utils';
 
 const field = cva(styles.field);
 

--- a/packages/components/src/Tooltip.tsx
+++ b/packages/components/src/Tooltip.tsx
@@ -5,7 +5,6 @@ import type {
 } from 'react-aria-components';
 
 import { cva } from 'class-variance-authority';
-import { forwardRef } from 'react';
 import {
 	Tooltip as AriaTooltip,
 	TooltipTrigger as AriaTooltipTrigger,
@@ -13,6 +12,7 @@ import {
 } from 'react-aria-components';
 
 import styles from './styles/Tooltip.module.css';
+import { forwardRef } from './utils';
 
 type TooltipProps = Omit<AriaTooltipProps, 'offset' | 'crossOffset'>;
 type TooltipTriggerProps = Omit<TooltipTriggerComponentProps, 'delay' | 'closeDelay'>;

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -69,3 +69,4 @@ export { Text } from './Text';
 export { TextArea } from './TextArea';
 export { TextField } from './TextField';
 export { Tooltip, TooltipTrigger } from './Tooltip';
+export { forwardRef } from './utils';

--- a/packages/components/src/utils.tsx
+++ b/packages/components/src/utils.tsx
@@ -1,0 +1,16 @@
+import type { ReactNode, Ref, RefAttributes } from 'react';
+
+import { forwardRef as reactForwardRef } from 'react';
+
+/**
+ * forwardRef with generics support.
+ *
+ * https://www.totaltypescript.com/forwardref-with-generic-components#the-solution
+ */
+// biome-ignore lint/complexity/noBannedTypes: <explanation>
+const forwardRef = <T, P = {}>(
+	render: (props: P, ref: Ref<T>) => ReactNode,
+	// biome-ignore lint/suspicious/noExplicitAny: <explanation>
+): ((props: P & RefAttributes<T>) => ReactNode) => reactForwardRef(render) as any;
+
+export { forwardRef };

--- a/packages/components/stories/TagGroup.stories.tsx
+++ b/packages/components/stories/TagGroup.stories.tsx
@@ -61,9 +61,7 @@ export const Removable: Story = {
 		return (
 			<TagGroup onRemove={(keys) => list.remove(...keys)} {...args}>
 				<Label>Label</Label>
-				<TagList items={list.items}>
-					{(item: { id?: number; name?: string }) => <Tag>{item.name}</Tag>}
-				</TagList>
+				<TagList items={list.items}>{(item) => <Tag>{item.name}</Tag>}</TagList>
 			</TagGroup>
 		);
 	},


### PR DESCRIPTION
## Summary

RAC does something similar [via a type](https://github.com/adobe/react-spectrum/blob/main/packages/react-aria-components/src/utils.tsx#L19-L24) but I prefer [this approach](https://www.totaltypescript.com/forwardref-with-generic-components#the-solution).