### PR TITLE
fix(components): set `Popover` trigger in `ComboBox` to `Group` instead of `Input`

### DIFF
--- a/.changeset/gentle-ties-rule.md
+++ b/.changeset/gentle-ties-rule.md
@@ -1,0 +1,5 @@
+---
+"@launchpad-ui/components": patch
+---
+
+Set `Popover` trigger in `ComboBox` to `Group` instead of `Input`

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -36,6 +36,7 @@
 	"dependencies": {
 		"@launchpad-ui/icons": "workspace:~",
 		"@launchpad-ui/tokens": "workspace:~",
+		"@react-aria/utils": "3.24.0",
 		"@react-types/shared": "3.23.0",
 		"class-variance-authority": "0.7.0",
 		"react-aria-components": "1.2.0",

--- a/packages/components/src/ComboBox.tsx
+++ b/packages/components/src/ComboBox.tsx
@@ -1,13 +1,16 @@
-import type { ForwardedRef } from 'react';
-import type { ComboBoxProps } from 'react-aria-components';
+import type { CSSProperties, ForwardedRef } from 'react';
+import type { ComboBoxProps, PopoverProps } from 'react-aria-components';
 import type { IconButtonProps } from './IconButton';
 import type { forwardRefType } from './utils';
 
+import { useResizeObserver } from '@react-aria/utils';
 import { cva } from 'class-variance-authority';
-import { forwardRef, useContext } from 'react';
+import { createContext, forwardRef, useCallback, useContext, useRef, useState } from 'react';
 import {
 	ComboBox as AriaComboBox,
 	ComboBoxStateContext,
+	GroupContext,
+	Provider,
 	composeRenderProps,
 } from 'react-aria-components';
 
@@ -16,10 +19,27 @@ import styles from './styles/ComboBox.module.css';
 
 const box = cva(styles.box);
 
+const PopoverContext = createContext<PopoverProps>({});
+
 const _ComboBox = <T extends object>(
 	props: ComboBoxProps<T>,
 	ref: ForwardedRef<HTMLDivElement>,
 ) => {
+	const groupRef = useRef<HTMLDivElement>(null);
+	// https://github.com/adobe/react-spectrum/blob/main/packages/react-aria-components/src/ComboBox.tsx#L155-L170
+	const [groupWidth, setGroupWidth] = useState<string | null>(null);
+	// biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
+	const onResize = useCallback(() => {
+		if (groupRef.current) {
+			setGroupWidth(`${groupRef.current.offsetWidth}px`);
+		}
+	}, [groupRef, setGroupWidth]);
+
+	useResizeObserver({
+		ref: groupRef,
+		onResize: onResize,
+	});
+
 	return (
 		<AriaComboBox
 			{...props}
@@ -27,7 +47,24 @@ const _ComboBox = <T extends object>(
 			className={composeRenderProps(props.className, (className, renderProps) =>
 				box({ ...renderProps, className }),
 			)}
-		/>
+		>
+			{composeRenderProps(props.children, (children, { isInvalid, isDisabled }) => (
+				<Provider
+					values={[
+						[GroupContext, { ref: groupRef, isInvalid, isDisabled }],
+						[
+							PopoverContext,
+							{
+								triggerRef: groupRef,
+								style: { '--trigger-width': groupWidth } as CSSProperties,
+							},
+						],
+					]}
+				>
+					{children}
+				</Provider>
+			))}
+		</AriaComboBox>
 	);
 };
 
@@ -59,5 +96,5 @@ const _ComboBoxClearButton = (
 
 const ComboBoxClearButton = forwardRef(_ComboBoxClearButton);
 
-export { ComboBox, ComboBoxClearButton };
+export { ComboBox, ComboBoxClearButton, PopoverContext };
 export type { ComboBoxProps };

--- a/packages/components/src/Popover.tsx
+++ b/packages/components/src/Popover.tsx
@@ -5,15 +5,14 @@ import type {
 } from 'react-aria-components';
 
 import { cva } from 'class-variance-authority';
-import { forwardRef } from 'react';
+import { forwardRef, useContext } from 'react';
 import {
 	OverlayArrow as AriaOverlayArrow,
 	Popover as AriaPopover,
-	PopoverContext,
 	composeRenderProps,
-	useSlottedContext,
 } from 'react-aria-components';
 
+import { PopoverContext } from './ComboBox';
 import styles from './styles/Popover.module.css';
 
 interface PopoverProps extends Omit<AriaPopoverProps, 'offset' | 'crossOffset'> {}
@@ -22,14 +21,15 @@ interface OverlayArrowProps extends Omit<AriaOverlayArrowProps, 'children'> {}
 const popover = cva(styles.popover);
 const arrow = cva(styles.arrow);
 
-const _Popover = (props: PopoverProps, ref: ForwardedRef<HTMLDivElement>) => {
-	const context = useSlottedContext(PopoverContext);
-	const isComboBox = context?.trigger === 'ComboBox';
+const _Popover = (props: PopoverProps, ref: ForwardedRef<HTMLElement>) => {
+	const popoverProps = useContext(PopoverContext);
+
 	return (
 		<AriaPopover
+			{...popoverProps}
 			{...props}
-			offset={isComboBox ? 9 : 4}
-			crossOffset={isComboBox ? -8 : 0}
+			offset={4}
+			crossOffset={0}
 			ref={ref}
 			className={composeRenderProps(props.className, (className, renderProps) =>
 				popover({ ...renderProps, className }),

--- a/packages/components/src/styles/Popover.module.css
+++ b/packages/components/src/styles/Popover.module.css
@@ -50,7 +50,7 @@
 
   &[data-trigger='ComboBox'] {
     /* stylelint-disable-next-line csstools/value-no-unknown-custom-properties */
-    min-width: calc(var(--lp-spacing-300) * 2 + var(--trigger-width) + 2px);
+    min-width: var(--trigger-width);
   }
 
   &[data-trigger='ComboBoxDialog'] {

--- a/packages/components/stories/ComboBox.stories.tsx
+++ b/packages/components/stories/ComboBox.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryFn, StoryObj } from '@storybook/react';
 
+import { Icon } from '@launchpad-ui/icons';
 import { vars } from '@launchpad-ui/vars';
 import { expect, userEvent, within } from '@storybook/test';
 
@@ -82,6 +83,7 @@ export const Descriptions: Story = {
 			<>
 				<Label>Label</Label>
 				<Group>
+					<Icon name="search" size="small" />
 					<Input />
 					<IconButton
 						icon="chevron-down"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -408,6 +408,9 @@ importers:
       '@launchpad-ui/tokens':
         specifier: workspace:~
         version: link:../tokens
+      '@react-aria/utils':
+        specifier: 3.24.0
+        version: 3.24.0(react@18.3.1)
       '@react-types/shared':
         specifier: 3.23.0
         version: 3.23.0(react@18.3.1)


### PR DESCRIPTION
## Summary

Set `Popover` trigger in `ComboBox` to `Group` instead of `Input` to ensure the popover is sized and positioned correctly. This requires us to emulate a bit of their logic and define a separate context to pass to popover.