### PR TITLE
fix(components): adjust styles for `OverlayArrow`

### DIFF
--- a/.changeset/twelve-toes-fail.md
+++ b/.changeset/twelve-toes-fail.md
@@ -1,0 +1,5 @@
+---
+"@launchpad-ui/components": patch
+---
+
+Adjust styles for `OverlayArrow`

--- a/packages/components/src/styles/Popover.module.css
+++ b/packages/components/src/styles/Popover.module.css
@@ -28,7 +28,7 @@
   & .arrow svg {
     display: block;
     fill: var(--lp-color-bg-overlay-primary);
-    stroke: var(--lp-color-border-ui-primary);
+    stroke: light-dark(var(--lp-color-border-ui-secondary), transparent);
     stroke-width: 1px;
   }
 


### PR DESCRIPTION
## Summary

Adjust styles for `OverlayArrow` to account for removing the border from `Popover`.