### PR TITLE
fix: remove css patch plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,6 @@
 		"typescript": "^5.5.2",
 		"typescript-plugin-css-modules": "^5.1.0",
 		"vite": "^5.4.0",
-		"vite-css-modules": "^1.4.2",
 		"vitest": "^2.0.0"
 	},
 	"packageManager": "pnpm@9.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -173,9 +173,6 @@ importers:
       vite:
         specifier: ^5.4.0
         version: 5.4.0(@types/node@20.16.1)(less@4.2.0)(lightningcss@1.26.0)(sass@1.77.8)(stylus@0.62.0)
-      vite-css-modules:
-        specifier: ^1.4.2
-        version: 1.4.2(lightningcss@1.26.0)(postcss@8.4.40)(rollup@4.19.1)(vite@5.4.0(@types/node@20.16.1)(less@4.2.0)(lightningcss@1.26.0)(sass@1.77.8)(stylus@0.62.0))
       vitest:
         specifier: ^2.0.0
         version: 2.0.5(@types/node@20.16.1)(@vitest/ui@2.0.5)(jsdom@24.1.1)(less@4.2.0)(lightningcss@1.26.0)(sass@1.77.8)(stylus@0.62.0)
@@ -5238,9 +5235,6 @@ packages:
   functions-have-names@1.2.3:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
 
-  generic-names@4.0.0:
-    resolution: {integrity: sha512-ySFolZQfw9FoDb3ed9d80Cm9f0+r7qj+HJkWjeD9RBfpxEVTlVhol+gvaQB/78WbwYfbnNh8nWHHBSlg072y6A==}
-
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
@@ -6003,10 +5997,6 @@ packages:
     resolution: {integrity: sha512-OfCBkGEw4nN6JLtgRidPX6QxjBQGQf72q3si2uvqyFEMbycSFFHwAZeXx6cJgFM9wmLrf9zBwCP3Ivqa+LLZPw==}
     engines: {node: '>=6'}
 
-  loader-utils@3.3.1:
-    resolution: {integrity: sha512-FMJTLMXfCLMLfJxcX9PFqX5qD88Z5MRGaZCVzfuqeZSPsyiBzs+pahDQjbIWz2QIzPZz0NX9Zy4FX3lmK6YHIg==}
-    engines: {node: '>= 12.13.0'}
-
   locate-path@3.0.0:
     resolution: {integrity: sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==}
     engines: {node: '>=6'}
@@ -6697,12 +6687,6 @@ packages:
 
   postcss-modules-scope@3.2.0:
     resolution: {integrity: sha512-oq+g1ssrsZOsx9M96c5w8laRmvEu9C3adDSjI8oTcbfkrTE8hx/zfyobUoWIxaKPO8bt6S62kxpw5GqypEw1QQ==}
-    engines: {node: ^10 || ^12 || >= 14}
-    peerDependencies:
-      postcss: ^8.1.0
-
-  postcss-modules-values@4.0.0:
-    resolution: {integrity: sha512-RDxHkAiEGI78gS2ofyvCsu7iycRv7oqw5xMWn9iMoR0N/7mf9D50ecQqUo5BZ9Zh2vH4bCUR/ktCqbB9m8vJjQ==}
     engines: {node: ^10 || ^12 || >= 14}
     peerDependencies:
       postcss: ^8.1.0
@@ -7688,16 +7672,6 @@ packages:
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
-
-  vite-css-modules@1.4.2:
-    resolution: {integrity: sha512-WDTgxeSZ6Z0RR1dU+Y+0utFR98g0F4yRspBN4em8tUUIbv70knajR26marzJbkRyX0+Erhd4OKT3Zq0fKzu1rg==}
-    peerDependencies:
-      lightningcss: ^1.23.0
-      postcss: ^8.4.33
-      vite: ^5.0.12
-    peerDependenciesMeta:
-      lightningcss:
-        optional: true
 
   vite-node@1.6.0:
     resolution: {integrity: sha512-de6HJgzC+TFzOu0NTC4RAIsyf/DY/ibWDYQUcuEA84EMHhcefTUGkjFHKKEJhQN4A+6I0u++kr3l36ZF2d7XRw==}
@@ -12548,10 +12522,6 @@ snapshots:
 
   functions-have-names@1.2.3: {}
 
-  generic-names@4.0.0:
-    dependencies:
-      loader-utils: 3.3.1
-
   gensync@1.0.0-beta.2: {}
 
   get-caller-file@2.0.5: {}
@@ -13360,8 +13330,6 @@ snapshots:
       pify: 4.0.1
       strip-bom: 3.0.0
 
-  loader-utils@3.3.1: {}
-
   locate-path@3.0.0:
     dependencies:
       p-locate: 3.0.0
@@ -14068,11 +14036,6 @@ snapshots:
     dependencies:
       postcss: 8.4.40
       postcss-selector-parser: 6.1.1
-
-  postcss-modules-values@4.0.0(postcss@8.4.40):
-    dependencies:
-      icss-utils: 5.1.0(postcss@8.4.40)
-      postcss: 8.4.40
 
   postcss-resolve-nested-selector@0.1.4: {}
 
@@ -15291,24 +15254,6 @@ snapshots:
   v8flags@4.0.1: {}
 
   vary@1.1.2: {}
-
-  vite-css-modules@1.4.2(lightningcss@1.26.0)(postcss@8.4.40)(rollup@4.19.1)(vite@5.4.0(@types/node@20.16.1)(less@4.2.0)(lightningcss@1.26.0)(sass@1.77.8)(stylus@0.62.0)):
-    dependencies:
-      '@ampproject/remapping': 2.3.0
-      '@rollup/pluginutils': 5.1.0(rollup@4.19.1)
-      generic-names: 4.0.0
-      icss-utils: 5.1.0(postcss@8.4.40)
-      magic-string: 0.30.11
-      postcss: 8.4.40
-      postcss-modules-extract-imports: 3.1.0(postcss@8.4.40)
-      postcss-modules-local-by-default: 4.0.5(postcss@8.4.40)
-      postcss-modules-scope: 3.2.0(postcss@8.4.40)
-      postcss-modules-values: 4.0.0(postcss@8.4.40)
-      vite: 5.4.0(@types/node@20.16.1)(less@4.2.0)(lightningcss@1.26.0)(sass@1.77.8)(stylus@0.62.0)
-    optionalDependencies:
-      lightningcss: 1.26.0
-    transitivePeerDependencies:
-      - rollup
 
   vite-node@1.6.0(@types/node@20.16.1)(less@4.2.0)(lightningcss@1.26.0)(sass@1.77.8)(stylus@0.62.0):
     dependencies:

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -8,7 +8,6 @@ import browserslist from 'browserslist';
 import { browserslistToTargets } from 'lightningcss';
 import { PluginPure } from 'rollup-plugin-pure';
 import { defineConfig } from 'vite';
-import { patchCssModules } from 'vite-css-modules';
 import { configDefaults } from 'vitest/config';
 
 import tsconfig from './tsconfig.json';
@@ -57,7 +56,6 @@ export default defineConfig({
 		devSourcemap: true,
 	},
 	plugins: [
-		patchCssModules(),
 		react(),
 		vanillaExtractPlugin(),
 		cssImport(),


### PR DESCRIPTION
## Summary

Remove css patch plugin since it [disables Lightning's transforms](https://github.com/privatenumber/vite-css-modules/blob/develop/src/patch.ts#L198). Chromatic missed the regression first time around.