### PR TITLE
fix(components): fix `Switch` styles for Chrome 129

### DIFF
--- a/.changeset/strange-flowers-explain.md
+++ b/.changeset/strange-flowers-explain.md
@@ -1,0 +1,5 @@
+---
+"@launchpad-ui/components": patch
+---
+
+Fix `Switch` styles for Chrome 129

--- a/packages/components/src/styles/Switch.module.css
+++ b/packages/components/src/styles/Switch.module.css
@@ -5,6 +5,7 @@
 }
 
 .track {
+	position: relative;
 	display: flex;
 	align-items: center;
 	gap: var(--lp-spacing-200);


### PR DESCRIPTION
## Summary

Fix `Switch` styles for Chrome 129.