### PR TITLE
fix(alert): bump close specificity

### DIFF
--- a/.changeset/curly-bottles-marry.md
+++ b/.changeset/curly-bottles-marry.md
@@ -1,0 +1,6 @@
+---
+"@launchpad-ui/alert": patch
+"@launchpad-ui/core": patch
+---
+
+Bump alert close specificity

--- a/packages/alert/src/styles/Alert.module.css
+++ b/packages/alert/src/styles/Alert.module.css
@@ -193,7 +193,7 @@
   word-break: break-word;
 }
 
-.Alert-close {
+.Alert .Alert-close {
   margin-left: auto;
 }
 


### PR DESCRIPTION
## Summary

Address issue in Gonfalon where button styles are loaded after alert resulting in improper alignment. Once Alert gets rewritten with RAC and added to `components` these sort of issues won't happen.