### PR TITLE
feat(components): make `Modal` dismissable by default

### DIFF
--- a/.changeset/pretty-snakes-notice.md
+++ b/.changeset/pretty-snakes-notice.md
@@ -1,0 +1,5 @@
+---
+"@launchpad-ui/components": patch
+---
+
+Make `Modal` dismissable by default

--- a/packages/components/src/Modal.tsx
+++ b/packages/components/src/Modal.tsx
@@ -54,9 +54,13 @@ const _Modal = (
  */
 const Modal = forwardRef(_Modal);
 
-const _ModalOverlay = (props: ModalOverlayProps, ref: ForwardedRef<HTMLDivElement>) => {
+const _ModalOverlay = (
+	{ isDismissable = true, ...props }: ModalOverlayProps,
+	ref: ForwardedRef<HTMLDivElement>,
+) => {
 	return (
 		<AriaModalOverlay
+			isDismissable={isDismissable}
 			{...props}
 			ref={ref}
 			className={composeRenderProps(props.className, (className, renderProps) =>


### PR DESCRIPTION
## Summary

Make `Modal` dismissable by default.