### PR TITLE
fix(components): increase `Checkbox` icon specificity

### DIFF
--- a/.changeset/fifty-bugs-walk.md
+++ b/.changeset/fifty-bugs-walk.md
@@ -1,0 +1,5 @@
+---
+"@launchpad-ui/components": patch
+---
+
+Increase `Checkbox` icon specificity

--- a/packages/components/src/styles/Checkbox.module.css
+++ b/packages/components/src/styles/Checkbox.module.css
@@ -12,10 +12,10 @@
     all var(--lp-duration-100) ease-in-out,
     outline,
     outline-offset 0ms;
-}
-
-.icon {
-  fill: var(--lp-color-text-interactive-primary-base);
+  
+  & .icon {
+    fill: var(--lp-color-text-interactive-primary-base);
+  }
 }
 
 .checkbox {


### PR DESCRIPTION
## Summary

To address cases where icon styles are loaded after the component's resulting in currentcolor winning.