### PR TITLE
fix(components): unset border radius for `Input` in `Group`

### DIFF
--- a/.changeset/gentle-trainers-crash.md
+++ b/.changeset/gentle-trainers-crash.md
@@ -1,0 +1,5 @@
+---
+"@launchpad-ui/components": patch
+---
+
+Unset border radius for `Input` in `Group`

--- a/packages/components/src/styles/Group.module.css
+++ b/packages/components/src/styles/Group.module.css
@@ -16,5 +16,6 @@
     padding: 0;
     outline: none;
     border: none;
+    border-radius: unset;
   }
 }


### PR DESCRIPTION
## Summary

To avoid border radius on highlighted text.
