### PR TITLE
fix(components): align items in `Toolbar`

### DIFF
--- a/.changeset/curvy-pugs-kick.md
+++ b/.changeset/curvy-pugs-kick.md
@@ -1,0 +1,5 @@
+---
+"@launchpad-ui/components": patch
+---
+
+Align items in `Toolbar`

--- a/packages/components/src/styles/Separator.module.css
+++ b/packages/components/src/styles/Separator.module.css
@@ -1,6 +1,7 @@
 .separator {
 	background: var(--lp-color-border-ui-primary);
 	margin-block: var(--lp-spacing-200);
+	align-self: stretch;
 
 	&[aria-orientation='vertical'] {
 		width: var(--lp-size-1);

--- a/packages/components/src/styles/Toolbar.module.css
+++ b/packages/components/src/styles/Toolbar.module.css
@@ -5,6 +5,7 @@
 
 	&[data-orientation='horizontal'] {
 		flex-direction: row;
+		align-items: center;
 	}
 
 	&[data-orientation='vertical'] {


### PR DESCRIPTION
## Summary

Align items in `Toolbar` so non-button elements such as `Checkbox` are centered.