### PR TITLE
refactor(components): use `Group` in `ButtonGroup`

### DIFF
--- a/.changeset/honest-geckos-think.md
+++ b/.changeset/honest-geckos-think.md
@@ -1,0 +1,5 @@
+---
+"@launchpad-ui/components": patch
+---
+
+Use `Group` in `ButtonGroup`

--- a/packages/components/src/ButtonGroup.tsx
+++ b/packages/components/src/ButtonGroup.tsx
@@ -1,9 +1,10 @@
 import type { VariantProps } from 'class-variance-authority';
-import type { ComponentPropsWithRef, ForwardedRef } from 'react';
+import type { ForwardedRef } from 'react';
+import type { GroupProps } from 'react-aria-components';
 
 import { cva } from 'class-variance-authority';
 import { forwardRef } from 'react';
-import { ButtonContext } from 'react-aria-components';
+import { ButtonContext, Group, Provider, composeRenderProps } from 'react-aria-components';
 
 import styles from './styles/ButtonGroup.module.css';
 
@@ -20,18 +21,24 @@ const buttonGroup = cva(styles.base, {
 	},
 });
 
-interface ButtonGroupProps extends ComponentPropsWithRef<'div'>, VariantProps<typeof buttonGroup> {
-	isDisabled?: boolean;
-}
+interface ButtonGroupProps extends GroupProps, VariantProps<typeof buttonGroup> {}
 
 const _ButtonGroup = (
-	{ children, className, spacing = 'basic', isDisabled, ...props }: ButtonGroupProps,
+	{ spacing = 'basic', ...props }: ButtonGroupProps,
 	ref: ForwardedRef<HTMLDivElement>,
 ) => {
 	return (
-		<div {...props} ref={ref} className={buttonGroup({ spacing, className })}>
-			<ButtonContext.Provider value={{ isDisabled }}>{children}</ButtonContext.Provider>
-		</div>
+		<Group
+			{...props}
+			ref={ref}
+			className={composeRenderProps(props.className, (className, renderProps) =>
+				buttonGroup({ ...renderProps, spacing, className }),
+			)}
+		>
+			{composeRenderProps(props.children, (children, { isDisabled }) => (
+				<Provider values={[[ButtonContext, { isDisabled }]]}>{children}</Provider>
+			))}
+		</Group>
 	);
 };
 

--- a/packages/components/src/styles/ButtonGroup.module.css
+++ b/packages/components/src/styles/ButtonGroup.module.css
@@ -8,24 +8,30 @@
 
 .compact {
   gap: initial;
+
+  & :first-child {
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+    border-right: none;
+  }
+
+  & :last-child {
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+  }
+
+  & :not(:first-child):not(:last-child) {
+    border-radius: 0;
+  }
+
+  /* At least three children */
+  &:has(> :nth-child(3)) {
+    & :last-child {
+      border-left: none;
+    }
+  }
 }
 
 .large {
   gap: var(--lp-spacing-600);
-}
-
-.compact :first-child {
-  border-top-right-radius: 0;
-  border-bottom-right-radius: 0;
-  border-right: none;
-}
-
-.compact :last-child {
-  border-top-left-radius: 0;
-  border-bottom-left-radius: 0;
-  border-left: none;
-}
-
-.compact :not(:first-child):not(:last-child) {
-  border-radius: 0;
 }

--- a/packages/components/stories/ButtonGroup.stories.tsx
+++ b/packages/components/stories/ButtonGroup.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
-import { Button, ButtonGroup } from '../src';
+import { Button, ButtonGroup, IconButton, Menu, MenuItem, MenuTrigger, Popover } from '../src';
 
 const meta: Meta<typeof ButtonGroup> = {
 	component: ButtonGroup,
@@ -36,4 +36,24 @@ export const Compact: Story = {
 
 export const Large: Story = {
 	args: { ...defaultArgs, spacing: 'large' },
+};
+
+export const SplitButton: Story = {
+	args: {
+		children: (
+			<>
+				<Button>Split button</Button>
+				<MenuTrigger>
+					<IconButton icon="chevron-down" aria-label="open" />
+					<Popover>
+						<Menu>
+							<MenuItem>Item one</MenuItem>
+							<MenuItem>Item two</MenuItem>
+						</Menu>
+					</Popover>
+				</MenuTrigger>
+			</>
+		),
+		spacing: 'compact',
+	},
 };

--- a/packages/components/stories/ButtonGroup.stories.tsx
+++ b/packages/components/stories/ButtonGroup.stories.tsx
@@ -45,7 +45,7 @@ export const SplitButton: Story = {
 				<Button>Split button</Button>
 				<MenuTrigger>
 					<IconButton icon="chevron-down" aria-label="open" />
-					<Popover>
+					<Popover placement="bottom end">
 						<Menu>
 							<MenuItem>Item one</MenuItem>
 							<MenuItem>Item two</MenuItem>


### PR DESCRIPTION
## Summary

Use `Group` in `ButtonGroup` for better accessibility. Also add a story to show how to create a split button with the component.