### PR TITLE
chore: add repository and license fields to package.json

### DIFF
--- a/.changeset/nervous-berries-play.md
+++ b/.changeset/nervous-berries-play.md
@@ -1,0 +1,50 @@
+---
+"@launchpad-ui/progress-bubbles": patch
+"@launchpad-ui/split-button": patch
+"@launchpad-ui/collapsible": patch
+"@launchpad-ui/inline-edit": patch
+"@launchpad-ui/components": patch
+"@launchpad-ui/data-table": patch
+"@launchpad-ui/focus-trap": patch
+"@launchpad-ui/navigation": patch
+"@launchpad-ui/pagination": patch
+"@launchpad-ui/clipboard": patch
+"@launchpad-ui/dropdown": patch
+"@launchpad-ui/markdown": patch
+"@launchpad-ui/progress": patch
+"@launchpad-ui/snackbar": patch
+"@launchpad-ui/tab-list": patch
+"@launchpad-ui/columns": patch
+"@launchpad-ui/counter": patch
+"@launchpad-ui/overlay": patch
+"@launchpad-ui/popover": patch
+"@launchpad-ui/tooltip": patch
+"@launchpad-ui/avatar": patch
+"@launchpad-ui/banner": patch
+"@launchpad-ui/button": patch
+"@launchpad-ui/drawer": patch
+"@launchpad-ui/filter": patch
+"@launchpad-ui/inline": patch
+"@launchpad-ui/portal": patch
+"@launchpad-ui/select": patch
+"@launchpad-ui/slider": patch
+"@launchpad-ui/toggle": patch
+"@launchpad-ui/tokens": patch
+"@launchpad-ui/alert": patch
+"@launchpad-ui/icons": patch
+"@launchpad-ui/modal": patch
+"@launchpad-ui/stack": patch
+"@launchpad-ui/table": patch
+"@launchpad-ui/toast": patch
+"@launchpad-ui/types": patch
+"@launchpad-ui/card": patch
+"@launchpad-ui/chip": patch
+"@launchpad-ui/core": patch
+"@launchpad-ui/form": patch
+"@launchpad-ui/menu": patch
+"@launchpad-ui/vars": patch
+"@launchpad-ui/box": patch
+"@launchpad-ui/tag": patch
+---
+
+Add repository and license fields to package.json

--- a/.plop/templates/component/package.json.hbs
+++ b/.plop/templates/component/package.json.hbs
@@ -5,7 +5,13 @@
   "publishConfig": {
     "access": "public"
   },
+  "repository": {
+		"type": "git",
+		"url": "https://github.com/launchdarkly/launchpad-ui",
+    "directory": "packages/{{kebabCase name}}"
+	},
   "description": "{{description}}",
+  "license": "Apache-2.0",
   "files": [
     "dist"
   ],

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
 		"url": "git+https://github.com/launchdarkly/launchpad-ui.git"
 	},
 	"author": "Catamorphic Co.",
-	"license": "",
+	"license": "Apache-2.0",
 	"bugs": {
 		"url": "https://github.com/launchdarkly/launchpad-ui/issues"
 	},

--- a/packages/alert/package.json
+++ b/packages/alert/package.json
@@ -5,7 +5,12 @@
 	"publishConfig": {
 		"access": "public"
 	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/launchdarkly/launchpad-ui"
+	},
 	"description": "An element that informs users of a state or function of the product at a more granular level than banners.",
+	"license": "Apache-2.0",
 	"files": ["dist"],
 	"main": "dist/index.js",
 	"module": "dist/index.es.js",

--- a/packages/avatar/package.json
+++ b/packages/avatar/package.json
@@ -5,7 +5,12 @@
 	"publishConfig": {
 		"access": "public"
 	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/launchdarkly/launchpad-ui"
+	},
 	"description": "An element that represents a user visually.",
+	"license": "Apache-2.0",
 	"files": ["dist"],
 	"main": "dist/index.js",
 	"module": "dist/index.es.js",

--- a/packages/banner/package.json
+++ b/packages/banner/package.json
@@ -5,7 +5,12 @@
 	"publishConfig": {
 		"access": "public"
 	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/launchdarkly/launchpad-ui"
+	},
 	"description": "An element that contains a system-wide message or status.",
+	"license": "Apache-2.0",
 	"files": ["dist"],
 	"main": "dist/index.js",
 	"module": "dist/index.es.js",

