### PR TITLE
chore: tag deprecated components

### DIFF
--- a/.changeset/late-otters-grab.md
+++ b/.changeset/late-otters-grab.md
@@ -1,0 +1,25 @@
+---
+"@launchpad-ui/split-button": patch
+"@launchpad-ui/inline-edit": patch
+"@launchpad-ui/focus-trap": patch
+"@launchpad-ui/dropdown": patch
+"@launchpad-ui/progress": patch
+"@launchpad-ui/counter": patch
+"@launchpad-ui/overlay": patch
+"@launchpad-ui/popover": patch
+"@launchpad-ui/tooltip": patch
+"@launchpad-ui/button": patch
+"@launchpad-ui/drawer": patch
+"@launchpad-ui/filter": patch
+"@launchpad-ui/portal": patch
+"@launchpad-ui/select": patch
+"@launchpad-ui/toggle": patch
+"@launchpad-ui/modal": patch
+"@launchpad-ui/chip": patch
+"@launchpad-ui/form": patch
+"@launchpad-ui/menu": patch
+"@launchpad-ui/tag": patch
+"@launchpad-ui/core": patch
+---
+
+Tag deprecated components

--- a/packages/button/src/Button.tsx
+++ b/packages/button/src/Button.tsx
@@ -139,6 +139,11 @@ const ButtonComponent = forwardRef<HTMLButtonElement, ButtonProps>((props, ref) 
 
 ButtonComponent.displayName = 'Button';
 
+/**
+ * @deprecated use `Button` from `@launchpad-ui/components` instead
+ *
+ * https://launchpad.launchdarkly.com/?path=/docs/components-buttons-button--docs
+ */
 const Button = memo(ButtonComponent);
 
 export { Button };

--- a/packages/button/src/ButtonGroup.tsx
+++ b/packages/button/src/ButtonGroup.tsx
@@ -9,6 +9,11 @@ type ButtonGroupProps = ComponentProps<'div'> & {
 	'data-test-id'?: string;
 };
 
+/**
+ * @deprecated use `ButtonGroup` from `@launchpad-ui/components` instead
+ *
+ * https://launchpad.launchdarkly.com/?path=/docs/components-buttons-buttongroup--docs
+ */
 const ButtonGroup = ({
 	spacing = 'normal',
 	className,

--- a/packages/button/src/IconButton.tsx
+++ b/packages/button/src/IconButton.tsx
@@ -106,6 +106,11 @@ const IconButtonComponent = forwardRef<HTMLButtonElement, IconButtonProps>((prop
 
 IconButtonComponent.displayName = 'IconButton';
 
+/**
+ * @deprecated use `IconButton` from `@launchpad-ui/components` instead
+ *
+ * https://launchpad.launchdarkly.com/?path=/docs/components-buttons-iconbutton--docs
+ */
 const IconButton = memo(IconButtonComponent);
 
 export { IconButton };

--- a/packages/button/src/UploadButton.tsx
+++ b/packages/button/src/UploadButton.tsx
@@ -12,6 +12,11 @@ type UploadButtonProps = Omit<ButtonProps, 'onSelect'> & {
 	id: string;
 };
 
+/**
+ * @deprecated use `FileTrigger` from `@launchpad-ui/components` instead
+ *
+ * https://launchpad.launchdarkly.com/?path=/docs/components-buttons-filetrigger--docs
+ */
 const UploadButton = ({
 	id,
 	className,

--- a/packages/chip/src/Chip.tsx
+++ b/packages/chip/src/Chip.tsx
@@ -13,6 +13,11 @@ type ChipProps = ComponentProps<'span'> & {
 	'data-test-id'?: string;
 };
 
+/**
+ * @deprecated use `TagGroup` from `@launchpad-ui/components` instead
+ *
+ * https://launchpad.launchdarkly.com/?path=/docs/components-collections-taggroup--docs
+ */
 const Chip = ({
 	kind,
 	onClick,

--- a/packages/components/stories/ListBox.stories.tsx
+++ b/packages/components/stories/ListBox.stories.tsx
@@ -10,7 +10,7 @@ import { Header, ListBox, ListBoxItem, Section } from '../src';
 const meta: Meta<typeof ListBox> = {
 	component: ListBox,
 	// @ts-ignore
-	subcomponents: { ListBoxItem },
+	subcomponents: { ListBoxItem, Section, Header },
 	title: 'Components/Collections/ListBox',
 	parameters: {
 		status: {

--- a/packages/components/stories/Menu.stories.tsx
+++ b/packages/components/stories/Menu.stories.tsx
@@ -22,7 +22,7 @@ import {
 const meta: Meta<typeof Menu> = {
 	component: Menu,
 	// @ts-ignore
-	subcomponents: { MenuItem, MenuTrigger, SubmenuTrigger },
+	subcomponents: { MenuItem, MenuTrigger, SubmenuTrigger, Section, Header, Keyboard, Separator },
 	title: 'Components/Collections/Menu',
 	parameters: {
 		status: {

--- a/packages/components/stories/Modal.stories.tsx
+++ b/packages/components/stories/Modal.stories.tsx
@@ -10,7 +10,7 @@ import { Button, Dialog, DialogTrigger, Heading, IconButton, Modal, ModalOverlay
 const meta: Meta<typeof Modal> = {
 	component: Modal,
 	// @ts-ignore
-	subcomponents: { ModalOverlay, Dialog, DialogTrigger },
+	subcomponents: { ModalOverlay, Dialog, DialogTrigger, Heading },
 	title: 'Components/Overlays/Modal',
 	parameters: {
 		status: {

--- a/packages/components/stories/TextField.stories.tsx
+++ b/packages/components/stories/TextField.stories.tsx
@@ -3,10 +3,12 @@ import type { Meta, StoryFn, StoryObj } from '@storybook/react';
 import { vars } from '@launchpad-ui/vars';
 import { userEvent, within } from '@storybook/test';
 
-import { Input, Label, Text, TextArea, TextField } from '../src';
+import { FieldError, Input, Label, Text, TextArea, TextField } from '../src';
 
 const meta: Meta<typeof TextField> = {
 	component: TextField,
+	// @ts-ignore
+	subcomponents: { Label, Text, Input, TextArea, FieldError },
 	title: 'Components/Forms/TextField',
 	parameters: {
 		status: {

--- a/packages/counter/src/Counter.tsx
+++ b/packages/counter/src/Counter.tsx
@@ -11,6 +11,11 @@ type CounterProps = ComponentProps<'span'> & {
 	'data-test-id'?: string;
 };
 
+/**
+ * @deprecated use `TagGroup` from `@launchpad-ui/components` instead
+ *
+ * https://launchpad.launchdarkly.com/?path=/docs/components-collections-taggroup--docs
+ */
 const Counter = ({
 	value,
 	className,

--- a/packages/drawer/src/Drawer.tsx
+++ b/packages/drawer/src/Drawer.tsx
@@ -46,6 +46,11 @@ type DrawerProps = {
 	hideCancel?: boolean;
 };
 
+/**
+ * @deprecated use `Modal` from `@launchpad-ui/components` instead
+ *
+ * https://launchpad.launchdarkly.com/?path=/docs/components-overlays-modal--docs#drawer
+ */
 const Drawer = (props: DrawerProps) => (
 	<Portal>
 		<DrawerContainer {...props} />

--- a/packages/dropdown/src/Dropdown.tsx
+++ b/packages/dropdown/src/Dropdown.tsx
@@ -15,6 +15,11 @@ type DropdownProps<T extends string | object | number> = PopoverProps & {
 	onStateChange?: (state: DropdownState) => void;
 };
 
+/**
+ * @deprecated use `Menu` from `@launchpad-ui/components` instead
+ *
+ * https://launchpad.launchdarkly.com/?path=/docs/components-collections-menu--docs
+ */
 const Dropdown = <T extends string | object | number>(props: DropdownProps<T>) => {
 	const {
 		placement,

--- a/packages/filter/src/AppliedFilter.tsx
+++ b/packages/filter/src/AppliedFilter.tsx
@@ -27,6 +27,11 @@ type AppliedFilterProps = {
 	'data-test-id'?: string;
 };
 
+/**
+ * @deprecated use `Menu` from `@launchpad-ui/components` instead
+ *
+ * https://launchpad.launchdarkly.com/?path=/docs/components-collections-menu--docs
+ */
 const AppliedFilter = ({
 	searchValue,
 	onSearchChange,

--- a/packages/filter/src/Filter.tsx
+++ b/packages/filter/src/Filter.tsx
@@ -37,6 +37,11 @@ type FilterProps = Pick<MenuProps<string>, 'size' | 'enableVirtualization'> & {
 	clearAriaLabel?: string;
 };
 
+/**
+ * @deprecated use `Menu` from `@launchpad-ui/components` instead
+ *
+ * https://launchpad.launchdarkly.com/?path=/docs/components-collections-menu--docs
+ */
 const Filter = ({
 	searchValue,
 	onSearchChange,

--- a/packages/focus-trap/src/FocusTrap.tsx
+++ b/packages/focus-trap/src/FocusTrap.tsx
@@ -9,12 +9,20 @@ type FocusTrapContextType = {
 	contain: boolean;
 };
 
+/**
+ * @deprecated use attribute `data-react-aria-top-layer` for overlays in `@launchpad-ui/components` instead
+ *
+ * https://github.com/adobe/react-spectrum/discussions/6000#discussioncomment-8671656
+ */
 const FocusTrapContext = createContext<FocusTrapContextType>({
 	contain: true,
 });
 
 const useFocusTrapContext = () => useContext(FocusTrapContext);
 
+/**
+ * @deprecated not used for overlays in `@launchpad-ui/components`
+ */
 const FocusTrap = (props: FocusTrapProps) => {
 	const { contain } = useFocusTrapContext();
 

--- a/packages/form/src/Checkbox.tsx
+++ b/packages/form/src/Checkbox.tsx
@@ -13,6 +13,11 @@ type CheckboxProps = ComponentProps<'input'> & {
 	'data-test-id'?: string;
 };
 
+/**
+ * @deprecated use `Checkbox` or `CheckboxGroup` from `@launchpad-ui/components` instead
+ *
+ * https://launchpad.launchdarkly.com/?path=/docs/components-forms-checkbox--docs
+ */
 const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
 	(
 		{

--- a/packages/form/src/CompactTextField.tsx
+++ b/packages/form/src/CompactTextField.tsx
@@ -13,6 +13,11 @@ type CompactTextFieldProps = TextFieldProps & {
 	needsErrorFeedback?: boolean;
 };
 
+/**
+ * @deprecated use `TextField` from `@launchpad-ui/components` instead
+ *
+ * https://launchpad.launchdarkly.com/?path=/docs/components-forms-textfield--docs
+ */
 const CompactTextField = forwardRef<HTMLInputElement, CompactTextFieldProps>(
 	(
 		{

--- a/packages/form/src/FieldError.tsx
+++ b/packages/form/src/FieldError.tsx
@@ -13,6 +13,11 @@ type FieldErrorProps = ComponentProps<'span'> & {
 	'data-test-id'?: string;
 };
 
+/**
+ * @deprecated use `FieldError` from `@launchpad-ui/components` instead
+ *
+ * https://launchpad.launchdarkly.com/?path=/docs/components-forms-textfield--docs
+ */
 const FieldError = ({
 	name,
 	errorMessage,

--- a/packages/form/src/FieldSet.tsx
+++ b/packages/form/src/FieldSet.tsx
@@ -8,6 +8,11 @@ type FieldSetProps = ComponentProps<'fieldset'> & {
 	'data-test-id'?: string;
 };
 
+/**
+ * @deprecated use `FieldGroup` from `@launchpad-ui/components` instead
+ *
+ * https://launchpad.launchdarkly.com/?path=/docs/components-forms-fieldgroup--docs
+ */
 const FieldSet = ({
 	children,
 	className,

--- a/packages/form/src/Form.tsx
+++ b/packages/form/src/Form.tsx
@@ -14,6 +14,11 @@ type FormProps = ComponentProps<'form'> & {
 	'data-test-id'?: string;
 };
 
+/**
+ * @deprecated use `Form` from `@launchpad-ui/components` instead
+ *
+ * https://launchpad.launchdarkly.com/?path=/docs/components-forms-form--docs
+ */
 const Form = (props: FormProps) => {
 	const {
 		className,

--- a/packages/form/src/FormField.tsx
+++ b/packages/form/src/FormField.tsx
@@ -28,6 +28,11 @@ type FormFieldProps = {
 	FieldErrorProps?: Partial<FieldErrorProps>;
 };
 
+/**
+ * @deprecated use form elements from `@launchpad-ui/components` instead
+ *
+ * https://launchpad.launchdarkly.com/?path=/docs/components-forms-textfield--docs
+ */
 const FormField = ({
 	isRequired,
 	label,

--- a/packages/form/src/FormGroup.tsx
+++ b/packages/form/src/FormGroup.tsx
@@ -11,6 +11,11 @@ type FormGroupProps = ComponentProps<'fieldset'> & {
 	'data-test-id'?: string;
 };
 
+/**
+ * @deprecated use `FieldGroup` from `@launchpad-ui/components` instead
+ *
+ * https://launchpad.launchdarkly.com/?path=/docs/components-forms-fieldgroup--docs
+ */
 const FormGroup = (props: FormGroupProps) => {
 	const {
 		className,

--- a/packages/form/src/FormHint.tsx
+++ b/packages/form/src/FormHint.tsx
@@ -8,6 +8,11 @@ type FormHintProps = ComponentProps<'div'> & {
 	'data-test-id'?: string;
 };
 
+/**
+ * @deprecated use `Text` with `[slot='description']` from `@launchpad-ui/components` instead
+ *
+ * https://launchpad.launchdarkly.com/?path=/docs/components-forms-textfield--docs
+ */
 const FormHint = ({
 	className,
 	children,

--- a/packages/form/src/IconField.tsx
+++ b/packages/form/src/IconField.tsx
@@ -17,6 +17,11 @@ type IconFieldProps = ComponentProps<'div'> & {
 	ariaLabel?: string;
 };
 
+/**
+ * @deprecated use `Group` from `@launchpad-ui/components` instead
+ *
+ * https://launchpad.launchdarkly.com/?path=/docs/components-content-group--docs
+ */
 const IconField = ({
 	icon,
 	children,

--- a/packages/form/src/Label.tsx
+++ b/packages/form/src/Label.tsx
@@ -12,6 +12,11 @@ type LabelProps = ComponentProps<'label'> & {
 	'data-test-id'?: string;
 };
 
+/**
+ * @deprecated use `Label` from `@launchpad-ui/components` instead
+ *
+ * https://launchpad.launchdarkly.com/?path=/docs/components-forms-textfield--docs
+ */
 const Label = ({
 	disabled,
 	className,

--- a/packages/form/src/Radio.tsx
+++ b/packages/form/src/Radio.tsx
@@ -11,6 +11,11 @@ type RadioProps = Omit<ComponentProps<'input'>, 'type'> & {
 	'data-test-id'?: string;
 };
 
+/**
+ * @deprecated use `RadioGroup` from `@launchpad-ui/components` instead
+ *
+ * https://launchpad.launchdarkly.com/?path=/docs/components-forms-radiogroup--docs
+ */
 const Radio = ({
 	'aria-label': ariaLabel,
 	'aria-labelledby': ariaLabelledby,

--- a/packages/form/src/RadioGroup.tsx
+++ b/packages/form/src/RadioGroup.tsx
@@ -44,6 +44,11 @@ type RadioGroupProps = {
 	'data-test-id'?: string;
 };
 
+/**
+ * @deprecated use `RadioGroup` from `@launchpad-ui/components` instead
+ *
+ * https://launchpad.launchdarkly.com/?path=/docs/components-forms-radiogroup--docs
+ */
 const RadioGroup = (props: RadioGroupProps) => {
 	const {
 		name,

--- a/packages/form/src/RequiredAsterisk.tsx
+++ b/packages/form/src/RequiredAsterisk.tsx
@@ -8,6 +8,11 @@ type RequiredAsteriskProps = ComponentProps<'span'> & {
 	'data-test-id'?: string;
 };
 
+/**
+ * @deprecated use `Label` from `@launchpad-ui/components` instead
+ *
+ * https://launchpad.launchdarkly.com/?path=/docs/components-forms-textfield--docs
+ */
 const RequiredAsterisk = ({
 	className,
 	'data-test-id': testId = 'required-asterisk',

--- a/packages/form/src/SelectField.tsx
+++ b/packages/form/src/SelectField.tsx
@@ -9,6 +9,11 @@ type SelectFieldProps = ComponentProps<'select'> & {
 	'data-test-id'?: string;
 };
 
+/**
+ * @deprecated use `Select` from `@launchpad-ui/components` instead
+ *
+ * https://launchpad.launchdarkly.com/?path=/docs/components-pickers-select--docs
+ */
 const SelectField = forwardRef<HTMLSelectElement, SelectFieldProps>(
 	({ className, children, 'data-test-id': testId = 'select', ...rest }: SelectFieldProps, ref) => {
 		const classes = cx(styles.formInput, className);

--- a/packages/form/src/TextArea.tsx
+++ b/packages/form/src/TextArea.tsx
@@ -10,6 +10,11 @@ type TextAreaProps = ComponentProps<'textarea'> & {
 	'data-test-id'?: string;
 };
 
+/**
+ * @deprecated use `TextArea` from `@launchpad-ui/components` instead
+ *
+ * https://launchpad.launchdarkly.com/?path=/docs/components-forms-textfield--docs#multi%20line
+ */
 const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
 	({ className, 'data-test-id': testId = 'text-area', ...props }, ref) => {
 		const onKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {

--- a/packages/form/src/TextField.tsx
+++ b/packages/form/src/TextField.tsx
@@ -13,6 +13,11 @@ type TextFieldProps = ComponentProps<'input'> & {
 	'data-test-id'?: string;
 };
 
+/**
+ * @deprecated use `TextField` from `@launchpad-ui/components` instead
+ *
+ * https://launchpad.launchdarkly.com/?path=/docs/components-forms-textfield--docs
+ */
 const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
 	(
 		{

--- a/packages/inline-edit/src/InlineEdit.tsx
+++ b/packages/inline-edit/src/InlineEdit.tsx
@@ -29,6 +29,11 @@ type InlineEditProps = ComponentProps<'div'> &
 		confirmButtonLabel?: string;
 	};
 
+/**
+ * @deprecated use `minimal` variant for fields from `@launchpad-ui/components` instead
+ *
+ * https://launchpad.launchdarkly.com/?path=/docs/components-forms-textfield--docs#minimal
+ */
 const InlineEdit = forwardRef<HTMLInputElement, InlineEditProps>(
 	(
 		{

--- a/packages/menu/src/Menu.tsx
+++ b/packages/menu/src/Menu.tsx
@@ -62,6 +62,11 @@ type ControlledMenuProps<T> = {
 
 type MenuProps<T extends number | string> = ControlledMenuProps<T>;
 
+/**
+ * @deprecated use `Menu` or `ListBox` from `@launchpad-ui/components` instead
+ *
+ * https://launchpad.launchdarkly.com/?path=/docs/components-collections-menu--docs
+ */
 const Menu = <T extends number | string>(props: MenuProps<T>) => {
 	const {
 		children,

--- a/packages/modal/src/AbsoluteModalFooter.tsx
+++ b/packages/modal/src/AbsoluteModalFooter.tsx
@@ -7,6 +7,11 @@ import { ModalFooter } from './ModalFooter';
 import styles from './styles/Modal.module.css';
 import { useAbsoluteFooter } from './utils';
 
+/**
+ * @deprecated use `div[slot='footer']` with `Modal` from `@launchpad-ui/components` instead
+ *
+ * https://launchpad.launchdarkly.com/?path=/docs/components-overlays-modal--docs
+ */
 const AbsoluteModalFooter = ({ className, ...rest }: ModalFooterProps) => {
 	const ref = useRef<HTMLDivElement>(null);
 	useAbsoluteFooter(ref);

--- a/packages/modal/src/Modal.tsx
+++ b/packages/modal/src/Modal.tsx
@@ -17,6 +17,11 @@ type ModalProps = {
 	'data-test-id'?: string;
 };
 
+/**
+ * @deprecated use `Modal` from `@launchpad-ui/components` instead
+ *
+ * https://launchpad.launchdarkly.com/?path=/docs/components-overlays-modal--docs
+ */
 const Modal = ({
 	className,
 	onCancel,

--- a/packages/modal/src/ModalBody.tsx
+++ b/packages/modal/src/ModalBody.tsx
@@ -10,6 +10,11 @@ type ModalBodyProps = ComponentProps<'div'> & {
 	'data-test-id'?: string;
 };
 
+/**
+ * @deprecated use `div[slot='body']` with `Modal` from `@launchpad-ui/components` instead
+ *
+ * https://launchpad.launchdarkly.com/?path=/docs/components-overlays-modal--docs
+ */
 const ModalBody = ({
 	children,
 	className,

--- a/packages/modal/src/ModalFooter.tsx
+++ b/packages/modal/src/ModalFooter.tsx
@@ -12,6 +12,11 @@ type ModalFooterProps = HTMLAttributes<HTMLDivElement> & {
 	'data-test-id'?: string;
 };
 
+/**
+ * @deprecated use `div[slot='footer']` with `Modal` from `@launchpad-ui/components` instead
+ *
+ * https://launchpad.launchdarkly.com/?path=/docs/components-overlays-modal--docs
+ */
 const ModalFooter = forwardRef<HTMLDivElement, ModalFooterProps>(
 	(
 		{ secondaryButton, primaryButton, className, 'data-test-id': testId = 'modal-footer', ...rest },

--- a/packages/modal/src/ModalHeader.tsx
+++ b/packages/modal/src/ModalHeader.tsx
@@ -17,6 +17,11 @@ type ModalHeaderProps = {
 	'data-test-id'?: string;
 };
 
+/**
+ * @deprecated use `div[slot='header']` with `Modal` from `@launchpad-ui/components` instead
+ *
+ * https://launchpad.launchdarkly.com/?path=/docs/components-overlays-modal--docs
+ */
 const ModalHeader = ({
 	withCloseButton = true,
 	title,

--- a/packages/overlay/src/Overlay.tsx
+++ b/packages/overlay/src/Overlay.tsx
@@ -14,6 +14,9 @@ type OverlayProps = {
 	children?: ReactNode;
 };
 
+/**
+ * @deprecated not used for overlays in `@launchpad-ui/components`
+ */
 const Overlay = ({
 	isOpen,
 	lazy = true,

--- a/packages/popover/src/Popover.tsx
+++ b/packages/popover/src/Popover.tsx
@@ -101,12 +101,9 @@ const isOrContainsElement = (referenceElement: Element, element: Element) => {
 };
 
 /**
- * Popover component driven by floating-ui.
+ * @deprecated use `Popover` from `@launchpad-ui/components` instead
  *
- * If you need more control over the popover's behavior,
- * you may specify the `isOpen` prop to use the component
- * in controlled mode.
- *
+ * https://launchpad.launchdarkly.com/?path=/docs/components-overlays-popover--docs
  */
 const Popover = ({
 	rootElementTag = 'span',

--- a/packages/portal/src/Portal.tsx
+++ b/packages/portal/src/Portal.tsx
@@ -8,6 +8,9 @@ type PortalProps = ComponentProps<'div'> & {
 	'data-test-id'?: string;
 };
 
+/**
+ * @deprecated not used for overlays in `@launchpad-ui/components`
+ */
 const Portal = forwardRef<HTMLDivElement, PortalProps>(
 	(
 		{ container = globalThis?.document?.body, 'data-test-id': testId = 'portal', ...props },

--- a/packages/progress/src/Progress.tsx
+++ b/packages/progress/src/Progress.tsx
@@ -16,6 +16,11 @@ type ProgressProps = {
 const clamp = (number: number, lower: number, upper?: number) =>
 	upper ? Math.min(Math.max(number, lower), upper) : Math.min(number, lower);
 
+/**
+ * @deprecated use `ProgressBar` from `@launchpad-ui/components` instead
+ *
+ * https://launchpad.launchdarkly.com/?path=/docs/components-status-progressbar--docs
+ */
 const Progress = ({
 	value,
 	size = 'small',

--- a/packages/select/src/MultiSelect/MultiSelect.tsx
+++ b/packages/select/src/MultiSelect/MultiSelect.tsx
@@ -25,6 +25,11 @@ type MultiSelectProps<T extends object> = SharedSelectProps<T> &
 		isSelectableAll?: boolean;
 	};
 
+/**
+ * @deprecated use `Select` from `@launchpad-ui/components` instead
+ *
+ * https://launchpad.launchdarkly.com/?path=/docs/components-pickers-select--docs
+ */
 const MultiSelect = <T extends object>(props: MultiSelectProps<T>) => {
 	const {
 		autoFocus,

--- a/packages/select/src/SingleSelect/SingleSelect.tsx
+++ b/packages/select/src/SingleSelect/SingleSelect.tsx
@@ -20,6 +20,11 @@ type SingleSelectProps<T extends object> = SharedSelectProps<T> &
 		trigger?: (props: SingleSelectTriggerProps<T>) => JSX.Element;
 	};
 
+/**
+ * @deprecated use `Select` from `@launchpad-ui/components` instead
+ *
+ * https://launchpad.launchdarkly.com/?path=/docs/components-pickers-select--docs
+ */
 const SingleSelect = <T extends object>(props: SingleSelectProps<T>) => {
 	const {
 		autoFocus,

--- a/packages/split-button/src/SplitButton.tsx
+++ b/packages/split-button/src/SplitButton.tsx
@@ -13,6 +13,11 @@ type SplitButtonProps = ComponentProps<'div'> & {
 	'data-test-id'?: string;
 };
 
+/**
+ * @deprecated use `ButtonGroup` from `@launchpad-ui/components` instead
+ *
+ * https://launchpad.launchdarkly.com/?path=/docs/components-buttons-buttongroup--split-button
+ */
 const SplitButton = ({
 	disabled,
 	kind,

--- a/packages/tag/src/Tag.tsx
+++ b/packages/tag/src/Tag.tsx
@@ -26,6 +26,11 @@ type TagProps<T extends object> = AriaTagProps<T> & {
 	children: ReactNode;
 };
 
+/**
+ * @deprecated use `TagGroup` from `@launchpad-ui/components` instead
+ *
+ * https://launchpad.launchdarkly.com/?path=/docs/components-collections-taggroup--docs
+ */
 const Tag = <T extends object>(props: TagProps<T>) => {
 	const { children, item, state, onClick, size = 'small' } = props;
 

--- a/packages/tag/src/TagGroup.tsx
+++ b/packages/tag/src/TagGroup.tsx
@@ -31,6 +31,11 @@ type TagGroupProps<T extends object> = AriaTagGroupProps<T> & {
 	maxRows?: number;
 };
 
+/**
+ * @deprecated use `TagGroup` from `@launchpad-ui/components` instead
+ *
+ * https://launchpad.launchdarkly.com/?path=/docs/components-collections-taggroup--docs
+ */
 const TagGroup = <T extends object>(props: TagGroupProps<T>) => {
 	const {
 		onRemove,

--- a/packages/toggle/src/Toggle.tsx
+++ b/packages/toggle/src/Toggle.tsx
@@ -51,6 +51,11 @@ type ToggleProps = InputBase &
  * goodness (the useFocus hook is leveraged).
  */
 
+/**
+ * @deprecated use `Switch` from `@launchpad-ui/components` instead
+ *
+ * https://launchpad.launchdarkly.com/?path=/docs/components-forms-switch--docs
+ */
 const Toggle = (props: ToggleProps) => {
 	const { className, isDisabled = false, autoFocus, 'data-test-id': testId = 'toggle' } = props;
 

--- a/packages/tooltip/src/Tooltip.tsx
+++ b/packages/tooltip/src/Tooltip.tsx
@@ -12,6 +12,11 @@ type TooltipProps = Omit<PopoverProps, 'children'> & {
 	children?: ReactNode;
 };
 
+/**
+ * @deprecated use `Tooltip` from `@launchpad-ui/components` instead
+ *
+ * https://launchpad.launchdarkly.com/?path=/docs/components-overlays-tooltip--docs
+ */
 const TooltipBase = ({
 	className,
 	children,
@@ -37,6 +42,11 @@ const TooltipBase = ({
 	);
 };
 
+/**
+ * @deprecated use `Tooltip` from `@launchpad-ui/components` instead
+ *
+ * https://launchpad.launchdarkly.com/?path=/docs/components-overlays-tooltip--docs
+ */
 const Tooltip = forwardRef<Element, TooltipProps>((props, ref) => (
 	<TooltipBase {...props} targetElementRef={ref} />
 ));


### PR DESCRIPTION
## Summary

Tag deprecated components [with JSDoc](https://jsdoc.app/tags-deprecated).

## Screenshots (if appropriate):

<img width="715" alt="Screenshot 2024-04-04 at 11 15 40 AM" src="https://github.com/launchdarkly/launchpad-ui/assets/2147624/3d3ec5cc-94b5-4eeb-9a69-ddaadfe38bac">
