### PR TITLE
fix(components): fix styles for `TextArea` resizing

### DIFF
--- a/.changeset/lovely-cameras-rest.md
+++ b/.changeset/lovely-cameras-rest.md
@@ -1,0 +1,5 @@
+---
+"@launchpad-ui/components": patch
+---
+
+Fix styles for `TextArea` resizing

--- a/packages/components/src/TextArea.tsx
+++ b/packages/components/src/TextArea.tsx
@@ -2,10 +2,14 @@ import type { ForwardedRef } from 'react';
 import type { TextAreaProps as AriaTextAreaProps } from 'react-aria-components';
 import type { InputVariants } from './Input';
 
+import { cva, cx } from 'class-variance-authority';
 import { forwardRef } from 'react';
 import { TextArea as AriaTextArea, composeRenderProps } from 'react-aria-components';
 
 import { input } from './Input';
+import styles from './styles/TextArea.module.css';
+
+const area = cva(styles.area);
 
 interface TextAreaProps extends AriaTextAreaProps, InputVariants {}
 
@@ -18,7 +22,7 @@ const _TextArea = (
 			{...props}
 			ref={ref}
 			className={composeRenderProps(props.className, (className, renderProps) =>
-				input({ ...renderProps, variant, className }),
+				cx(input({ variant }), area({ ...renderProps, className })),
 			)}
 		/>
 	);

--- a/packages/components/src/styles/TextArea.module.css
+++ b/packages/components/src/styles/TextArea.module.css
@@ -1,0 +1,3 @@
+.area {
+	flex: unset;
+}


### PR DESCRIPTION
## Summary

Fix styles for `TextArea` resizing by removing flex used for input groups.

## Testing approaches

Can resize `TextArea` from all directions in Chromatic build.
