### PR TITLE
fix(components): cast generics for forwardRef

### DIFF
--- a/.changeset/six-points-eat.md
+++ b/.changeset/six-points-eat.md
@@ -1,0 +1,5 @@
+---
+"@launchpad-ui/components": patch
+---
+
+Cast generics for forwardRef

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
 	"homepage": "https://github.com/launchdarkly/launchpad-ui#readme",
 	"devDependencies": {
 		"@axe-core/playwright": "^4.8.5",
-		"@biomejs/biome": "^1.5.3",
+		"@biomejs/biome": "1.5.3",
 		"@changesets/changelog-github": "^0.5.0",
 		"@changesets/cli": "^2.27.1",
 		"@commitlint/cli": "^19.0.3",

--- a/packages/components/src/Button.tsx
+++ b/packages/components/src/Button.tsx
@@ -3,7 +3,7 @@ import type { ForwardedRef } from 'react';
 import type { ButtonProps as AriaButtonProps } from 'react-aria-components';
 
 import { cva, cx } from 'class-variance-authority';
-import { useContext } from 'react';
+import { forwardRef, useContext } from 'react';
 import {
 	Button as AriaButton,
 	SelectStateContext,
@@ -11,7 +11,6 @@ import {
 } from 'react-aria-components';
 
 import styles from './styles/Button.module.css';
-import { forwardRef } from './utils';
 
 const button = cva(styles.base, {
 	variants: {

--- a/packages/components/src/ButtonGroup.tsx
+++ b/packages/components/src/ButtonGroup.tsx
@@ -2,10 +2,10 @@ import type { VariantProps } from 'class-variance-authority';
 import type { ComponentPropsWithRef, ForwardedRef } from 'react';
 
 import { cva } from 'class-variance-authority';
+import { forwardRef } from 'react';
 import { ButtonContext } from 'react-aria-components';
 
 import styles from './styles/ButtonGroup.module.css';
-import { forwardRef } from './utils';
 
 const buttonGroup = cva(styles.base, {
 	variants: {

--- a/packages/components/src/Checkbox.tsx
+++ b/packages/components/src/Checkbox.tsx
@@ -3,10 +3,10 @@ import type { CheckboxProps } from 'react-aria-components';
 
 import { Icon } from '@launchpad-ui/icons';
 import { cva } from 'class-variance-authority';
+import { forwardRef } from 'react';
 import { Checkbox as AriaCheckbox, composeRenderProps } from 'react-aria-components';
 
 import styles from './styles/Checkbox.module.css';
-import { forwardRef } from './utils';
 
 const checkbox = cva(styles.checkbox);
 const box = cva(styles.box);

--- a/packages/components/src/CheckboxGroup.tsx
+++ b/packages/components/src/CheckboxGroup.tsx
@@ -2,10 +2,10 @@ import type { ForwardedRef } from 'react';
 import type { CheckboxGroupProps } from 'react-aria-components';
 
 import { cva } from 'class-variance-authority';
+import { forwardRef } from 'react';
 import { CheckboxGroup as AriaCheckboxGroup, composeRenderProps } from 'react-aria-components';
 
 import styles from './styles/CheckboxGroup.module.css';
-import { forwardRef } from './utils';
 
 const group = cva(styles.group);
 

--- a/packages/components/src/ComboBox.tsx
+++ b/packages/components/src/ComboBox.tsx
@@ -1,11 +1,12 @@
 import type { ForwardedRef } from 'react';
 import type { ComboBoxProps } from 'react-aria-components';
+import type { forwardRefType } from './utils';
 
 import { cva } from 'class-variance-authority';
+import { forwardRef } from 'react';
 import { ComboBox as AriaComboBox, composeRenderProps } from 'react-aria-components';
 
 import styles from './styles/ComboBox.module.css';
-import { forwardRef } from './utils';
 
 const box = cva(styles.box);
 
@@ -29,7 +30,7 @@ const _ComboBox = <T extends object>(
  *
  * https://react-spectrum.adobe.com/react-aria/ComboBox.html
  */
-const ComboBox = forwardRef(_ComboBox);
+const ComboBox = (forwardRef as forwardRefType)(_ComboBox);
 
 export { ComboBox };
 export type { ComboBoxProps };

--- a/packages/components/src/Dialog.tsx
+++ b/packages/components/src/Dialog.tsx
@@ -2,10 +2,10 @@ import type { ForwardedRef } from 'react';
 import type { DialogProps, DialogTriggerProps } from 'react-aria-components';
 
 import { cva } from 'class-variance-authority';
+import { forwardRef } from 'react';
 import { Dialog as AriaDialog, DialogTrigger } from 'react-aria-components';
 
 import styles from './styles/Dialog.module.css';
-import { forwardRef } from './utils';
 
 const dialog = cva(styles.dialog);
 

--- a/packages/components/src/FieldError.tsx
+++ b/packages/components/src/FieldError.tsx
@@ -2,10 +2,10 @@ import type { ForwardedRef } from 'react';
 import type { FieldErrorProps } from 'react-aria-components';
 
 import { cva } from 'class-variance-authority';
+import { forwardRef } from 'react';
 import { FieldError as AriaFieldError, composeRenderProps } from 'react-aria-components';
 
 import styles from './styles/FieldError.module.css';
-import { forwardRef } from './utils';
 
 const error = cva(styles.error);
 

--- a/packages/components/src/Group.tsx
+++ b/packages/components/src/Group.tsx
@@ -2,10 +2,10 @@ import type { ForwardedRef } from 'react';
 import type { GroupProps } from 'react-aria-components';
 
 import { cva } from 'class-variance-authority';
+import { forwardRef } from 'react';
 import { Group as AriaGroup, composeRenderProps } from 'react-aria-components';
 
 import styles from './styles/Group.module.css';
-import { forwardRef } from './utils';
 
 const group = cva(styles.group);
 

--- a/packages/components/src/IconButton.tsx
+++ b/packages/components/src/IconButton.tsx
@@ -7,11 +7,11 @@ import type { ButtonVariants } from './Button';
 
 import { Icon } from '@launchpad-ui/icons';
 import { cva, cx } from 'class-variance-authority';
+import { forwardRef } from 'react';
 import { Button as AriaButton, composeRenderProps } from 'react-aria-components';
 
 import { button } from './Button';
 import styles from './styles/IconButton.module.css';
-import { forwardRef } from './utils';
 
 const iconButton = cva(styles.base, {
 	variants: {

--- a/packages/components/src/Input.tsx
+++ b/packages/components/src/Input.tsx
@@ -2,10 +2,10 @@ import type { ForwardedRef } from 'react';
 import type { InputProps } from 'react-aria-components';
 
 import { cva } from 'class-variance-authority';
+import { forwardRef } from 'react';
 import { Input as AriaInput, composeRenderProps } from 'react-aria-components';
 
 import styles from './styles/Input.module.css';
-import { forwardRef } from './utils';
 
 const input = cva(styles.input);
 

--- a/packages/components/src/Label.tsx
+++ b/packages/components/src/Label.tsx
@@ -2,10 +2,10 @@ import type { ForwardedRef } from 'react';
 import type { LabelProps } from 'react-aria-components';
 
 import { cva } from 'class-variance-authority';
+import { forwardRef } from 'react';
 import { Label as AriaLabel } from 'react-aria-components';
 
 import styles from './styles/Label.module.css';
-import { forwardRef } from './utils';
 
 const label = cva(styles.label);
 

--- a/packages/components/src/Link.tsx
+++ b/packages/components/src/Link.tsx
@@ -4,11 +4,11 @@ import type { LinkProps as AriaLinkProps } from 'react-aria-components';
 import type { LinkProps as _RouterLinkProps } from 'react-router-dom';
 
 import { cva } from 'class-variance-authority';
+import { forwardRef } from 'react';
 import { Link as AriaLink, composeRenderProps } from 'react-aria-components';
 import { useHref, useLinkClickHandler } from 'react-router-dom';
 
 import styles from './styles/Link.module.css';
-import { forwardRef } from './utils';
 
 const link = cva(styles.base, {
 	variants: {

--- a/packages/components/src/LinkButton.tsx
+++ b/packages/components/src/LinkButton.tsx
@@ -2,11 +2,11 @@ import type { ForwardedRef } from 'react';
 import type { ButtonVariants } from './Button';
 import type { LinkProps } from './Link';
 
+import { forwardRef } from 'react';
 import { composeRenderProps } from 'react-aria-components';
 
 import { button } from './Button';
 import { Link } from './Link';
-import { forwardRef } from './utils';
 
 type LinkButtonProps = LinkProps & ButtonVariants;
 

--- a/packages/components/src/ListBox.tsx
+++ b/packages/components/src/ListBox.tsx
@@ -1,8 +1,10 @@
 import type { ForwardedRef } from 'react';
 import type { ListBoxItemProps, ListBoxProps } from 'react-aria-components';
+import type { forwardRefType } from './utils';
 
 import { Icon } from '@launchpad-ui/icons';
 import { cva } from 'class-variance-authority';
+import { forwardRef } from 'react';
 import {
 	ListBox as AriaListBox,
 	ListBoxItem as AriaListBoxItem,
@@ -10,7 +12,6 @@ import {
 } from 'react-aria-components';
 
 import styles from './styles/ListBox.module.css';
-import { forwardRef } from './utils';
 
 const box = cva(styles.box);
 const item = cva(styles.item);
@@ -32,7 +33,7 @@ const _ListBox = <T extends object>(props: ListBoxProps<T>, ref: ForwardedRef<HT
  *
  * https://react-spectrum.adobe.com/react-aria/ListBox.html
  */
-const ListBox = forwardRef(_ListBox);
+const ListBox = (forwardRef as forwardRefType)(_ListBox);
 
 const _ListBoxItem = <T extends object>(
 	props: ListBoxItemProps<T>,
@@ -64,7 +65,7 @@ const _ListBoxItem = <T extends object>(
  *
  * https://react-spectrum.adobe.com/react-aria/ListBox.html
  */
-const ListBoxItem = forwardRef(_ListBoxItem);
+const ListBoxItem = (forwardRef as forwardRefType)(_ListBoxItem);
 
 export { ListBox, ListBoxItem };
 export type { ListBoxProps, ListBoxItemProps };

--- a/packages/components/src/Menu.tsx
+++ b/packages/components/src/Menu.tsx
@@ -6,9 +6,11 @@ import type {
 	MenuTriggerProps,
 	SubmenuTriggerProps,
 } from 'react-aria-components';
+import type { forwardRefType } from './utils';
 
 import { Icon } from '@launchpad-ui/icons';
 import { cva } from 'class-variance-authority';
+import { forwardRef } from 'react';
 import {
 	Menu as AriaMenu,
 	MenuItem as AriaMenuItem,
@@ -18,7 +20,6 @@ import {
 } from 'react-aria-components';
 
 import styles from './styles/Menu.module.css';
-import { forwardRef } from './utils';
 
 const menu = cva(styles.menu);
 const item = cva(styles.item, {
@@ -48,7 +49,7 @@ const _Menu = <T extends object>(
  *
  * https://react-spectrum.adobe.com/react-aria/Menu.html
  */
-const Menu = forwardRef(_Menu);
+const Menu = (forwardRef as forwardRefType)(_Menu);
 
 const _MenuItem = <T extends object>(
 	{ variant = 'default', ...props }: MenuItemProps<T>,
@@ -78,7 +79,7 @@ const _MenuItem = <T extends object>(
 /**
  * A MenuItem represents an individual action in a Menu.
  */
-const MenuItem = forwardRef(_MenuItem);
+const MenuItem = (forwardRef as forwardRefType)(_MenuItem);
 
 export { Menu, MenuItem, MenuTrigger, SubmenuTrigger };
 export type { MenuProps, MenuItemProps, MenuTriggerProps, SubmenuTriggerProps };

--- a/packages/components/src/Modal.tsx
+++ b/packages/components/src/Modal.tsx
@@ -3,6 +3,7 @@ import type { ForwardedRef } from 'react';
 import type { ModalOverlayProps } from 'react-aria-components';
 
 import { cva } from 'class-variance-authority';
+import { forwardRef } from 'react';
 import {
 	Modal as AriaModal,
 	ModalOverlay as AriaModalOverlay,
@@ -10,7 +11,6 @@ import {
 } from 'react-aria-components';
 
 import styles from './styles/Modal.module.css';
-import { forwardRef } from './utils';
 
 const modal = cva(styles.base, {
 	variants: {

--- a/packages/components/src/Popover.tsx
+++ b/packages/components/src/Popover.tsx
@@ -5,6 +5,7 @@ import type {
 } from 'react-aria-components';
 
 import { cva } from 'class-variance-authority';
+import { forwardRef } from 'react';
 import {
 	OverlayArrow as AriaOverlayArrow,
 	Popover as AriaPopover,
@@ -12,7 +13,6 @@ import {
 } from 'react-aria-components';
 
 import styles from './styles/Popover.module.css';
-import { forwardRef } from './utils';
 
 type PopoverProps = Omit<AriaPopoverProps, 'offset' | 'crossOffset'>;
 type OverlayArrowProps = Omit<AriaOverlayArrowProps, 'children'>;

--- a/packages/components/src/ProgressBar.tsx
+++ b/packages/components/src/ProgressBar.tsx
@@ -3,10 +3,10 @@ import type { ForwardedRef } from 'react';
 import type { ProgressBarProps as AriaProgressBarProps } from 'react-aria-components';
 
 import { cva, cx } from 'class-variance-authority';
+import { forwardRef } from 'react';
 import { ProgressBar as AriaProgressBar, composeRenderProps } from 'react-aria-components';
 
 import styles from './styles/ProgressBar.module.css';
-import { forwardRef } from './utils';
 
 const progressBar = cva(styles.progress);
 

--- a/packages/components/src/Radio.tsx
+++ b/packages/components/src/Radio.tsx
@@ -3,10 +3,10 @@ import type { RadioProps } from 'react-aria-components';
 
 import { Icon } from '@launchpad-ui/icons';
 import { cva } from 'class-variance-authority';
+import { forwardRef } from 'react';
 import { Radio as AriaRadio, composeRenderProps } from 'react-aria-components';
 
 import styles from './styles/Radio.module.css';
-import { forwardRef } from './utils';
 
 const radio = cva(styles.radio);
 const circle = cva(styles.circle);

--- a/packages/components/src/RadioGroup.tsx
+++ b/packages/components/src/RadioGroup.tsx
@@ -2,10 +2,10 @@ import type { ForwardedRef } from 'react';
 import type { RadioGroupProps } from 'react-aria-components';
 
 import { cva } from 'class-variance-authority';
+import { forwardRef } from 'react';
 import { RadioGroup as AriaRadioGroup, composeRenderProps } from 'react-aria-components';
 
 import styles from './styles/RadioGroup.module.css';
-import { forwardRef } from './utils';
 
 const group = cva(styles.group);
 

--- a/packages/components/src/SearchField.tsx
+++ b/packages/components/src/SearchField.tsx
@@ -2,10 +2,10 @@ import type { ForwardedRef } from 'react';
 import type { SearchFieldProps } from 'react-aria-components';
 
 import { cva } from 'class-variance-authority';
+import { forwardRef } from 'react';
 import { SearchField as AriaSearchField, composeRenderProps } from 'react-aria-components';
 
 import styles from './styles/SearchField.module.css';
-import { forwardRef } from './utils';
 
 const search = cva(styles.search);
 

--- a/packages/components/src/Select.tsx
+++ b/packages/components/src/Select.tsx
@@ -1,7 +1,9 @@
 import type { ForwardedRef } from 'react';
 import type { SelectProps, SelectValueProps } from 'react-aria-components';
+import type { forwardRefType } from './utils';
 
 import { cva } from 'class-variance-authority';
+import { forwardRef } from 'react';
 import {
 	Select as AriaSelect,
 	SelectValue as AriaSelectValue,
@@ -9,7 +11,6 @@ import {
 } from 'react-aria-components';
 
 import styles from './styles/Select.module.css';
-import { forwardRef } from './utils';
 
 const select = cva(styles.select);
 const value = cva(styles.value);
@@ -31,7 +32,7 @@ const _Select = <T extends object>(props: SelectProps<T>, ref: ForwardedRef<HTML
  *
  * https://react-spectrum.adobe.com/react-aria/Select.html
  */
-const Select = forwardRef(_Select);
+const Select = (forwardRef as forwardRefType)(_Select);
 
 const _SelectValue = <T extends object>(
 	props: SelectValueProps<T>,
@@ -53,7 +54,7 @@ const _SelectValue = <T extends object>(
  *
  * https://react-spectrum.adobe.com/react-aria/Select.html
  */
-const SelectValue = forwardRef(_SelectValue);
+const SelectValue = (forwardRef as forwardRefType)(_SelectValue);
 
 export { Select, SelectValue };
 export type { SelectProps, SelectValueProps };

--- a/packages/components/src/Switch.tsx
+++ b/packages/components/src/Switch.tsx
@@ -2,10 +2,10 @@ import type { ForwardedRef, ReactNode } from 'react';
 import type { SwitchProps as AriaSwitchProps } from 'react-aria-components';
 
 import { cva } from 'class-variance-authority';
+import { forwardRef } from 'react';
 import { Switch as AriaSwitch, composeRenderProps } from 'react-aria-components';
 
 import styles from './styles/Switch.module.css';
-import { forwardRef } from './utils';
 
 const _switch = cva(styles.switch);
 

--- a/packages/components/src/TagGroup.tsx
+++ b/packages/components/src/TagGroup.tsx
@@ -1,8 +1,10 @@
 import type { VariantProps } from 'class-variance-authority';
 import type { ForwardedRef } from 'react';
 import type { TagGroupProps, TagListProps, TagProps as AriaTagProps } from 'react-aria-components';
+import type { forwardRefType } from './utils';
 
 import { cva } from 'class-variance-authority';
+import { forwardRef } from 'react';
 import {
 	Tag as AriaTag,
 	TagGroup as AriaTagGroup,
@@ -12,7 +14,6 @@ import {
 
 import { IconButton } from './IconButton';
 import styles from './styles/TagGroup.module.css';
-import { forwardRef } from './utils';
 
 const group = cva(styles.group);
 const list = cva(styles.list);
@@ -66,7 +67,7 @@ const _TagList = <T extends object>(props: TagListProps<T>, ref: ForwardedRef<HT
 /**
  * A tag list is a container for tags within a TagGroup.
  */
-const TagList = forwardRef(_TagList);
+const TagList = (forwardRef as forwardRefType)(_TagList);
 
 const _Tag = (
 	{ size = 'medium', variant = 'default', children, ...props }: TagProps,

--- a/packages/components/src/Text.tsx
+++ b/packages/components/src/Text.tsx
@@ -2,10 +2,10 @@ import type { ForwardedRef } from 'react';
 import type { TextProps } from 'react-aria-components';
 
 import { cva } from 'class-variance-authority';
+import { forwardRef } from 'react';
 import { Text as AriaText } from 'react-aria-components';
 
 import styles from './styles/Text.module.css';
-import { forwardRef } from './utils';
 
 const text = cva(styles.text);
 

--- a/packages/components/src/TextArea.tsx
+++ b/packages/components/src/TextArea.tsx
@@ -2,10 +2,10 @@ import type { ForwardedRef } from 'react';
 import type { TextAreaProps } from 'react-aria-components';
 
 import { cva } from 'class-variance-authority';
+import { forwardRef } from 'react';
 import { TextArea as AriaTextArea, composeRenderProps } from 'react-aria-components';
 
 import styles from './styles/Input.module.css';
-import { forwardRef } from './utils';
 
 const input = cva(styles.input);
 

--- a/packages/components/src/TextField.tsx
+++ b/packages/components/src/TextField.tsx
@@ -2,10 +2,10 @@ import type { ForwardedRef } from 'react';
 import type { TextFieldProps } from 'react-aria-components';
 
 import { cva } from 'class-variance-authority';
+import { forwardRef } from 'react';
 import { TextField as AriaTextField, composeRenderProps } from 'react-aria-components';
 
 import styles from './styles/TextField.module.css';
-import { forwardRef } from './utils';
 
 const field = cva(styles.field);
 

--- a/packages/components/src/Tooltip.tsx
+++ b/packages/components/src/Tooltip.tsx
@@ -5,6 +5,7 @@ import type {
 } from 'react-aria-components';
 
 import { cva } from 'class-variance-authority';
+import { forwardRef } from 'react';
 import {
 	Tooltip as AriaTooltip,
 	TooltipTrigger as AriaTooltipTrigger,
@@ -12,7 +13,6 @@ import {
 } from 'react-aria-components';
 
 import styles from './styles/Tooltip.module.css';
-import { forwardRef } from './utils';
 
 type TooltipProps = Omit<AriaTooltipProps, 'offset' | 'crossOffset'>;
 type TooltipTriggerProps = Omit<TooltipTriggerComponentProps, 'delay' | 'closeDelay'>;

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -33,6 +33,7 @@ export type { TextProps } from './Text';
 export type { TextAreaProps } from './TextArea';
 export type { TextFieldProps } from './TextField';
 export type { TooltipProps, TooltipTriggerProps } from './Tooltip';
+export type { forwardRefType } from './utils';
 
 export { Button } from './Button';
 export { ButtonGroup } from './ButtonGroup';
@@ -69,4 +70,3 @@ export { Text } from './Text';
 export { TextArea } from './TextArea';
 export { TextField } from './TextField';
 export { Tooltip, TooltipTrigger } from './Tooltip';
-export { forwardRef } from './utils';

--- a/packages/components/src/utils.tsx
+++ b/packages/components/src/utils.tsx
@@ -1,16 +1,11 @@
-import type { ReactNode, Ref, RefAttributes } from 'react';
+import type { ReactElement, Ref, RefAttributes } from 'react';
 
-import { forwardRef as reactForwardRef } from 'react';
-
-/**
- * forwardRef with generics support.
- *
- * https://www.totaltypescript.com/forwardref-with-generic-components#the-solution
- */
+// https://github.com/adobe/react-spectrum/blob/main/packages/react-aria-components/src/utils.tsx#L20-L24
 // biome-ignore lint/complexity/noBannedTypes: <explanation>
-const forwardRef = <T, P = {}>(
-	render: (props: P, ref: Ref<T>) => ReactNode,
-	// biome-ignore lint/suspicious/noExplicitAny: <explanation>
-): ((props: P & RefAttributes<T>) => ReactNode) => reactForwardRef(render) as any;
+declare function forwardRef<T, P = {}>(
+	render: (props: P, ref: Ref<T>) => ReactElement | null,
+): (props: P & RefAttributes<T>) => ReactElement | null;
 
-export { forwardRef };
+type forwardRefType = typeof forwardRef;
+
+export type { forwardRefType };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ importers:
         specifier: ^4.8.5
         version: 4.8.5(playwright-core@1.42.1)
       '@biomejs/biome':
-        specifier: ^1.5.3
+        specifier: 1.5.3
         version: 1.5.3
       '@changesets/changelog-github':
         specifier: ^0.5.0


### PR DESCRIPTION
## Summary

#1192 broke Storybook generated props for RAC because the override for `forwardRef` was being for every component instead of just the ones with generics. So to minimize confusion we should emulate how RAC handles this internally with a cast utility type that only gets applied to components with generics.