--- a/packages/box/package.json
+++ b/packages/box/package.json
@@ -5,7 +5,12 @@
 	"publishConfig": {
 		"access": "public"
 	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/launchdarkly/launchpad-ui"
+	},
 	"description": "A polymorphic React component with design token sprinkles.",
+	"license": "Apache-2.0",
 	"files": ["dist"],
 	"main": "dist/index.js",
 	"module": "dist/index.es.js",

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -5,7 +5,12 @@
 	"publishConfig": {
 		"access": "public"
 	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/launchdarkly/launchpad-ui"
+	},
 	"description": "An element that triggers an action based on user interaction.",
+	"license": "Apache-2.0",
 	"files": ["dist"],
 	"main": "dist/index.js",
 	"module": "dist/index.es.js",

--- a/packages/card/package.json
+++ b/packages/card/package.json
@@ -5,7 +5,12 @@
 	"publishConfig": {
 		"access": "public"
 	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/launchdarkly/launchpad-ui"
+	},
 	"description": "",
+	"license": "Apache-2.0",
 	"files": ["dist"],
 	"main": "dist/index.js",
 	"module": "dist/index.es.js",

--- a/packages/chip/package.json
+++ b/packages/chip/package.json
@@ -5,7 +5,12 @@
 	"publishConfig": {
 		"access": "public"
 	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/launchdarkly/launchpad-ui"
+	},
 	"description": "An element representing keywords that categorize feature states for quick recognition.",
+	"license": "Apache-2.0",
 	"files": ["dist"],
 	"main": "dist/index.js",
 	"module": "dist/index.es.js",

--- a/packages/clipboard/package.json
+++ b/packages/clipboard/package.json
@@ -5,7 +5,12 @@
 	"publishConfig": {
 		"access": "public"
 	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/launchdarkly/launchpad-ui"
+	},
 	"description": "An element that copies text to the clipboard.",
+	"license": "Apache-2.0",
 	"files": ["dist"],
 	"main": "dist/index.js",
 	"module": "dist/index.es.js",

--- a/packages/collapsible/package.json
+++ b/packages/collapsible/package.json
@@ -5,7 +5,12 @@
 	"publishConfig": {
 		"access": "public"
 	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/launchdarkly/launchpad-ui"
+	},
 	"description": "A progressive disclosure component that allows the user to to click a trigger to show more content",
+	"license": "Apache-2.0",
 	"files": ["dist"],
 	"main": "dist/index.js",
 	"module": "dist/index.es.js",

--- a/packages/columns/package.json
+++ b/packages/columns/package.json
@@ -5,7 +5,12 @@
 	"publishConfig": {
 		"access": "public"
 	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/launchdarkly/launchpad-ui"
+	},
 	"description": "Elements used to lay out content horizontally with consistent spacing.",
+	"license": "Apache-2.0",
 	"files": ["dist"],
 	"main": "dist/index.js",
 	"module": "dist/index.es.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -5,7 +5,13 @@
 	"publishConfig": {
 		"access": "public"
 	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/launchdarkly/launchpad-ui",
+		"directory": "packages/components"
+	},
 	"description": "An implementation of LaunchDarkly's LaunchPad Design System using React Aria Components.",
+	"license": "Apache-2.0",
 	"files": ["dist"],
 	"main": "dist/index.js",
 	"module": "dist/index.es.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,13 +5,14 @@
 	"publishConfig": {
 		"access": "public"
 	},
-	"description": "Contains all LaunchPad design system packages.",
-	"files": ["dist"],
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/launchdarkly/launchpad-ui",
 		"directory": "packages/core"
 	},
+	"description": "Contains all LaunchPad design system packages.",
+	"license": "Apache-2.0",
+	"files": ["dist"],
 	"main": "dist/index.js",
 	"module": "dist/index.es.js",
 	"types": "dist/index.d.ts",

--- a/packages/counter/package.json
+++ b/packages/counter/package.json
@@ -5,7 +5,12 @@
 	"publishConfig": {
 		"access": "public"
 	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/launchdarkly/launchpad-ui"
+	},
 	"description": "Indicates the count value of a resource.",
+	"license": "Apache-2.0",
 	"files": ["dist"],
 	"main": "dist/index.js",
 	"module": "dist/index.es.js",

--- a/packages/data-table/package.json
+++ b/packages/data-table/package.json
@@ -5,7 +5,12 @@
 	"publishConfig": {
 		"access": "public"
 	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/launchdarkly/launchpad-ui"
+	},
 	"description": "An element used to display data in rows and columns.",
+	"license": "Apache-2.0",
 	"files": ["dist"],
 	"main": "dist/index.js",
 	"module": "dist/index.es.js",

