### PR TITLE
fix(components): remove max-width on `ListBox`

### DIFF
--- a/.changeset/clean-dodos-laugh.md
+++ b/.changeset/clean-dodos-laugh.md
@@ -1,0 +1,5 @@
+---
+"@launchpad-ui/components": patch
+---
+
+Remove max-width on `ListBox`

--- a/packages/components/src/styles/ListBox.module.css
+++ b/packages/components/src/styles/ListBox.module.css
@@ -1,5 +1,6 @@
 .box {
   composes: menu from './Menu.module.css';
+  max-width: unset;
 }
 
 .item {


### PR DESCRIPTION
## Summary

We want most styles from `Menu` except the max width.