### PR TITLE
fix(components): ensure `Tooltip` content can be hovered

### DIFF
--- a/.changeset/eleven-cooks-move.md
+++ b/.changeset/eleven-cooks-move.md
@@ -1,0 +1,5 @@
+---
+"@launchpad-ui/components": patch
+---
+
+Ensure `Tooltip` content can be hovered

--- a/packages/components/__tests__/Tooltip.spec.tsx
+++ b/packages/components/__tests__/Tooltip.spec.tsx
@@ -16,4 +16,18 @@ describe('Tooltip', () => {
 		await user.hover(screen.getByRole('button'));
 		expect(await screen.findByRole('tooltip')).toBeVisible();
 	});
+
+	it('remains open on hover of content', async () => {
+		const user = userEvent.setup();
+		render(
+			<TooltipTrigger>
+				<Button>Trigger</Button>
+				<Tooltip>Message</Tooltip>
+			</TooltipTrigger>,
+		);
+		await user.hover(document.body);
+		await user.hover(screen.getByRole('button'));
+		await user.hover(await screen.findByRole('tooltip'));
+		expect(await screen.findByRole('tooltip')).toBeVisible();
+	});
 });

--- a/packages/components/src/Tooltip.tsx
+++ b/packages/components/src/Tooltip.tsx
@@ -23,7 +23,7 @@ const _Tooltip = (props: TooltipProps, ref: ForwardedRef<HTMLDivElement>) => {
 	return (
 		<AriaTooltip
 			{...props}
-			offset={0}
+			offset={4}
 			crossOffset={0}
 			ref={ref}
 			className={composeRenderProps(props.className, (className, renderProps) =>
@@ -41,7 +41,7 @@ const _Tooltip = (props: TooltipProps, ref: ForwardedRef<HTMLDivElement>) => {
 const Tooltip = forwardRef(_Tooltip);
 
 const TooltipTrigger = (props: TooltipTriggerProps) => {
-	return <AriaTooltipTrigger {...props} delay={500} closeDelay={0} />;
+	return <AriaTooltipTrigger {...props} delay={500} closeDelay={250} />;
 };
 
 export { Tooltip, TooltipTrigger };

--- a/packages/components/src/styles/TagGroup.module.css
+++ b/packages/components/src/styles/TagGroup.module.css
@@ -17,6 +17,7 @@
   padding: var(--lp-spacing-100) var(--lp-spacing-200);
   border-radius: var(--lp-border-radius-medium);
   outline: none;
+  cursor: default;
 
   &[data-focus-visible] {
     outline: 2px solid var(--lp-color-shadow-interactive-focus);

--- a/packages/components/src/styles/Tooltip.module.css
+++ b/packages/components/src/styles/Tooltip.module.css
@@ -11,8 +11,6 @@
 }
 
 .tooltip {
-  --lp-tooltip-offset: var(--lp-size-4);
-
   isolation: isolate;
   font: var(--lp-body-2-regular);
   padding: var(--lp-spacing-200) var(--lp-spacing-300);
@@ -31,26 +29,18 @@
 
   &[data-placement='top'] {
     --origin: translateY(4px);
-
-    margin-bottom: var(--lp-tooltip-offset);
   }
 
   &[data-placement='bottom'] {
     --origin: translateY(-4px);
-
-    margin-top: var(--lp-tooltip-offset);
   }
 
   &[data-placement='right'] {
     --origin: translateX(-4px);
-
-    margin-left: var(--lp-tooltip-offset);
   }
 
   &[data-placement='left'] {
     --origin: translateX(4px);
-
-    margin-right: var(--lp-tooltip-offset);
   }
 
   @media (prefers-reduced-motion: no-preference) {


### PR DESCRIPTION
## Summary

Ensure `Tooltip` content can be hovered to meet [a11y requirements](https://www.w3.org/WAI/WCAG21/Understanding/content-on-hover-or-focus.html).

## Testing approaches

Open a tooltip and notice you can hover to the content without it closing.
