### PR TITLE
fix(components): adjust `ListBox` styles

### DIFF
--- a/.changeset/metal-cougars-tease.md
+++ b/.changeset/metal-cougars-tease.md
@@ -1,0 +1,5 @@
+---
+"@launchpad-ui/components": patch
+---
+
+Adjust `ListBox` styles

--- a/packages/components/src/ListBox.tsx
+++ b/packages/components/src/ListBox.tsx
@@ -53,7 +53,11 @@ const _ListBoxItem = <T extends object>(
 			{composeRenderProps(props.children, (children, { isSelected }) => (
 				<>
 					{children}
-					{isSelected && <Icon name="check" size="medium" className={styles.check} />}
+					{isSelected ? (
+						<Icon name="check" size="medium" className={styles.check} />
+					) : (
+						<div className={styles.icon} slot="check" />
+					)}
 				</>
 			))}
 		</AriaListBoxItem>

--- a/packages/components/src/styles/ListBox.module.css
+++ b/packages/components/src/styles/ListBox.module.css
@@ -5,13 +5,14 @@
 
 .item {
   composes: item from './Menu.module.css';
+  justify-content: space-between;
 
   &:has([slot='label']) {
     &[data-selection-mode] {
       grid-template-areas:
         'label check'
         'desc check';
-      grid-template-columns: max-content 1fr;
+      grid-template-columns: 1fr min-content;
     }
   }
 
@@ -26,5 +27,9 @@
 
 .check {
   grid-area: check;
-  margin-left: auto;
+}
+
+.icon {
+  height: var(--lp-size-20);
+  width: var(--lp-size-20);
 }

--- a/packages/components/src/styles/Select.module.css
+++ b/packages/components/src/styles/Select.module.css
@@ -13,7 +13,7 @@
     color: var(--lp-color-text-field-placeholder);
   }
 
-  & [slot='description'] {
+  & :is([slot='description'], [slot='check']) {
     display: none;
   }
 }


### PR DESCRIPTION
## Summary

Adjust `ListBox` styles to ensure descriptions wrap and items account for check mark space.