### PR TITLE
feat(components): add `error` variant to `Toast`

### DIFF
--- a/.changeset/tidy-falcons-obey.md
+++ b/.changeset/tidy-falcons-obey.md
@@ -1,0 +1,5 @@
+---
+"@launchpad-ui/components": patch
+---
+
+Add `error` variant to `Toast`

--- a/packages/components/src/Toast.tsx
+++ b/packages/components/src/Toast.tsx
@@ -187,6 +187,8 @@ const snackbarQueue = new AriaToastQueue<SnackbarValue>({
 const timeout = 6000;
 
 const ToastQueue = {
+	error: (children: ToastContent['children'], options?: ToastOptions) =>
+		toastQueue.add({ children, status: 'error' }, { ...options, timeout }),
 	info: (children: ToastContent['children'], options?: ToastOptions) =>
 		toastQueue.add({ children, status: 'info' }, { ...options, timeout }),
 	success: (children: ToastContent['children'], options?: ToastOptions) =>


### PR DESCRIPTION
## Summary

Add `error` variant to `Toast` to replace `warning` which was removed.