### PR TITLE
fix(components): update `Menu` selection states

### DIFF
--- a/.changeset/kind-turtles-mix.md
+++ b/.changeset/kind-turtles-mix.md
@@ -1,0 +1,5 @@
+---
+"@launchpad-ui/components": patch
+---
+
+Update `Menu` selection states

--- a/packages/components/src/Checkbox.tsx
+++ b/packages/components/src/Checkbox.tsx
@@ -1,5 +1,5 @@
 import type { ForwardedRef } from 'react';
-import type { CheckboxProps } from 'react-aria-components';
+import type { CheckboxProps, CheckboxRenderProps } from 'react-aria-components';
 
 import { Icon } from '@launchpad-ui/icons';
 import { cva } from 'class-variance-authority';
@@ -10,6 +10,16 @@ import styles from './styles/Checkbox.module.css';
 
 const checkbox = cva(styles.checkbox);
 const box = cva(styles.box);
+
+const CheckboxInner = ({ isSelected, isIndeterminate }: Partial<CheckboxRenderProps>) => (
+	<div className={box()}>
+		{isIndeterminate ? (
+			<Icon name="minus" size="small" className={styles.icon} />
+		) : isSelected ? (
+			<Icon name="check" size="small" className={styles.icon} />
+		) : null}
+	</div>
+);
 
 const _Checkbox = (props: CheckboxProps, ref: ForwardedRef<HTMLLabelElement>) => {
 	return (
@@ -22,13 +32,7 @@ const _Checkbox = (props: CheckboxProps, ref: ForwardedRef<HTMLLabelElement>) =>
 		>
 			{composeRenderProps(props.children, (children, { isSelected, isIndeterminate }) => (
 				<>
-					<div className={box()}>
-						{isIndeterminate ? (
-							<Icon name="minus" size="small" className={styles.icon} />
-						) : isSelected ? (
-							<Icon name="check" size="small" className={styles.icon} />
-						) : null}
-					</div>
+					<CheckboxInner isSelected={isSelected} isIndeterminate={isIndeterminate} />
 					{children}
 				</>
 			))}
@@ -43,5 +47,5 @@ const _Checkbox = (props: CheckboxProps, ref: ForwardedRef<HTMLLabelElement>) =>
  */
 const Checkbox = forwardRef(_Checkbox);
 
-export { Checkbox };
+export { Checkbox, CheckboxInner, checkbox };
 export type { CheckboxProps };

--- a/packages/components/src/Menu.tsx
+++ b/packages/components/src/Menu.tsx
@@ -19,9 +19,8 @@ import {
 	composeRenderProps,
 } from 'react-aria-components';
 
-import { Checkbox } from './Checkbox';
-import { Radio } from './Radio';
-import { RadioGroup } from './RadioGroup';
+import { CheckboxInner, checkbox } from './Checkbox';
+import { RadioInner, radio } from './Radio';
 import styles from './styles/Menu.module.css';
 
 const menu = cva(styles.menu);
@@ -66,18 +65,32 @@ const _MenuItem = <T extends object>(
 				item({ ...renderProps, variant, className }),
 			)}
 		>
-			{composeRenderProps(props.children, (children, { selectionMode, isSelected, hasSubmenu }) => (
-				<>
-					{selectionMode === 'multiple' && <Checkbox isReadOnly isSelected={isSelected} />}
-					{selectionMode === 'single' && (
-						<RadioGroup isReadOnly value={isSelected ? '' : undefined}>
-							<Radio value="" />
-						</RadioGroup>
-					)}
-					{children}
-					{hasSubmenu && <Icon name="chevron-right" size="small" className={styles.submenu} />}
-				</>
-			))}
+			{composeRenderProps(
+				props.children,
+				(children, { selectionMode, isSelected, hasSubmenu, isDisabled }) => (
+					<>
+						{selectionMode === 'multiple' && (
+							<div
+								className={checkbox({ className: styles.check })}
+								data-selected={isSelected || undefined}
+								data-disabled={isDisabled || undefined}
+							>
+								<CheckboxInner isSelected={isSelected} />
+							</div>
+						)}
+						{selectionMode === 'single' && (
+							<div
+								className={radio({ className: styles.check })}
+								data-disabled={isDisabled || undefined}
+							>
+								<RadioInner isSelected={isSelected} />
+							</div>
+						)}
+						{children}
+						{hasSubmenu && <Icon name="chevron-right" size="small" className={styles.submenu} />}
+					</>
+				),
+			)}
 		</AriaMenuItem>
 	);
 };

