### PR TITLE
feat(components): set `Group` context within `TextField`

### DIFF
--- a/.changeset/chatty-clocks-bake.md
+++ b/.changeset/chatty-clocks-bake.md
@@ -1,0 +1,5 @@
+---
+"@launchpad-ui/components": patch
+---
+
+Set `Group` context within `TextField`

--- a/packages/components/__tests__/TextField.spec.tsx
+++ b/packages/components/__tests__/TextField.spec.tsx
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { render, screen } from '../../../test/utils';
-import { Input, Label, TextArea, TextField } from '../src';
+import { Group, IconButton, Input, Label, TextArea, TextField } from '../src';
 
 describe('TextField', () => {
 	it('renders an input', () => {
@@ -22,5 +22,18 @@ describe('TextField', () => {
 			</TextField>,
 		);
 		expect(screen.getByRole('textbox')).toBeVisible();
+	});
+
+	it('sets context for groups', () => {
+		render(
+			<TextField isInvalid>
+				<Label>Label</Label>
+				<Group>
+					<Input />
+					<IconButton icon="add" aria-label="add" size="small" />
+				</Group>
+			</TextField>,
+		);
+		expect(screen.getByRole('group')).toHaveAttribute('data-invalid', 'true');
 	});
 });

--- a/packages/components/src/TextField.tsx
+++ b/packages/components/src/TextField.tsx
@@ -3,7 +3,12 @@ import type { TextFieldProps } from 'react-aria-components';
 
 import { cva } from 'class-variance-authority';
 import { forwardRef } from 'react';
-import { TextField as AriaTextField, composeRenderProps } from 'react-aria-components';
+import {
+	GroupContext,
+	Provider,
+	TextField as AriaTextField,
+	composeRenderProps,
+} from 'react-aria-components';
 
 import styles from './styles/TextField.module.css';
 
@@ -17,7 +22,11 @@ const _TextField = (props: TextFieldProps, ref: ForwardedRef<HTMLDivElement>) =>
 			className={composeRenderProps(props.className, (className, renderProps) =>
 				field({ ...renderProps, className }),
 			)}
-		/>
+		>
+			{composeRenderProps(props.children, (children, { isInvalid, isDisabled }) => (
+				<Provider values={[[GroupContext, { isInvalid, isDisabled }]]}>{children}</Provider>
+			))}
+		</AriaTextField>
 	);
 };
 


### PR DESCRIPTION
## Summary

Set `Group` context within `TextField` ([like SearchField does](https://github.com/adobe/react-spectrum/blob/main/packages/react-aria-components/src/SearchField.tsx#L100)) using [Provider](https://react-spectrum.adobe.com/react-aria/advanced.html#provider) to improve DX.