### PR TITLE
fix(components)!: use `href` and `routerOptions` with `RouterProvider` for links

### DIFF
--- a/.changeset/young-badgers-speak.md
+++ b/.changeset/young-badgers-speak.md
@@ -1,0 +1,5 @@
+---
+"@launchpad-ui/components": minor
+---
+
+Use `href` and `routerOptions` with `RouterProvider` for links

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,9 +1,12 @@
 import type { ReactRenderer } from '@storybook/react';
 import type { DecoratorFunction, GlobalTypes, Parameters } from '@storybook/types';
+import type { ReactNode } from 'react';
 
 import { Box } from '@launchpad-ui/box';
+import { RouterProvider as AriaRouterProvider } from '@launchpad-ui/components';
 import { withThemeByDataAttribute } from '@storybook/addon-themes';
 import { themes } from '@storybook/theming';
+import { BrowserRouter, useHref, useNavigate } from 'react-router-dom';
 
 import { allModes } from './modes';
 
@@ -11,6 +14,15 @@ import '../packages/components/src/styles/themes.css';
 import '../packages/tokens/dist/index.css';
 import '../packages/tokens/dist/media-queries.css';
 import '../packages/tokens/dist/themes.css';
+
+const RouterProvider = ({ children }: { children: ReactNode }) => {
+	const navigate = useNavigate();
+	return (
+		<AriaRouterProvider navigate={navigate} useHref={useHref}>
+			{children}
+		</AriaRouterProvider>
+	);
+};
 
 export const parameters: Parameters = {
 	actions: { disable: true },
@@ -83,28 +95,34 @@ export const decorators: DecoratorFunction<ReactRenderer>[] = [
 		const sideBySide = mirror === 'side-by-side';
 		const stacked = mirror === 'stacked';
 
-		return mirror ? (
-			<Box display="flex" flexDirection={sideBySide ? 'row' : 'column'} minHeight="100vh">
-				<Box
-					padding="$400"
-					width={sideBySide ? '50vw' : undefined}
-					height={stacked ? '50vh' : undefined}
-				>
-					<StoryFn />
-				</Box>
-				<Box
-					data-theme="dark"
-					padding="$400"
-					width={sideBySide ? '50vw' : undefined}
-					height={stacked ? '50vh' : undefined}
-				>
-					<StoryFn />
-				</Box>
-			</Box>
-		) : (
-			<Box padding="$400">
-				<StoryFn />
-			</Box>
+		return (
+			<BrowserRouter>
+				<RouterProvider>
+					{mirror ? (
+						<Box display="flex" flexDirection={sideBySide ? 'row' : 'column'} minHeight="100vh">
+							<Box
+								padding="$400"
+								width={sideBySide ? '50vw' : undefined}
+								height={stacked ? '50vh' : undefined}
+							>
+								<StoryFn />
+							</Box>
+							<Box
+								data-theme="dark"
+								padding="$400"
+								width={sideBySide ? '50vw' : undefined}
+								height={stacked ? '50vh' : undefined}
+							>
+								<StoryFn />
+							</Box>
+						</Box>
+					) : (
+						<Box padding="$400">
+							<StoryFn />
+						</Box>
+					)}
+				</RouterProvider>
+			</BrowserRouter>
 		);
 	},
 	withThemeByDataAttribute<ReactRenderer>({

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
 		"plop": "^4.0.0",
 		"react": "18.3.1",
 		"react-dom": "18.3.1",
+		"react-router-dom": "6.16.0",
 		"rollup-plugin-pure": "^0.2.1",
 		"storybook-addon-pseudo-states": "^3.0.1",
 		"stylelint": "^16.5.0",

--- a/packages/components/__tests__/LinkButton.spec.tsx
+++ b/packages/components/__tests__/LinkButton.spec.tsx
@@ -9,7 +9,7 @@ describe('LinkButton', () => {
 	it('renders', () => {
 		render(
 			<MemoryRouter>
-				<LinkButton to="/">LinkButton</LinkButton>
+				<LinkButton href="/">LinkButton</LinkButton>
 			</MemoryRouter>,
 		);
 		expect(screen.getByRole('link')).toBeVisible();
@@ -22,7 +22,7 @@ describe('LinkButton', () => {
 		render(
 			<RouterProvider navigate={vi.fn()}>
 				<MemoryRouter>
-					<LinkButton to="/path" onPress={spy}>
+					<LinkButton href="/path" onPress={spy}>
 						LinkButton
 					</LinkButton>
 				</MemoryRouter>

--- a/packages/components/__tests__/LinkIconButton.spec.tsx
+++ b/packages/components/__tests__/LinkIconButton.spec.tsx
@@ -8,7 +8,7 @@ describe('LinkIconButton', () => {
 	it('renders', () => {
 		render(
 			<MemoryRouter>
-				<LinkIconButton icon="add" aria-label="create" to="/" />
+				<LinkIconButton icon="add" aria-label="create" href="/" />
 			</MemoryRouter>,
 		);
 		expect(screen.getByRole('link')).toBeVisible();

--- a/packages/components/global.d.ts
+++ b/packages/components/global.d.ts
@@ -1,7 +1,8 @@
-import type { NavigateOptions } from 'react-router-dom';
+import type { NavigateOptions, To } from 'react-router-dom';
 
 declare module 'react-aria-components' {
 	interface RouterConfig {
+		href: To;
 		routerOptions: NavigateOptions;
 	}
 }

--- a/packages/components/global.d.ts
+++ b/packages/components/global.d.ts
@@ -1,0 +1,7 @@
+import type { NavigateOptions } from 'react-router-dom';
+
+declare module 'react-aria-components' {
+	interface RouterConfig {
+		routerOptions: NavigateOptions;
+	}
+}

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -39,8 +39,7 @@
 		"@react-aria/utils": "3.24.0",
 		"@react-types/shared": "3.23.0",
 		"class-variance-authority": "0.7.0",
-		"react-aria-components": "1.2.0",
-		"react-router-dom": "6.16.0"
+		"react-aria-components": "1.2.0"
 	},
 	"peerDependencies": {
 		"react": "18.3.1",
@@ -49,6 +48,7 @@
 	"devDependencies": {
 		"react-stately": "3.31.0",
 		"react": "18.3.1",
-		"react-dom": "18.3.1"
+		"react-dom": "18.3.1",
+		"react-router-dom": "6.16.0"
 	}
 }

--- a/packages/components/src/Link.tsx
+++ b/packages/components/src/Link.tsx
@@ -1,12 +1,10 @@
 import type { VariantProps } from 'class-variance-authority';
-import type { ForwardedRef, MouseEvent } from 'react';
+import type { ForwardedRef } from 'react';
 import type { LinkProps as AriaLinkProps } from 'react-aria-components';
-import type { LinkProps as _RouterLinkProps } from 'react-router-dom';
 
 import { cva } from 'class-variance-authority';
 import { forwardRef } from 'react';
 import { Link as AriaLink, composeRenderProps } from 'react-aria-components';
-import { useHref, useLinkClickHandler } from 'react-router-dom';
 
 import styles from './styles/Link.module.css';
 
@@ -22,23 +20,10 @@ const link = cva(styles.base, {
 	},
 });
 
-interface RouterLinkProps
-	extends Omit<
-		_RouterLinkProps,
-		| 'children'
-		| 'className'
-		| 'slot'
-		| 'style'
-		| 'download'
-		| 'onBlur'
-		| 'onFocus'
-		| 'onKeyDown'
-		| 'onKeyUp'
-	> {}
-interface LinkProps extends AriaLinkProps, Partial<RouterLinkProps>, VariantProps<typeof link> {}
+interface LinkProps extends AriaLinkProps, VariantProps<typeof link> {}
 
-const _RACLink = (
-	{ variant = 'default', ...props }: AriaLinkProps & VariantProps<typeof link>,
+const _Link = (
+	{ variant = 'default', ...props }: LinkProps,
 	ref: ForwardedRef<HTMLAnchorElement>,
 ) => {
 	return (
@@ -50,41 +35,6 @@ const _RACLink = (
 			)}
 		/>
 	);
-};
-const RACLink = forwardRef(_RACLink);
-
-const _RouterLink = (
-	{ to, replace, state, ...props }: AriaLinkProps & RouterLinkProps,
-	ref: ForwardedRef<HTMLAnchorElement>,
-) => {
-	const href = useHref(to);
-	const handleClick = useLinkClickHandler(to, {
-		replace,
-		state,
-		target: props.target,
-	});
-
-	return (
-		<RACLink
-			{...props}
-			ref={ref}
-			href={href}
-			onPress={(event) => {
-				props.onPress?.(event);
-				// https://reactrouter.com/en/main/hooks/use-link-click-handler
-				handleClick({
-					...event,
-					button: 0, // https://github.com/remix-run/react-router/blob/main/packages/react-router-dom/dom.ts#L41
-					preventDefault: () => undefined,
-				} as unknown as MouseEvent<HTMLAnchorElement>);
-			}}
-		/>
-	);
-};
-const RouterLink = forwardRef(_RouterLink);
-
-const _Link = ({ to, ...props }: LinkProps, ref: ForwardedRef<HTMLAnchorElement>) => {
-	return to ? <RouterLink {...props} to={to} ref={ref} /> : <RACLink {...props} ref={ref} />;
 };
 
 /**

--- a/packages/components/src/RouterProvider.tsx
+++ b/packages/components/src/RouterProvider.tsx
@@ -1,0 +1,3 @@
+import { RouterProvider } from 'react-aria-components';
+
+export { RouterProvider };

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -70,6 +70,7 @@ export { Radio } from './Radio';
 export { RadioButton } from './RadioButton';
 export { RadioGroup } from './RadioGroup';
 export { RadioIconButton } from './RadioIconButton';
+export { RouterProvider } from './RouterProvider';
 export { SearchField } from './SearchField';
 export { Section } from './Section';
 export { Select, SelectValue } from './Select';

--- a/packages/components/stories/Link.stories.tsx
+++ b/packages/components/stories/Link.stories.tsx
@@ -22,14 +22,14 @@ type Story = StoryObj<typeof Link>;
 export const Example: Story = {
 	args: {
 		children: 'Link',
-		href: '#',
+		href: '/test',
 	},
 };
 
 export const Subtle: Story = {
 	args: {
 		children: 'Link',
-		href: '#',
+		href: '/test',
 		variant: 'subtle',
 	},
 };
@@ -71,6 +71,6 @@ export const States: Story = {
 		await userEvent.tab();
 	},
 	args: {
-		href: '#',
+		href: '/test',
 	},
 };

--- a/packages/components/stories/LinkButton.stories.tsx
+++ b/packages/components/stories/LinkButton.stories.tsx
@@ -17,5 +17,9 @@ export default meta;
 type Story = StoryObj<typeof LinkButton>;
 
 export const Example: Story = {
-	args: { children: 'LinkButton', href: '/test', routerOptions: { state: { foo: 'bar' } } },
+	args: {
+		children: 'LinkButton',
+		href: { pathname: 'test' },
+		routerOptions: { state: { foo: 'bar' } },
+	},
 };

--- a/packages/components/stories/LinkButton.stories.tsx
+++ b/packages/components/stories/LinkButton.stories.tsx
@@ -1,6 +1,4 @@
-import type { Meta, StoryFn, StoryObj } from '@storybook/react';
-
-import { MemoryRouter } from 'react-router-dom';
+import type { Meta, StoryObj } from '@storybook/react';
 
 import { LinkButton } from '../src';
 
@@ -12,13 +10,6 @@ const meta: Meta<typeof LinkButton> = {
 			type: import.meta.env.STORYBOOK_PACKAGE_STATUS__COMPONENTS,
 		},
 	},
-	decorators: [
-		(Story: StoryFn) => (
-			<MemoryRouter>
-				<Story />
-			</MemoryRouter>
-		),
-	],
 };
 
 export default meta;
@@ -26,5 +17,5 @@ export default meta;
 type Story = StoryObj<typeof LinkButton>;
 
 export const Example: Story = {
-	args: { children: 'LinkButton', to: '/' },
+	args: { children: 'LinkButton', href: '/test', routerOptions: { state: { foo: 'bar' } } },
 };

--- a/packages/components/stories/LinkIconButton.stories.tsx
+++ b/packages/components/stories/LinkIconButton.stories.tsx
@@ -1,6 +1,4 @@
-import type { Meta, StoryFn, StoryObj } from '@storybook/react';
-
-import { MemoryRouter } from 'react-router-dom';
+import type { Meta, StoryObj } from '@storybook/react';
 
 import { LinkIconButton } from '../src';
 
@@ -12,13 +10,6 @@ const meta: Meta<typeof LinkIconButton> = {
 			type: import.meta.env.STORYBOOK_PACKAGE_STATUS__COMPONENTS,
 		},
 	},
-	decorators: [
-		(Story: StoryFn) => (
-			<MemoryRouter>
-				<Story />
-			</MemoryRouter>
-		),
-	],
 };
 
 export default meta;
@@ -26,9 +17,9 @@ export default meta;
 type Story = StoryObj<typeof LinkIconButton>;
 
 export const Example: Story = {
-	args: { icon: 'add', 'aria-label': 'create', to: '/' },
+	args: { icon: 'add', 'aria-label': 'create', href: '/test' },
 };
 
 export const Small: Story = {
-	args: { icon: 'add', 'aria-label': 'create', to: '/', size: 'small' },
+	args: { icon: 'add', 'aria-label': 'create', href: '/test', size: 'small' },
 };

--- a/packages/navigation/stories/Navigation.stories.tsx
+++ b/packages/navigation/stories/Navigation.stories.tsx
@@ -1,8 +1,5 @@
 import type { StoryObj } from '@storybook/react';
-import type { ReactNode } from 'react';
 import type { NavigationItemProps } from '../src';
-
-import { MemoryRouter } from 'react-router-dom';
 
 import { allModes } from '../../../.storybook/modes';
 import { Navigation, NavigationItem } from '../src';
@@ -29,7 +26,6 @@ export default {
 			},
 		},
 	},
-	decorators: [(storyFn: () => ReactNode) => <MemoryRouter>{storyFn()}</MemoryRouter>],
 };
 
 type Story = StoryObj<typeof Navigation<NavigationItemProps>>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -146,6 +146,9 @@ importers:
       react-dom:
         specifier: 18.3.1
         version: 18.3.1(react@18.3.1)
+      react-router-dom:
+        specifier: 6.16.0
+        version: 6.16.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       rollup-plugin-pure:
         specifier: ^0.2.1
         version: 0.2.1(rollup@4.17.2)
@@ -420,9 +423,6 @@ importers:
       react-aria-components:
         specifier: 1.2.0
         version: 1.2.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      react-router-dom:
-        specifier: 6.16.0
-        version: 6.16.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     devDependencies:
       react:
         specifier: 18.3.1
@@ -430,6 +430,9 @@ importers:
       react-dom:
         specifier: 18.3.1
         version: 18.3.1(react@18.3.1)
+      react-router-dom:
+        specifier: 6.16.0
+        version: 6.16.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-stately:
         specifier: 3.31.0
         version: 3.31.0(react@18.3.1)


### PR DESCRIPTION
## Summary

Use `href` and `routerOptions` with `RouterProvider` for links. This ensures state and other options are passed properly when using `react-router`.