### PR TITLE
fix(components): use separate stacking context for `Switch`

### DIFF
--- a/.changeset/cool-turkeys-melt.md
+++ b/.changeset/cool-turkeys-melt.md
@@ -1,0 +1,5 @@
+---
+"@launchpad-ui/components": patch
+---
+
+Use separate stacking context for `Switch`

--- a/packages/components/src/styles/Switch.module.css
+++ b/packages/components/src/styles/Switch.module.css
@@ -2,6 +2,7 @@
 	display: flex;
 	align-items: center;
 	gap: var(--lp-spacing-200);
+	isolation: isolate;
 }
 
 .track {


### PR DESCRIPTION
## Summary

https://developer.mozilla.org/en-US/docs/Web/CSS/isolation