### PR TITLE
chore: add editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = tab
+indent_size = 2
+trim_trailing_whitespace = true
+
+[*.{md,mdx}]
+trim_trailing_whitespace = false

--- a/nx.json
+++ b/nx.json
@@ -1,7 +1,5 @@
 {
-	"affected": {
-		"defaultBase": "main"
-	},
+	"defaultBase": "main",
 	"workspaceLayout": {
 		"appsDir": "apps",
 		"libsDir": "packages"


### PR DESCRIPTION
## Summary

Add a `.editorconfig` so that our code is formatted as expected when viewed via GitHub and a user does not have their tab size configured. Helps our case since we use [tabs instead of spaces](https://twitter.com/Rich_Harris/status/1541761871585464323) and GitHub defaults to a tab size of 8.