### PR TITLE
chore: add designers to icon package CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
 * @launchdarkly/team-core-product-frontend
+/packages/icons @matthewferry @antonio-darkly


### PR DESCRIPTION
Adds Antonio and Matthew to code owners of icon package

Should probably do this in terraform, but can do that as followup