--- a/packages/drawer/package.json
+++ b/packages/drawer/package.json
@@ -5,7 +5,12 @@
 	"publishConfig": {
 		"access": "public"
 	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/launchdarkly/launchpad-ui"
+	},
 	"description": "A partial overlay that appears from the right side of the screen.",
+	"license": "Apache-2.0",
 	"files": ["dist"],
 	"main": "dist/index.js",
 	"module": "dist/index.es.js",

--- a/packages/dropdown/package.json
+++ b/packages/dropdown/package.json
@@ -5,7 +5,12 @@
 	"publishConfig": {
 		"access": "public"
 	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/launchdarkly/launchpad-ui"
+	},
 	"description": "An element that displays a list of actions or options to a user.",
+	"license": "Apache-2.0",
 	"files": ["dist"],
 	"main": "dist/index.js",
 	"module": "dist/index.es.js",

--- a/packages/filter/package.json
+++ b/packages/filter/package.json
@@ -5,7 +5,12 @@
 	"publishConfig": {
 		"access": "public"
 	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/launchdarkly/launchpad-ui"
+	},
 	"description": "filter a list of results",
+	"license": "Apache-2.0",
 	"files": ["dist"],
 	"main": "dist/index.js",
 	"module": "dist/index.es.js",

--- a/packages/focus-trap/package.json
+++ b/packages/focus-trap/package.json
@@ -5,7 +5,12 @@
 	"publishConfig": {
 		"access": "public"
 	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/launchdarkly/launchpad-ui"
+	},
 	"description": "An internal utility not intended for public usage.",
+	"license": "Apache-2.0",
 	"files": ["dist"],
 	"main": "dist/index.js",
 	"module": "dist/index.es.js",

--- a/packages/form/package.json
+++ b/packages/form/package.json
@@ -5,7 +5,12 @@
 	"publishConfig": {
 		"access": "public"
 	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/launchdarkly/launchpad-ui"
+	},
 	"description": "Elements for composing forms, such as input fields, labels, radio buttons, etc.",
+	"license": "Apache-2.0",
 	"files": ["dist"],
 	"main": "dist/index.js",
 	"module": "dist/index.es.js",

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -5,7 +5,13 @@
 	"publishConfig": {
 		"access": "public"
 	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/launchdarkly/launchpad-ui",
+		"directory": "packages/icons"
+	},
 	"description": "An element that supplements content and represents an action or feature within LaunchDarkly.",
+	"license": "Apache-2.0",
 	"files": ["dist"],
 	"main": "dist/index.js",
 	"module": "dist/index.es.js",

--- a/packages/inline-edit/package.json
+++ b/packages/inline-edit/package.json
@@ -5,7 +5,12 @@
 	"publishConfig": {
 		"access": "public"
 	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/launchdarkly/launchpad-ui"
+	},
 	"description": "An element used to display and allow inline editing of a form element value.",
+	"license": "Apache-2.0",
 	"files": ["dist"],
 	"main": "dist/index.js",
 	"module": "dist/index.es.js",

--- a/packages/inline/package.json
+++ b/packages/inline/package.json
@@ -5,7 +5,12 @@
 	"publishConfig": {
 		"access": "public"
 	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/launchdarkly/launchpad-ui"
+	},
 	"description": "An element used to add horizontal space between components.",
+	"license": "Apache-2.0",
 	"files": ["dist"],
 	"main": "dist/index.js",
 	"module": "dist/index.es.js",

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -5,7 +5,12 @@
 	"publishConfig": {
 		"access": "public"
 	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/launchdarkly/launchpad-ui"
+	},
 	"description": "Render formatted plaintext.",
+	"license": "Apache-2.0",
 	"files": ["dist"],
 	"main": "dist/index.js",
 	"module": "dist/index.es.js",

--- a/packages/menu/package.json
+++ b/packages/menu/package.json
@@ -5,7 +5,12 @@
 	"publishConfig": {
 		"access": "public"
 	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/launchdarkly/launchpad-ui"
+	},
 	"description": "An element that presents a list of items a user can choose from.",
+	"license": "Apache-2.0",
 	"files": ["dist"],
 	"main": "dist/index.js",
 	"module": "dist/index.es.js",

--- a/packages/modal/package.json
+++ b/packages/modal/package.json
@@ -5,7 +5,12 @@
 	"publishConfig": {
 		"access": "public"
 	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/launchdarkly/launchpad-ui"
+	},
 	"description": "An element that presents users information and actions over a page.",
