### PR TITLE
fix(components): prevent checkbox from shrinking

### DIFF
--- a/.changeset/rich-cats-pay.md
+++ b/.changeset/rich-cats-pay.md
@@ -1,0 +1,5 @@
+---
+"@launchpad-ui/components": patch
+---
+
+Prevent `Checkbox` from shrinking

--- a/packages/components/src/styles/Checkbox.module.css
+++ b/packages/components/src/styles/Checkbox.module.css
@@ -2,6 +2,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  flex-shrink: 0;
   width: var(--lp-size-16);
   height: var(--lp-size-16);
   border-radius: 2px;


### PR DESCRIPTION
## Summary

Prevent `Checkbox` from shrinking in flex containers.