### PR TITLE
test: use RAC `RouterProvider` to avoid jsdom error

### DIFF
--- a/packages/components/__tests__/LinkButton.spec.tsx
+++ b/packages/components/__tests__/LinkButton.spec.tsx
@@ -1,3 +1,4 @@
+import { RouterProvider } from 'react-aria-components';
 import { MemoryRouter } from 'react-router-dom';
 import { describe, expect, it, vi } from 'vitest';
 
@@ -19,11 +20,13 @@ describe('LinkButton', () => {
 		const user = userEvent.setup();
 
 		render(
-			<MemoryRouter>
-				<LinkButton to="/" onPress={spy}>
-					LinkButton
-				</LinkButton>
-			</MemoryRouter>,
+			<RouterProvider navigate={vi.fn()}>
+				<MemoryRouter>
+					<LinkButton to="/path" onPress={spy}>
+						LinkButton
+					</LinkButton>
+				</MemoryRouter>
+			</RouterProvider>,
 		);
 
 		await user.click(screen.getByRole('link'));


### PR DESCRIPTION
## Summary

Use RAC [RouterProvider](https://react-spectrum.adobe.com/react-aria/routing.html#routerprovider) to avoid the jsdom error `Error: Not implemented: navigation (except hash changes)` when `to` is more than `/`. Ran into this while adopting RAC links.