+	"license": "Apache-2.0",
 	"files": ["dist"],
 	"main": "dist/index.js",
 	"module": "dist/index.es.js",

--- a/packages/navigation/package.json
+++ b/packages/navigation/package.json
@@ -5,7 +5,12 @@
 	"publishConfig": {
 		"access": "public"
 	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/launchdarkly/launchpad-ui"
+	},
 	"description": "An element used to provide navigation links to help users move through an app.",
+	"license": "Apache-2.0",
 	"files": ["dist"],
 	"main": "dist/index.js",
 	"module": "dist/index.es.js",

--- a/packages/overlay/package.json
+++ b/packages/overlay/package.json
@@ -5,7 +5,12 @@
 	"publishConfig": {
 		"access": "public"
 	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/launchdarkly/launchpad-ui"
+	},
 	"description": "An element that manages modals and popovers.",
+	"license": "Apache-2.0",
 	"files": ["dist"],
 	"main": "dist/index.js",
 	"module": "dist/index.es.js",

--- a/packages/pagination/package.json
+++ b/packages/pagination/package.json
@@ -5,7 +5,12 @@
 	"publishConfig": {
 		"access": "public"
 	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/launchdarkly/launchpad-ui"
+	},
 	"description": "Navigate through a paged list.",
+	"license": "Apache-2.0",
 	"files": ["dist"],
 	"main": "dist/index.js",
 	"module": "dist/index.es.js",

--- a/packages/popover/package.json
+++ b/packages/popover/package.json
@@ -5,7 +5,12 @@
 	"publishConfig": {
 		"access": "public"
 	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/launchdarkly/launchpad-ui"
+	},
 	"description": "An element that displays content within a portal triggered by user interactions.",
+	"license": "Apache-2.0",
 	"files": ["dist"],
 	"main": "dist/index.js",
 	"module": "dist/index.es.js",

--- a/packages/portal/package.json
+++ b/packages/portal/package.json
@@ -5,7 +5,12 @@
 	"publishConfig": {
 		"access": "public"
 	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/launchdarkly/launchpad-ui"
+	},
 	"description": "An element that renders a subtree in a different part of the DOM.",
+	"license": "Apache-2.0",
 	"files": ["dist"],
 	"main": "dist/index.js",
 	"module": "dist/index.es.js",

--- a/packages/progress-bubbles/package.json
+++ b/packages/progress-bubbles/package.json
@@ -5,7 +5,12 @@
 	"publishConfig": {
 		"access": "public"
 	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/launchdarkly/launchpad-ui"
+	},
 	"description": "Shows current progress through a multistep flow.",
+	"license": "Apache-2.0",
 	"files": ["dist"],
 	"main": "dist/index.js",
 	"module": "dist/index.es.js",

--- a/packages/progress/package.json
+++ b/packages/progress/package.json
@@ -5,7 +5,12 @@
 	"publishConfig": {
 		"access": "public"
 	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/launchdarkly/launchpad-ui"
+	},
 	"description": "An element that indicates a page or content is loading.",
+	"license": "Apache-2.0",
 	"files": ["dist"],
 	"main": "dist/index.js",
 	"module": "dist/index.es.js",

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -5,7 +5,12 @@
 	"publishConfig": {
 		"access": "public"
 	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/launchdarkly/launchpad-ui"
+	},
 	"description": "Select dropdowns supporting single and multi select.",
+	"license": "Apache-2.0",
 	"files": ["dist"],
 	"main": "dist/index.js",
 	"module": "dist/index.es.js",

--- a/packages/slider/package.json
+++ b/packages/slider/package.json
@@ -5,7 +5,12 @@
 	"publishConfig": {
 		"access": "public"
 	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/launchdarkly/launchpad-ui"
+	},
 	"description": "An element used to set a value within a range.",
+	"license": "Apache-2.0",
 	"files": ["dist"],
 	"main": "dist/index.js",
 	"module": "dist/index.es.js",

--- a/packages/snackbar/package.json
+++ b/packages/snackbar/package.json
@@ -5,7 +5,12 @@
 	"publishConfig": {
 		"access": "public"
 	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/launchdarkly/launchpad-ui"
+	},
 	"description": "An element that provides brief messages about app processes with a CTA.",
+	"license": "Apache-2.0",
 	"files": ["dist"],
 	"main": "dist/index.js",
 	"module": "dist/index.es.js",

