### PR TITLE
fix(components): correct `ComboBox` popover size and position

### DIFF
--- a/.changeset/wicked-moles-knock.md
+++ b/.changeset/wicked-moles-knock.md
@@ -1,0 +1,5 @@
+---
+"@launchpad-ui/components": patch
+---
+
+Correct `ComboBox` popover size and position

--- a/packages/components/src/Popover.tsx
+++ b/packages/components/src/Popover.tsx
@@ -9,7 +9,9 @@ import { forwardRef } from 'react';
 import {
 	OverlayArrow as AriaOverlayArrow,
 	Popover as AriaPopover,
+	PopoverContext,
 	composeRenderProps,
+	useSlottedContext,
 } from 'react-aria-components';
 
 import styles from './styles/Popover.module.css';
@@ -21,11 +23,13 @@ const popover = cva(styles.popover);
 const arrow = cva(styles.arrow);
 
 const _Popover = (props: PopoverProps, ref: ForwardedRef<HTMLDivElement>) => {
+	const context = useSlottedContext(PopoverContext);
+	const isComboBox = context?.trigger === 'ComboBox';
 	return (
 		<AriaPopover
 			{...props}
-			offset={0}
-			crossOffset={0}
+			offset={isComboBox ? 9 : 4}
+			crossOffset={isComboBox ? -8 : 0}
 			ref={ref}
 			className={composeRenderProps(props.className, (className, renderProps) =>
 				popover({ ...renderProps, className }),

--- a/packages/components/src/styles/Popover.module.css
+++ b/packages/components/src/styles/Popover.module.css
@@ -11,8 +11,7 @@
 }
 
 .popover {
-  --lp-popover-offset: var(--lp-size-4);
-  --lp-arrow-offset: var(--lp-size-6);
+  --lp-arrow-offset: var(--lp-size-2);
 
   isolation: isolate;
   border-radius: var(--lp-border-radius-regular);
@@ -44,16 +43,18 @@
     max-width: var(--lp-menu-max-width);
   }
 
-  &[data-trigger='Select'],
-  &[data-trigger='ComboBox'] {
+  &[data-trigger='Select'] {
     /* stylelint-disable-next-line csstools/value-no-unknown-custom-properties */
     min-width: var(--trigger-width);
   }
 
+  &[data-trigger='ComboBox'] {
+    /* stylelint-disable-next-line csstools/value-no-unknown-custom-properties */
+    min-width: calc(var(--lp-spacing-300) * 2 + var(--trigger-width) + 2px);
+  }
+
   &[data-placement='top'] {
     --origin: translateY(4px);
-
-    margin-bottom: var(--lp-popover-offset);
 
     &:has(.arrow) {
       margin-bottom: var(--lp-arrow-offset);
@@ -62,8 +63,6 @@
 
   &[data-placement='bottom'] {
     --origin: translateY(-4px);
-
-    margin-top: var(--lp-popover-offset);
 
     & .arrow svg {
       transform: rotate(180deg);
@@ -77,8 +76,6 @@
   &[data-placement='right'] {
     --origin: translateX(-4px);
 
-    margin-left: var(--lp-popover-offset);
-
     & .arrow svg {
       transform: rotate(90deg);
     }
@@ -90,8 +87,6 @@
 
   &[data-placement='left'] {
     --origin: translateX(4px);
-
-    margin-right: var(--lp-popover-offset);
 
     & .arrow svg {
       transform: rotate(-90deg);


### PR DESCRIPTION
## Summary

Correct `ComboBox` popover styles since `--trigger-width` is based off the `Input` size. We use `Group` with input styles so we need to adjust things accordingly.