### PR TITLE
fix: icons codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 * @launchdarkly/team-core-product-frontend
-/packages/icons @matthewferry @antonio-darkly
+/packages/icons/src @matthewferry @antonio-darkly


### PR DESCRIPTION
## Summary

Unable to merge #1294 because it includes updates to `icons` package.json and changelog. Tweak codeowners to only get design review for source code changes.