--- a/packages/split-button/package.json
+++ b/packages/split-button/package.json
@@ -5,7 +5,12 @@
 	"publishConfig": {
 		"access": "public"
 	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/launchdarkly/launchpad-ui"
+	},
 	"description": "An element that presents an immediate action and additional options from a dropdown.",
+	"license": "Apache-2.0",
 	"files": ["dist"],
 	"main": "dist/index.js",
 	"module": "dist/index.es.js",

--- a/packages/stack/package.json
+++ b/packages/stack/package.json
@@ -5,7 +5,12 @@
 	"publishConfig": {
 		"access": "public"
 	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/launchdarkly/launchpad-ui"
+	},
 	"description": "An element used to add space between components.",
+	"license": "Apache-2.0",
 	"files": ["dist"],
 	"main": "dist/index.js",
 	"module": "dist/index.es.js",

--- a/packages/tab-list/package.json
+++ b/packages/tab-list/package.json
@@ -5,7 +5,12 @@
 	"publishConfig": {
 		"access": "public"
 	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/launchdarkly/launchpad-ui"
+	},
 	"description": "An element that navigates between related sections of content on the same page.",
+	"license": "Apache-2.0",
 	"files": ["dist"],
 	"main": "dist/index.js",
 	"module": "dist/index.es.js",

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -5,7 +5,12 @@
 	"publishConfig": {
 		"access": "public"
 	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/launchdarkly/launchpad-ui"
+	},
 	"description": "An element used to organize and display data to users.",
+	"license": "Apache-2.0",
 	"files": ["dist"],
 	"main": "dist/index.js",
 	"module": "dist/index.es.js",

--- a/packages/tag/package.json
+++ b/packages/tag/package.json
@@ -5,7 +5,12 @@
 	"publishConfig": {
 		"access": "public"
 	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/launchdarkly/launchpad-ui"
+	},
 	"description": "Tags allow users to categorize content. They can represent keywords or people, and are grouped to describe an item or a search request.",
+	"license": "Apache-2.0",
 	"files": ["dist"],
 	"main": "dist/index.js",
 	"module": "dist/index.es.js",

--- a/packages/toast/package.json
+++ b/packages/toast/package.json
@@ -5,7 +5,12 @@
 	"publishConfig": {
 		"access": "public"
 	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/launchdarkly/launchpad-ui"
+	},
 	"description": "Contains a concise message that indicates the completion of a task that requires no user interactions. ",
+	"license": "Apache-2.0",
 	"files": ["dist"],
 	"main": "dist/index.js",
 	"module": "dist/index.es.js",

--- a/packages/toggle/package.json
+++ b/packages/toggle/package.json
@@ -5,7 +5,12 @@
 	"publishConfig": {
 		"access": "public"
 	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/launchdarkly/launchpad-ui"
+	},
 	"description": "An element that represents on/off values as opposed to selection.",
+	"license": "Apache-2.0",
 	"files": ["dist"],
 	"main": "dist/index.js",
 	"module": "dist/index.es.js",

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -5,7 +5,13 @@
 	"publishConfig": {
 		"access": "public"
 	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/launchdarkly/launchpad-ui",
+		"directory": "packages/tokens"
+	},
 	"description": "LaunchPad design tokens delivered as CSS custom properties, CommonJS modules, and ES modules.",
+	"license": "Apache-2.0",
 	"files": ["dist"],
 	"type": "module",
 	"style": "dist/index.css",

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -5,7 +5,12 @@
 	"publishConfig": {
 		"access": "public"
 	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/launchdarkly/launchpad-ui"
+	},
 	"description": "An element that provides additional information on hover or focus.",
+	"license": "Apache-2.0",
 	"files": ["dist"],
 	"main": "dist/index.js",
 	"module": "dist/index.es.js",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -5,7 +5,12 @@
 	"publishConfig": {
 		"access": "public"
 	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/launchdarkly/launchpad-ui"
+	},
 	"description": "Shared types for LaunchPad components.",
+	"license": "Apache-2.0",
 	"files": ["dist"],
 	"types": "dist/index.d.ts",
 	"sideEffects": false,

--- a/packages/vars/package.json
+++ b/packages/vars/package.json
@@ -5,7 +5,12 @@
 	"publishConfig": {
 		"access": "public"
 	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/launchdarkly/launchpad-ui"
+	},
 	"description": "Vanilla Extract design token references for LaunchPad styles.",
+	"license": "Apache-2.0",
 	"files": ["dist"],
 	"main": "dist/index.js",
 	"module": "dist/index.es.js",


### PR DESCRIPTION
## Summary

So that the information is shown on their npm pages.