### PR TITLE
fix(markdown): remove top margin from markdown

### DIFF
--- a/.changeset/nine-cows-shake.md
+++ b/.changeset/nine-cows-shake.md
@@ -1,0 +1,5 @@
+---
+"@launchpad-ui/markdown": patch
+---
+
+Remove top margin from Markdown component

--- a/packages/markdown/src/styles/Markdown.module.css
+++ b/packages/markdown/src/styles/Markdown.module.css
@@ -1,7 +1,3 @@
-.Markdown {
-	margin-top: 0.3125rem;
-}
-
 .Markdown ol,
 .Markdown ul {
 	padding-left: 1.25rem;


### PR DESCRIPTION
## Summary

The markdown component has its own margin which introduces unnecessary layout challenges for consumers.

This change removes that margin and leaves that up to consumers instead.