### PR TITLE
feat(components): allow setting `delay` on `TooltipTrigger`

### DIFF
--- a/.changeset/witty-schools-hear.md
+++ b/.changeset/witty-schools-hear.md
@@ -1,0 +1,5 @@
+---
+"@launchpad-ui/components": patch
+---
+
+Allow setting `delay` on `TooltipTrigger`

--- a/packages/components/src/Tooltip.tsx
+++ b/packages/components/src/Tooltip.tsx
@@ -19,7 +19,7 @@ import styles from './styles/Tooltip.module.css';
 interface TooltipProps
 	extends Omit<AriaTooltipProps, 'offset' | 'crossOffset'>,
 		VariantProps<typeof tooltip> {}
-interface TooltipTriggerProps extends Omit<TooltipTriggerComponentProps, 'delay' | 'closeDelay'> {}
+interface TooltipTriggerProps extends Omit<TooltipTriggerComponentProps, 'closeDelay'> {}
 
 const tooltip = cva(styles.base, {
 	variants: {
@@ -59,7 +59,7 @@ const _Tooltip = (
 const Tooltip = forwardRef(_Tooltip);
 
 const TooltipTrigger = (props: TooltipTriggerProps) => {
-	return <AriaTooltipTrigger {...props} delay={500} closeDelay={250} />;
+	return <AriaTooltipTrigger delay={500} {...props} closeDelay={250} />;
 };
 
 export { Tooltip, TooltipTrigger };


### PR DESCRIPTION
## Summary

Allow setting `delay` on `TooltipTrigger`.
