### PR TITLE
fix(components): use interface instead of intersection

### DIFF
--- a/.changeset/gentle-bobcats-teach.md
+++ b/.changeset/gentle-bobcats-teach.md
@@ -1,0 +1,5 @@
+---
+"@launchpad-ui/components": patch
+---
+
+Use interface instead of intersection

--- a/packages/components/src/Button.tsx
+++ b/packages/components/src/Button.tsx
@@ -35,8 +35,8 @@ const button = cva(styles.base, {
 	},
 });
 
-type ButtonVariants = VariantProps<typeof button>;
-type ButtonProps = AriaButtonProps & ButtonVariants;
+interface ButtonVariants extends VariantProps<typeof button> {}
+interface ButtonProps extends AriaButtonProps, ButtonVariants {}
 
 const _Button = (
 	{ size = 'medium', variant = 'default', ...props }: ButtonProps,

--- a/packages/components/src/ButtonGroup.tsx
+++ b/packages/components/src/ButtonGroup.tsx
@@ -20,10 +20,9 @@ const buttonGroup = cva(styles.base, {
 	},
 });
 
-type ButtonGroupProps = ComponentPropsWithRef<'div'> &
-	VariantProps<typeof buttonGroup> & {
-		isDisabled?: boolean;
-	};
+interface ButtonGroupProps extends ComponentPropsWithRef<'div'>, VariantProps<typeof buttonGroup> {
+	isDisabled?: boolean;
+}
 
 const _ButtonGroup = (
 	{ children, className, spacing = 'basic', isDisabled, ...props }: ButtonGroupProps,

--- a/packages/components/src/IconButton.tsx
+++ b/packages/components/src/IconButton.tsx
@@ -25,12 +25,13 @@ const iconButton = cva(styles.base, {
 	},
 });
 
-type IconButtonProps = Omit<AriaButtonProps, 'children'> &
-	Required<Pick<AriaLabelingProps, 'aria-label'>> &
-	VariantProps<typeof iconButton> & {
-		icon: IconProps['name'];
-		variant?: Extract<ButtonVariants['variant'], 'default' | 'primary' | 'destructive' | 'minimal'>;
-	};
+interface IconButtonProps
+	extends Omit<AriaButtonProps, 'children' | 'aria-label'>,
+		Required<Pick<AriaLabelingProps, 'aria-label'>>,
+		VariantProps<typeof iconButton> {
+	icon: IconProps['name'];
+	variant?: Extract<ButtonVariants['variant'], 'default' | 'primary' | 'destructive' | 'minimal'>;
+}
 
 const _IconButton = (
 	{ size = 'medium', variant = 'default', icon, ...props }: IconButtonProps,

--- a/packages/components/src/Link.tsx
+++ b/packages/components/src/Link.tsx
@@ -22,7 +22,19 @@ const link = cva(styles.base, {
 	},
 });
 
-interface RouterLinkProps extends Omit<_RouterLinkProps, 'children' | 'className' | 'slot'> {}
+interface RouterLinkProps
+	extends Omit<
+		_RouterLinkProps,
+		| 'children'
+		| 'className'
+		| 'slot'
+		| 'style'
+		| 'download'
+		| 'onBlur'
+		| 'onFocus'
+		| 'onKeyDown'
+		| 'onKeyUp'
+	> {}
 interface LinkProps extends AriaLinkProps, Partial<RouterLinkProps>, VariantProps<typeof link> {}
 
 const _RACLink = (

--- a/packages/components/src/Link.tsx
+++ b/packages/components/src/Link.tsx
@@ -22,8 +22,8 @@ const link = cva(styles.base, {
 	},
 });
 