--- a/packages/components/src/Menu.tsx
+++ b/packages/components/src/Menu.tsx
@@ -19,6 +19,9 @@ import {
 	composeRenderProps,
 } from 'react-aria-components';
 
+import { Checkbox } from './Checkbox';
+import { Radio } from './Radio';
+import { RadioGroup } from './RadioGroup';
 import styles from './styles/Menu.module.css';
 
 const menu = cva(styles.menu);
@@ -65,8 +68,11 @@ const _MenuItem = <T extends object>(
 		>
 			{composeRenderProps(props.children, (children, { selectionMode, isSelected, hasSubmenu }) => (
 				<>
-					{selectionMode !== 'none' && (
-						<span className={styles.check}>{isSelected && <Icon name="check" size="small" />}</span>
+					{selectionMode === 'multiple' && <Checkbox isReadOnly isSelected={isSelected} />}
+					{selectionMode === 'single' && (
+						<RadioGroup isReadOnly value={isSelected ? '' : undefined}>
+							<Radio value="" />
+						</RadioGroup>
 					)}
 					{children}
 					{hasSubmenu && <Icon name="chevron-right" size="small" className={styles.submenu} />}

--- a/packages/components/src/Radio.tsx
+++ b/packages/components/src/Radio.tsx
@@ -1,5 +1,5 @@
 import type { ForwardedRef } from 'react';
-import type { RadioProps } from 'react-aria-components';
+import type { RadioProps, RadioRenderProps } from 'react-aria-components';
 
 import { Icon } from '@launchpad-ui/icons';
 import { cva } from 'class-variance-authority';
@@ -10,6 +10,12 @@ import styles from './styles/Radio.module.css';
 
 const radio = cva(styles.radio);
 const circle = cva(styles.circle);
+
+const RadioInner = ({ isSelected }: Partial<RadioRenderProps>) => (
+	<div className={circle()}>
+		{isSelected ? <Icon name="circle" className={styles.icon} /> : null}
+	</div>
+);
 
 const _Radio = (props: RadioProps, ref: ForwardedRef<HTMLLabelElement>) => {
 	return (
@@ -22,9 +28,7 @@ const _Radio = (props: RadioProps, ref: ForwardedRef<HTMLLabelElement>) => {
 		>
 			{composeRenderProps(props.children, (children, { isSelected }) => (
 				<>
-					<div className={circle()}>
-						{isSelected ? <Icon name="circle" className={styles.icon} /> : null}
-					</div>
+					<RadioInner isSelected={isSelected} />
 					{children}
 				</>
 			))}
@@ -39,5 +43,5 @@ const _Radio = (props: RadioProps, ref: ForwardedRef<HTMLLabelElement>) => {
  */
 const Radio = forwardRef(_Radio);
 
-export { Radio };
+export { Radio, RadioInner, radio };
 export type { RadioProps };

--- a/packages/components/src/styles/Checkbox.module.css
+++ b/packages/components/src/styles/Checkbox.module.css
@@ -7,7 +7,7 @@
   height: var(--lp-size-16);
   border-radius: 2px;
   border: var(--lp-border-width-200) solid var(--lp-color-border-field-base);
-  background: var(--lp-color-white-100);
+  background: var(--lp-color-bg-field-base);
   transition:
     all var(--lp-duration-100) ease-in-out,
     outline,

--- a/packages/components/src/styles/Header.module.css
+++ b/packages/components/src/styles/Header.module.css
@@ -2,8 +2,4 @@
   font: var(--lp-label-2-medium);
   color: var(--lp-color-text-ui-tertiary);
   padding-inline: var(--lp-spacing-200);
-
-  &:has(+ [data-selection-mode]:is([role='menuitemcheckbox'], [role='menuitemradio'])) {
-    padding-left: var(--lp-spacing-800);
-  }
 }

--- a/packages/components/src/styles/Menu.module.css
+++ b/packages/components/src/styles/Menu.module.css
@@ -99,7 +99,6 @@
 
 .check {
   grid-area: check;
-  width: var(--lp-size-16);
 }
 
 .submenu {

--- a/packages/components/src/styles/Menu.module.css
+++ b/packages/components/src/styles/Menu.module.css
@@ -16,7 +16,7 @@
 
 .item {
   padding-block: var(--lp-spacing-200);
-  padding-inline: var(--lp-spacing-200);
+  padding-inline: var(--lp-spacing-300);
   border-radius: var(--lp-border-radius-regular);
   outline: none;
   cursor: default;

--- a/packages/components/src/styles/Radio.module.css
+++ b/packages/components/src/styles/Radio.module.css
@@ -6,7 +6,7 @@
   height: var(--lp-size-16);
   border-radius: 100%;
   border: var(--lp-border-width-200) solid var(--lp-color-border-field-base);
-  background: var(--lp-color-white-100);
+  background: var(--lp-color-bg-field-base);
   transition:
     all var(--lp-duration-100) ease-in-out,
     outline,

--- a/packages/components/src/styles/RadioGroup.module.css
+++ b/packages/components/src/styles/RadioGroup.module.css
@@ -3,7 +3,6 @@
   flex-direction: column;
   align-items: flex-start;
   gap: var(--lp-spacing-200);
-  margin-bottom: var(--lp-spacing-300);
 
   &[data-orientation='horizontal'] {
     flex-direction: row;

--- a/packages/components/src/styles/RadioGroup.module.css
+++ b/packages/components/src/styles/RadioGroup.module.css
@@ -3,6 +3,7 @@
   flex-direction: column;
   align-items: flex-start;
   gap: var(--lp-spacing-200);
+  margin-bottom: var(--lp-spacing-300);
 
   &[data-orientation='horizontal'] {
     flex-direction: row;

--- a/packages/components/stories/Menu.stories.tsx
+++ b/packages/components/stories/Menu.stories.tsx
@@ -29,6 +29,9 @@ const meta: Meta<typeof Menu> = {
 			type: import.meta.env.STORYBOOK_PACKAGE_STATUS__COMPONENTS,
 		},
 		chromatic: { pauseAnimationAtEnd: true },
+		a11y: {
+			element: '[data-trigger]',
+		},
 	},
 	decorators: [
 		(Story: StoryFn) => (

--- a/packages/components/stories/Menu.stories.tsx
+++ b/packages/components/stories/Menu.stories.tsx
@@ -97,7 +97,7 @@ export const Grouping: Story = {
 	...open,
 };
 
-export const Selection: Story = {
+export const SingleSelection: Story = {
 	render: (args) => {
 		const [selected, setSelected] = useState<AriaSelection>(new Set(['react-aria-1']));
 
@@ -109,6 +109,22 @@ export const Selection: Story = {
 	},
 	args: {
 		selectionMode: 'single',
+	},
+	...open,
+};
+
+export const MultipleSelection: Story = {
+	render: (args) => {
+		const [selected, setSelected] = useState<AriaSelection>(new Set(['react-aria-1']));
+
+		return renderMenu({
+			selectedKeys: selected,
+			onSelectionChange: setSelected,
+			...args,
+		});
+	},
+	args: {
+		selectionMode: 'multiple',
 	},
 	...open,
 };

--- a/packages/components/stories/Modal.stories.tsx
+++ b/packages/components/stories/Modal.stories.tsx
@@ -17,6 +17,9 @@ const meta: Meta<typeof Modal> = {
 			type: import.meta.env.STORYBOOK_PACKAGE_STATUS__COMPONENTS,
 		},
 		chromatic: { pauseAnimationAtEnd: true },
+		a11y: {
+			element: 'div[data-rac]',
+		},
 	},
 	decorators: [
 		(Story: StoryFn, { viewMode }) =>

--- a/packages/components/stories/Popover.stories.tsx
+++ b/packages/components/stories/Popover.stories.tsx
@@ -15,6 +15,9 @@ const meta: Meta<typeof Popover> = {
 			type: import.meta.env.STORYBOOK_PACKAGE_STATUS__COMPONENTS,
 		},
 		chromatic: { pauseAnimationAtEnd: true },
+		a11y: {
+			element: '[data-trigger]',
+		},
 	},
 	decorators: [
 		(Story: StoryFn) => (

--- a/packages/components/stories/Tooltip.stories.tsx
+++ b/packages/components/stories/Tooltip.stories.tsx
@@ -14,6 +14,9 @@ const meta: Meta<typeof Tooltip> = {
 			type: import.meta.env.STORYBOOK_PACKAGE_STATUS__COMPONENTS,
 		},
 		chromatic: { pauseAnimationAtEnd: true },
+		a11y: {
+			element: '[data-overlay-container]',
+		},
 	},
 	decorators: [
 		(Story: StoryFn) => (


### PR DESCRIPTION
## Summary

Update `Menu` selection states to display radio and checkbox visuals. To avoid nested interactive elements violations we can extract the inner content of `Checkbox` and `Radio` to display in menu items.