### PR TITLE
fix: ensure RAC portals are included in axe scans

### DIFF
--- a/playwright/a11y.spec.ts
+++ b/playwright/a11y.spec.ts
@@ -86,6 +86,7 @@ test.describe('Storybook a11y', async () => {
 					})
 					.include('#storybook-root')
 					.include('[data-test-id="portal"]')
+					.include('[data-rac]')
 					.exclude('[data-a11y-ignore="aria-hidden-focus"]')
 					.analyze();
 


### PR DESCRIPTION
## Summary

Ensure RAC portals are included in axe scans by using the `[data-rac]` selector that every RAC renders.

## Testing approaches

Run the Playwright test in [UI mode](https://playwright.dev/docs/test-ui-mode) and log the nodes from the `passes` field within the scan results.
