### PR TITLE
include `displayName` in `forwardRefType` utility type

### DIFF
--- a/.changeset/gentle-dryers-know.md
+++ b/.changeset/gentle-dryers-know.md
@@ -1,0 +1,5 @@
+---
+"@launchpad-ui/components": patch
+---
+
+Updated "forwardRefType" type util to include optional "displayName" property from "forwardRef."

--- a/packages/components/src/utils.tsx
+++ b/packages/components/src/utils.tsx
@@ -4,7 +4,7 @@ import type { ReactElement, Ref, RefAttributes } from 'react';
 // biome-ignore lint/complexity/noBannedTypes: <explanation>
 declare function forwardRef<T, P = {}>(
 	render: (props: P, ref: Ref<T>) => ReactElement | null,
-): ((props: P & RefAttributes<T>) => ReactElement | null) & { displayName?: string | undefined };
+): ((props: P & RefAttributes<T>) => ReactElement | null) & { displayddName?: string | undefined };
 
 type forwardRefType = typeof forwardRef;
 

--- a/packages/components/src/utils.tsx
+++ b/packages/components/src/utils.tsx
@@ -4,7 +4,7 @@ import type { ReactElement, Ref, RefAttributes } from 'react';
 // biome-ignore lint/complexity/noBannedTypes: <explanation>
 declare function forwardRef<T, P = {}>(
 	render: (props: P, ref: Ref<T>) => ReactElement | null,
-): ((props: P & RefAttributes<T>) => ReactElement | null) & { displayddName?: string | undefined };
+): ((props: P & RefAttributes<T>) => ReactElement | null) & { displayName?: string | undefined };
 
 type forwardRefType = typeof forwardRef;
 

--- a/packages/components/src/utils.tsx
+++ b/packages/components/src/utils.tsx
@@ -4,7 +4,7 @@ import type { ReactElement, Ref, RefAttributes } from 'react';
 // biome-ignore lint/complexity/noBannedTypes: <explanation>
 declare function forwardRef<T, P = {}>(
 	render: (props: P, ref: Ref<T>) => ReactElement | null,
-): (props: P & RefAttributes<T>) => ReactElement | null;
+): ((props: P & RefAttributes<T>) => ReactElement | null) & { displayName?: string | undefined };
 
 type forwardRefType = typeof forwardRef;
 

--- a/packages/components/src/utils.tsx
+++ b/packages/components/src/utils.tsx
@@ -1,10 +1,11 @@
-import type { ReactElement, Ref, RefAttributes } from 'react';
+import type { NamedExoticComponent, ReactElement, Ref, RefAttributes } from 'react';
 
 // https://github.com/adobe/react-spectrum/blob/main/packages/react-aria-components/src/utils.tsx#L20-L24
 // biome-ignore lint/complexity/noBannedTypes: <explanation>
 declare function forwardRef<T, P = {}>(
 	render: (props: P, ref: Ref<T>) => ReactElement | null,
-): ((props: P & RefAttributes<T>) => ReactElement | null) & { displayName?: string | undefined };
+): ((props: P & RefAttributes<T>) => ReactElement | null) &
+	Pick<NamedExoticComponent, 'displayName'>;
 
 type forwardRefType = typeof forwardRef;
 


### PR DESCRIPTION
## Summary
Includes the `displayName` optional property from `forwardRef` so that wrapped components can be given display names, primarily for dev tools.

<!-- What is changing and why? -->

## Screenshots (if appropriate):

<!-- Are there any visual changes that would be helpful to the reviewer to see? -->

## Testing approaches

<!-- How are these changes tested? -->
