### PR TITLE
fix(components): add `DOMProps` to `LinkProps`

### DIFF
--- a/.changeset/two-timers-tell.md
+++ b/.changeset/two-timers-tell.md
@@ -1,0 +1,5 @@
+---
+"@launchpad-ui/components": patch
+---
+
+Add `DOMProps` to `LinkProps`

--- a/packages/components/src/Link.tsx
+++ b/packages/components/src/Link.tsx
@@ -1,3 +1,4 @@
+import type { DOMProps } from '@react-types/shared';
 import type { VariantProps } from 'class-variance-authority';
 import type { ForwardedRef } from 'react';
 import type { LinkProps as AriaLinkProps } from 'react-aria-components';
@@ -20,7 +21,7 @@ const link = cva(styles.base, {
 	},
 });
 
-interface LinkProps extends AriaLinkProps, VariantProps<typeof link> {}
+interface LinkProps extends AriaLinkProps, VariantProps<typeof link>, DOMProps {}
 
 const _Link = (
 	{ variant = 'default', ...props }: LinkProps,


### PR DESCRIPTION
## Summary

Add `DOMProps` to `LinkProps` to allow `id` on RAC links.