### PR TITLE
fix(components): ensure render props can be used as children

### DIFF
--- a/.changeset/shaggy-planets-smell.md
+++ b/.changeset/shaggy-planets-smell.md
@@ -1,0 +1,5 @@
+---
+"@launchpad-ui/components": patch
+---
+
+Ensure render props can be used as children

--- a/packages/components/src/Checkbox.tsx
+++ b/packages/components/src/Checkbox.tsx
@@ -11,7 +11,7 @@ import styles from './styles/Checkbox.module.css';
 const checkbox = cva(styles.checkbox);
 const box = cva(styles.box);
 
-const _Checkbox = ({ children, ...props }: CheckboxProps, ref: ForwardedRef<HTMLLabelElement>) => {
+const _Checkbox = (props: CheckboxProps, ref: ForwardedRef<HTMLLabelElement>) => {
 	return (
 		<AriaCheckbox
 			{...props}
@@ -20,7 +20,7 @@ const _Checkbox = ({ children, ...props }: CheckboxProps, ref: ForwardedRef<HTML
 				checkbox({ ...renderProps, className }),
 			)}
 		>
-			{({ isSelected, isIndeterminate }) => (
+			{composeRenderProps(props.children, (children, { isSelected, isIndeterminate }) => (
 				<>
 					<div className={box()}>
 						{isIndeterminate ? (
@@ -31,7 +31,7 @@ const _Checkbox = ({ children, ...props }: CheckboxProps, ref: ForwardedRef<HTML
 					</div>
 					{children}
 				</>
-			)}
+			))}
 		</AriaCheckbox>
 	);
 };

--- a/packages/components/src/Radio.tsx
+++ b/packages/components/src/Radio.tsx
@@ -11,7 +11,7 @@ import styles from './styles/Radio.module.css';
 const radio = cva(styles.radio);
 const circle = cva(styles.circle);
 
-const _Radio = ({ children, ...props }: RadioProps, ref: ForwardedRef<HTMLLabelElement>) => {
+const _Radio = (props: RadioProps, ref: ForwardedRef<HTMLLabelElement>) => {
 	return (
 		<AriaRadio
 			{...props}
@@ -20,14 +20,14 @@ const _Radio = ({ children, ...props }: RadioProps, ref: ForwardedRef<HTMLLabelE
 				radio({ ...renderProps, className }),
 			)}
 		>
-			{({ isSelected }) => (
+			{composeRenderProps(props.children, (children, { isSelected }) => (
 				<>
 					<div className={circle()}>
 						{isSelected ? <Icon name="circle" className={styles.icon} /> : null}
 					</div>
 					{children}
 				</>
-			)}
+			))}
 		</AriaRadio>
 	);
 };

--- a/packages/components/src/Switch.tsx
+++ b/packages/components/src/Switch.tsx
@@ -13,7 +13,7 @@ interface SwitchProps extends Omit<AriaSwitchProps, 'children'> {
 	children?: ReactNode;
 }
 
-const _Switch = ({ children, ...props }: SwitchProps, ref: ForwardedRef<HTMLLabelElement>) => {
+const _Switch = (props: SwitchProps, ref: ForwardedRef<HTMLLabelElement>) => {
 	return (
 		<AriaSwitch
 			{...props}
@@ -22,7 +22,7 @@ const _Switch = ({ children, ...props }: SwitchProps, ref: ForwardedRef<HTMLLabe
 				_switch({ ...renderProps, className }),
 			)}
 		>
-			{({ isSelected }) => (
+			{composeRenderProps(props.children, (children, { isSelected }) => (
 				<>
 					<div className={styles.track}>
 						{isSelected && <div className={styles.label}>On</div>}
@@ -31,7 +31,7 @@ const _Switch = ({ children, ...props }: SwitchProps, ref: ForwardedRef<HTMLLabe
 					</div>
 					{children}
 				</>
-			)}
+			))}
 		</AriaSwitch>
 	);
 };

--- a/packages/components/src/TagGroup.tsx
+++ b/packages/components/src/TagGroup.tsx
@@ -70,10 +70,10 @@ const _TagList = <T extends object>(props: TagListProps<T>, ref: ForwardedRef<HT
 const TagList = (forwardRef as forwardRefType)(_TagList);
 
 const _Tag = (
-	{ size = 'medium', variant = 'default', children, ...props }: TagProps,
+	{ size = 'medium', variant = 'default', ...props }: TagProps,
 	ref: ForwardedRef<HTMLDivElement>,
 ) => {
-	const textValue = typeof children === 'string' ? children : undefined;
+	const textValue = typeof props.children === 'string' ? props.children : undefined;
 
 	return (
 		<AriaTag
@@ -84,7 +84,7 @@ const _Tag = (
 				tag({ ...renderProps, size, variant, className }),
 			)}
 		>
-			{({ allowsRemoving }) => (
+			{composeRenderProps(props.children, (children, { allowsRemoving }) => (
 				<>
 					{children}
 					{allowsRemoving && (
@@ -97,7 +97,7 @@ const _Tag = (
 						/>
 					)}
 				</>
-			)}
+			))}
 		</AriaTag>
 	);
 };


### PR DESCRIPTION
## Summary

Use the `composeRenderProps` util to ensure consumers have access to [render props](https://react-spectrum.adobe.com/react-aria/styling.html#render-props) on applicable components. Helpful for things like adding tooltips or popovers to components that support hover/focus.