### PR TITLE
fix: update CODEOWNERS for icons dir

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 * @launchdarkly/team-core-product-frontend
-/packages/icons/src @matthewferry @antonio-darkly
+/packages/icons/src @matthewferry @antonio-darkly @launchdarkly/team-core-product-frontend

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,3 @@
 * @launchdarkly/team-core-product-frontend
-/packages/icons/src @matthewferry @antonio-darkly @launchdarkly/team-core-product-frontend
+/packages/icons/src @launchdarkly/team-core-product-frontend @matthewferry @antonio-darkly 
+/.changeset @launchdarkly/team-core-product-frontend @matthewferry @antonio-darkly 


### PR DESCRIPTION
Adds fe team to icons dir as code owners to not block on Antonio and Matthew
