### PR TITLE
fix(components): fix `Switch` animation on Firefox

### DIFF
--- a/.changeset/fast-glasses-carry.md
+++ b/.changeset/fast-glasses-carry.md
@@ -1,0 +1,5 @@
+---
+"@launchpad-ui/components": patch
+---
+
+Fix `Switch` animation on Firefox

--- a/packages/components/src/styles/Switch.module.css
+++ b/packages/components/src/styles/Switch.module.css
@@ -54,7 +54,7 @@
 	}
 
 	& .handle {
-		transform: translateX(calc(100cqw - 100%));
+		transform: translateX(calc(100% + var(--lp-spacing-400)));
 		box-shadow: 0 0 1px 0 rgb(0 117 66 / 0.75), 0 0 2px 0 rgb(0 117 66 / 0.06), 0 0 1px 0
 			rgb(0 117 66 / 0.35);
 	}


### PR DESCRIPTION
## Summary

Fix `Switch` animation on Firefox related to the [query unit value](https://www.w3.org/TR/css-contain-3/#container-lengths).

## Testing approaches

1. Go to https://launchpad.launchdarkly.com/?path=/story/components-forms-switch--off&globals=theme:dark in Firefox and jump between the `Off` and `On` stories. Notice the handle move past the container.
2. Notice the issue is not present when doing the same on the Chromatic build for this PR on any browser.