-type RouterLinkProps = Omit<_RouterLinkProps, 'children' | 'className' | 'slot'>;
-type LinkProps = AriaLinkProps & Partial<RouterLinkProps> & VariantProps<typeof link>;
+interface RouterLinkProps extends Omit<_RouterLinkProps, 'children' | 'className' | 'slot'> {}
+interface LinkProps extends AriaLinkProps, Partial<RouterLinkProps>, VariantProps<typeof link> {}
 
 const _RACLink = (
 	{ variant = 'default', ...props }: AriaLinkProps & VariantProps<typeof link>,

--- a/packages/components/src/LinkButton.tsx
+++ b/packages/components/src/LinkButton.tsx
@@ -8,7 +8,7 @@ import { composeRenderProps } from 'react-aria-components';
 import { button } from './Button';
 import { Link } from './Link';
 
-type LinkButtonProps = LinkProps & ButtonVariants;
+interface LinkButtonProps extends Omit<LinkProps, 'variant'>, ButtonVariants {}
 
 const _LinkButton = (
 	{ size = 'medium', variant = 'default', ...props }: LinkButtonProps,

--- a/packages/components/src/Menu.tsx
+++ b/packages/components/src/Menu.tsx
@@ -34,8 +34,8 @@ const item = cva(styles.item, {
 	},
 });
 
-type MenuProps<T> = AriaMenuProps<T>;
-type MenuItemProps<T> = AriaMenuItemProps<T> & VariantProps<typeof item>;
+interface MenuProps<T> extends AriaMenuProps<T> {}
+interface MenuItemProps<T> extends AriaMenuItemProps<T>, VariantProps<typeof item> {}
 
 const _Menu = <T extends object>(
 	{ className, ...props }: MenuProps<T>,

--- a/packages/components/src/Modal.tsx
+++ b/packages/components/src/Modal.tsx
@@ -30,7 +30,7 @@ const modal = cva(styles.base, {
 });
 const overlay = cva(styles.overlay);
 
-type ModalProps = ModalOverlayProps & VariantProps<typeof modal>;
+interface ModalProps extends ModalOverlayProps, VariantProps<typeof modal> {}
 
 const _Modal = (
 	{ size = 'medium', variant = 'default', ...props }: ModalProps,

--- a/packages/components/src/Popover.tsx
+++ b/packages/components/src/Popover.tsx
@@ -14,8 +14,8 @@ import {
 
 import styles from './styles/Popover.module.css';
 
-type PopoverProps = Omit<AriaPopoverProps, 'offset' | 'crossOffset'>;
-type OverlayArrowProps = Omit<AriaOverlayArrowProps, 'children'>;
+interface PopoverProps extends Omit<AriaPopoverProps, 'offset' | 'crossOffset'> {}
+interface OverlayArrowProps extends Omit<AriaOverlayArrowProps, 'children'> {}
 
 const popover = cva(styles.popover);
 const arrow = cva(styles.arrow);

--- a/packages/components/src/ProgressBar.tsx
+++ b/packages/components/src/ProgressBar.tsx
@@ -23,7 +23,7 @@ const icon = cva(styles.base, {
 	},
 });
 
-type ProgressBarProps = AriaProgressBarProps & VariantProps<typeof icon>;
+interface ProgressBarProps extends AriaProgressBarProps, VariantProps<typeof icon> {}
 
 const _ProgressBar = (
 	{ size = 'small', ...props }: ProgressBarProps,

--- a/packages/components/src/Switch.tsx
+++ b/packages/components/src/Switch.tsx
@@ -9,9 +9,9 @@ import styles from './styles/Switch.module.css';
 
 const _switch = cva(styles.switch);
 
-type SwitchProps = Omit<AriaSwitchProps, 'children'> & {
+interface SwitchProps extends Omit<AriaSwitchProps, 'children'> {
 	children?: ReactNode;
-};
+}
 
 const _Switch = ({ children, ...props }: SwitchProps, ref: ForwardedRef<HTMLLabelElement>) => {
 	return (

--- a/packages/components/src/TagGroup.tsx
+++ b/packages/components/src/TagGroup.tsx
@@ -39,7 +39,7 @@ const tag = cva(styles.tag, {
 	},
 });
 
-type TagProps = AriaTagProps & VariantProps<typeof tag>;
+interface TagProps extends AriaTagProps, VariantProps<typeof tag> {}
 
 const _TagGroup = ({ className, ...props }: TagGroupProps, ref: ForwardedRef<HTMLDivElement>) => {
 	return <AriaTagGroup {...props} ref={ref} className={group({ className })} />;

--- a/packages/components/src/Tooltip.tsx
+++ b/packages/components/src/Tooltip.tsx
@@ -14,8 +14,8 @@ import {
 
 import styles from './styles/Tooltip.module.css';
 
-type TooltipProps = Omit<AriaTooltipProps, 'offset' | 'crossOffset'>;
-type TooltipTriggerProps = Omit<TooltipTriggerComponentProps, 'delay' | 'closeDelay'>;
+interface TooltipProps extends Omit<AriaTooltipProps, 'offset' | 'crossOffset'> {}
+interface TooltipTriggerProps extends Omit<TooltipTriggerComponentProps, 'delay' | 'closeDelay'> {}
 
 const tooltip = cva(styles.tooltip);
 


### PR DESCRIPTION
## Summary

[Use interface instead of intersection](https://github.com/microsoft/TypeScript/wiki/Performance#preferring-interfaces-over-intersections). Addresses a bug I ran into where both types had incompatible property `variant` and the end result was undesired. This is because intersection recursively merges. From now on we'll use `interface` to be strict and explicit.

## Screenshots (if appropriate):

<img width="933" alt="Screenshot 2024-03-18 at 2 40 03 PM" src="https://github.com/launchdarkly/launchpad-ui/assets/2147624/7caff74b-374c-41b5-b995-d402d52c6eb7">
