### PR TITLE
fix(components): adjust `Input` focus outline offset

### DIFF
--- a/.changeset/angry-rules-cheat.md
+++ b/.changeset/angry-rules-cheat.md
@@ -1,0 +1,5 @@
+---
+"@launchpad-ui/components": patch
+---
+
+Adjust `Input` focus outline offset

--- a/packages/components/src/styles/Input.module.css
+++ b/packages/components/src/styles/Input.module.css
@@ -10,7 +10,7 @@
 
   &[data-focused] {
     outline: 2px solid var(--lp-color-shadow-interactive-focus);
-    outline-offset: -1px;
+    outline-offset: -2px;
     z-index: 1;
   }
 


### PR DESCRIPTION
## Summary

Adjust `Input` focus outline offset to match updates from #1275.