### PR TITLE
chore!: use `ref` prop instead of `forwardRef`

### DIFF
--- a/.changeset/angry-moose-promise.md
+++ b/.changeset/angry-moose-promise.md
@@ -1,0 +1,6 @@
+---
+"@launchpad-ui/components": minor
+"@launchpad-ui/icons": minor
+---
+
+Use `ref` prop instead of `forwardRef` and drop React 18 support

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -48,8 +48,8 @@
 		"react-router": "7.0.1"
 	},
 	"peerDependencies": {
-		"react": "^18.0.0 || ^19.0.0",
-		"react-dom": "^18.0.0 || ^19.0.0"
+		"react": "^19.0.0",
+		"react-dom": "^19.0.0"
 	},
 	"devDependencies": {
 		"react": "19.0.0",

--- a/packages/components/src/Alert.tsx
+++ b/packages/components/src/Alert.tsx
@@ -1,10 +1,9 @@
 import type { VariantProps } from 'class-variance-authority';
-import type { ForwardedRef, HTMLAttributes } from 'react';
+import type { HTMLAttributes, RefObject } from 'react';
 
 import { StatusIcon } from '@launchpad-ui/icons';
 import { useControlledState } from '@react-stately/utils';
 import { cva } from 'class-variance-authority';
-import { forwardRef } from 'react';
 import { HeadingContext, Provider } from 'react-aria-components';
 
 import { IconButton } from './IconButton';
@@ -37,21 +36,20 @@ interface AlertProps extends HTMLAttributes<HTMLDivElement>, AlertVariants {
 	isDismissable?: boolean;
 	isOpen?: boolean;
 	onDismiss?: () => void;
+	ref?: RefObject<HTMLDivElement | null>;
 }
 
-const _Alert = (
-	{
-		className,
-		children,
-		status = 'neutral',
-		variant = 'default',
-		isDismissable,
-		isOpen,
-		onDismiss,
-		...props
-	}: AlertProps,
-	ref: ForwardedRef<HTMLDivElement>,
-) => {
+const Alert = ({
+	className,
+	children,
+	status = 'neutral',
+	variant = 'default',
+	isDismissable,
+	isOpen,
+	onDismiss,
+	ref,
+	...props
+}: AlertProps) => {
 	const [open, setOpen] = useControlledState(isOpen, true, (val) => !val && onDismiss?.());
 
 	return open ? (
@@ -74,8 +72,6 @@ const _Alert = (
 		</div>
 	) : null;
 };
-
-const Alert = forwardRef(_Alert);
 
 export { Alert };
 export type { AlertProps };

--- a/packages/components/src/Breadcrumbs.tsx
+++ b/packages/components/src/Breadcrumbs.tsx
@@ -1,10 +1,13 @@
-import type { forwardRefType } from '@react-types/shared';
-import type { ForwardedRef } from 'react';
-import type { BreadcrumbProps, BreadcrumbsProps, ContextValue } from 'react-aria-components';
+import type { RefObject } from 'react';
+import type {
+	BreadcrumbProps as AriaBreadcrumbProps,
+	BreadcrumbsProps as AriaBreadcrumbsProps,
+	ContextValue,
+} from 'react-aria-components';
 import type { LinkProps } from './Link';
 
 import { cva } from 'class-variance-authority';
-import { createContext, forwardRef } from 'react';
+import { createContext } from 'react';
 import {
 	Breadcrumb as AriaBreadcrumb,
 	Breadcrumbs as AriaBreadcrumbs,
@@ -19,21 +22,29 @@ const crumb = cva(styles.crumb);
 
 const LinkContext = createContext<ContextValue<LinkProps, HTMLAnchorElement>>(null);
 
-const _Breadcrumbs = <T extends object>(
-	{ className, ...props }: BreadcrumbsProps<T>,
-	ref: ForwardedRef<HTMLOListElement>,
-) => {
-	return <AriaBreadcrumbs {...props} ref={ref} className={crumbs({ className })} />;
-};
+interface BreadcrumbsProps<T extends object> extends AriaBreadcrumbsProps<T> {
+	ref?: RefObject<HTMLOListElement | null>;
+}
+
+interface BreadcrumbProps extends AriaBreadcrumbProps {
+	ref?: RefObject<HTMLLIElement | null>;
+}
 
 /**
  * Breadcrumbs display a hierarchy of links to the current page or resource in an application.
  *
  * https://react-spectrum.adobe.com/react-aria/Breadcrumbs.html
  */
-const Breadcrumbs = (forwardRef as forwardRefType)(_Breadcrumbs);
+const Breadcrumbs = <T extends object>({ className, ref, ...props }: BreadcrumbsProps<T>) => {
+	return <AriaBreadcrumbs {...props} ref={ref} className={crumbs({ className })} />;
+};
 
-const _Breadcrumb = (props: BreadcrumbProps, ref: ForwardedRef<HTMLLIElement>) => {
+/**
+ * A Breadcrumb represents an individual item in a `<Breadcrumbs>` list.
+ *
+ * https://react-spectrum.adobe.com/react-aria/Breadcrumbs.html
+ */
+const Breadcrumb = ({ ref, ...props }: BreadcrumbProps) => {
 	return (
 		<AriaBreadcrumb
 			{...props}
@@ -48,13 +59,6 @@ const _Breadcrumb = (props: BreadcrumbProps, ref: ForwardedRef<HTMLLIElement>) =
 		</AriaBreadcrumb>
 	);
 };
-
-/**
- * A Breadcrumb represents an individual item in a `<Breadcrumbs>` list.
- *
- * https://react-spectrum.adobe.com/react-aria/Breadcrumbs.html
- */
-const Breadcrumb = forwardRef(_Breadcrumb);
 
 export { Breadcrumbs, Breadcrumb, LinkContext };
 export type { BreadcrumbsProps, BreadcrumbProps };

--- a/packages/components/src/Button.tsx
+++ b/packages/components/src/Button.tsx
@@ -1,9 +1,9 @@
 import type { VariantProps } from 'class-variance-authority';
-import type { ForwardedRef } from 'react';
+import type { RefObject } from 'react';
 import type { ButtonProps as AriaButtonProps } from 'react-aria-components';
 
 import { cva, cx } from 'class-variance-authority';
-import { forwardRef, useContext } from 'react';
+import { useContext } from 'react';
 import {
 	Button as AriaButton,
 	Provider,
@@ -40,12 +40,16 @@ const button = cva(styles.base, {
 });
 
 interface ButtonVariants extends VariantProps<typeof button> {}
-interface ButtonProps extends AriaButtonProps, ButtonVariants {}
+interface ButtonProps extends AriaButtonProps, ButtonVariants {
+	ref?: RefObject<HTMLButtonElement | null>;
+}
 
-const _Button = (
-	{ size = 'medium', variant = 'default', ...props }: ButtonProps,
-	ref: ForwardedRef<HTMLButtonElement>,
-) => {
+/**
+ * A button allows a user to perform an action, with mouse, touch, and keyboard interactions.
+ *
+ * https://react-spectrum.adobe.com/react-aria/Button.html
+ */
+const Button = ({ size = 'medium', variant = 'default', ref, ...props }: ButtonProps) => {
 	const selectContext = useSlottedContext(SelectContext);
 	const state = useContext(SelectStateContext);
 	const ctx = useContext(PerceivableContext);
@@ -72,13 +76,6 @@ const _Button = (
 		</AriaButton>
 	);
 };
-
-/**
- * A button allows a user to perform an action, with mouse, touch, and keyboard interactions.
- *
- * https://react-spectrum.adobe.com/react-aria/Button.html
- */
-const Button = forwardRef(_Button);
 
 export { Button, button };
 export type { ButtonProps, ButtonVariants };

--- a/packages/components/src/ButtonGroup.tsx
+++ b/packages/components/src/ButtonGroup.tsx
@@ -1,10 +1,9 @@
 import type { Orientation } from '@react-types/shared';
 import type { VariantProps } from 'class-variance-authority';
-import type { ForwardedRef } from 'react';
+import type { RefObject } from 'react';
 import type { GroupProps } from 'react-aria-components';
 
 import { cva } from 'class-variance-authority';
-import { forwardRef } from 'react';
 import {
 	ButtonContext,
 	Group,
@@ -34,12 +33,15 @@ const buttonGroup = cva(styles.base, {
 
 interface ButtonGroupProps extends GroupProps, VariantProps<typeof buttonGroup> {
 	orientation?: Orientation | null;
+	ref?: RefObject<HTMLDivElement | null>;
 }
 
-const _ButtonGroup = (
-	{ spacing = 'basic', orientation = 'horizontal', ...props }: ButtonGroupProps,
-	ref: ForwardedRef<HTMLDivElement>,
-) => {
+const ButtonGroup = ({
+	spacing = 'basic',
+	orientation = 'horizontal',
+	ref,
+	...props
+}: ButtonGroupProps) => {
 	return (
 		<Group
 			{...props}
@@ -62,8 +64,6 @@ const _ButtonGroup = (
 		</Group>
 	);
 };
-
-const ButtonGroup = forwardRef(_ButtonGroup);
 
 export { ButtonGroup };
 export type { ButtonGroupProps };

--- a/packages/components/src/Calendar.tsx
+++ b/packages/components/src/Calendar.tsx
@@ -1,21 +1,21 @@
 import type { CalendarDate } from '@internationalized/date';
 import type { RangeValue } from '@react-types/shared';
-import type { ForwardedRef, HTMLAttributes } from 'react';
+import type { HTMLAttributes, RefObject } from 'react';
 import type {
-	CalendarCellProps,
+	CalendarCellProps as AriaCalendarCellProps,
+	CalendarProps as AriaCalendarProps,
+	RangeCalendarProps as AriaRangeCalendarProps,
 	CalendarGridBodyProps,
 	CalendarGridHeaderProps,
 	CalendarGridProps,
 	CalendarHeaderCellProps,
-	CalendarProps,
 	DateRange,
 	DateValue,
-	RangeCalendarProps,
 } from 'react-aria-components';
 import type { ButtonProps } from './Button';
 
 import { cva, cx } from 'class-variance-authority';
-import { forwardRef, useState } from 'react';
+import { useState } from 'react';
 import {
 	Calendar as AriaCalendar,
 	CalendarCell as AriaCalendarCell,
@@ -35,20 +35,37 @@ import {
 import { Button, button } from './Button';
 import styles from './styles/Calendar.module.css';
 
-interface CalendarPickerProps extends HTMLAttributes<HTMLDivElement> {}
+interface CalendarPickerProps extends HTMLAttributes<HTMLDivElement> {
+	ref?: RefObject<HTMLDivElement | null>;
+}
 
 interface PresetProps extends Omit<ButtonProps, 'value'> {
 	value: CalendarDate | RangeValue<CalendarDate>;
+	ref?: RefObject<HTMLButtonElement | null>;
 }
 
 const calendar = cva(styles.calendar);
 const cell = cva(styles.cell);
 const range = cva(styles.range);
 
-const _Calendar = <T extends DateValue>(
-	props: CalendarProps<T>,
-	ref: ForwardedRef<HTMLDivElement>,
-) => {
+interface CalendarProps<T extends DateValue> extends AriaCalendarProps<T> {
+	ref?: RefObject<HTMLDivElement | null>;
+}
+
+interface CalendarCellProps extends AriaCalendarCellProps {
+	ref?: RefObject<HTMLTableCellElement | null>;
+}
+
+interface RangeCalendarProps<T extends DateValue> extends AriaRangeCalendarProps<T> {
+	ref?: RefObject<HTMLDivElement | null>;
+}
+
+/**
+ * A calendar displays one or more date grids and allows users to select a single date.
+ *
+ * https://react-spectrum.adobe.com/react-aria/Calendar.html
+ */
+const Calendar = <T extends DateValue>({ ref, ...props }: CalendarProps<T>) => {
 	return (
 		<AriaCalendar
 			{...props}
@@ -61,13 +78,11 @@ const _Calendar = <T extends DateValue>(
 };
 
 /**
- * A calendar displays one or more date grids and allows users to select a single date.
+ * A calendar cell displays a date cell within a calendar grid which can be selected by the user.
  *
  * https://react-spectrum.adobe.com/react-aria/Calendar.html
  */
-const Calendar = forwardRef(_Calendar);
-
-const _CalendarCell = (props: CalendarCellProps, ref: ForwardedRef<HTMLTableCellElement>) => {
+const CalendarCell = ({ ref, ...props }: CalendarCellProps) => {
 	return (
 		<AriaCalendarCell
 			{...props}
@@ -80,16 +95,11 @@ const _CalendarCell = (props: CalendarCellProps, ref: ForwardedRef<HTMLTableCell
 };
 
 /**
- * A calendar cell displays a date cell within a calendar grid which can be selected by the user.
+ * A range calendar displays one or more date grids and allows users to select a contiguous range of dates.
  *
- * https://react-spectrum.adobe.com/react-aria/Calendar.html
+ * https://react-spectrum.adobe.com/react-aria/RangeCalendar.html
  */
-const CalendarCell = forwardRef(_CalendarCell);
-
-const _RangeCalendar = <T extends DateValue>(
-	props: RangeCalendarProps<T>,
-	ref: ForwardedRef<HTMLDivElement>,
-) => {
+const RangeCalendar = <T extends DateValue>({ ref, ...props }: RangeCalendarProps<T>) => {
 	return (
 		<AriaRangeCalendar
 			{...props}
@@ -101,17 +111,7 @@ const _RangeCalendar = <T extends DateValue>(
 	);
 };
 
-/**
- * A range calendar displays one or more date grids and allows users to select a contiguous range of dates.
- *
- * https://react-spectrum.adobe.com/react-aria/RangeCalendar.html
- */
-const RangeCalendar = forwardRef(_RangeCalendar);
-
-const _CalendarPicker = (
-	{ children, className, ...props }: CalendarPickerProps,
-	ref: ForwardedRef<HTMLDivElement>,
-) => {
+const CalendarPicker = ({ children, className, ref, ...props }: CalendarPickerProps) => {
 	const [value, onChange] = useState<DateValue>();
 	const [range, onChangeRange] = useState<DateRange | null>();
 	const [focusedValue, onFocusChange] = useState<DateValue>();
@@ -133,9 +133,7 @@ const _CalendarPicker = (
 	);
 };
 
-const CalendarPicker = forwardRef(_CalendarPicker);
-
-const _Preset = ({ value, ...props }: PresetProps, ref: ForwardedRef<HTMLButtonElement>) => {
+const Preset = ({ value, ref, ...props }: PresetProps) => {
 	const context = useSlottedContext(CalendarContext);
 	const rangeContext = useSlottedContext(RangeCalendarContext);
 	const onPress = () => {
@@ -149,8 +147,6 @@ const _Preset = ({ value, ...props }: PresetProps, ref: ForwardedRef<HTMLButtonE
 	};
 	return <Button ref={ref} size="small" variant="minimal" {...props} onPress={onPress} />;
 };
-
-const Preset = forwardRef(_Preset);
 
 export {
 	Calendar,

--- a/packages/components/src/Checkbox.tsx
+++ b/packages/components/src/Checkbox.tsx
@@ -1,9 +1,11 @@
-import type { ForwardedRef } from 'react';
-import type { CheckboxProps, CheckboxRenderProps } from 'react-aria-components';
+import type { RefObject } from 'react';
+import type {
+	CheckboxProps as AriaCheckboxProps,
+	CheckboxRenderProps,
+} from 'react-aria-components';
 
 import { Icon } from '@launchpad-ui/icons';
 import { cva } from 'class-variance-authority';
-import { forwardRef } from 'react';
 import { Checkbox as AriaCheckbox, composeRenderProps } from 'react-aria-components';
 
 import styles from './styles/Checkbox.module.css';
@@ -21,7 +23,16 @@ const CheckboxInner = ({ isSelected, isIndeterminate }: Partial<CheckboxRenderPr
 	</div>
 );
 
-const _Checkbox = (props: CheckboxProps, ref: ForwardedRef<HTMLLabelElement>) => {
+interface CheckboxProps extends AriaCheckboxProps {
+	ref?: RefObject<HTMLLabelElement | null>;
+}
+
+/**
+ * A checkbox allows a user to select multiple items from a list of individual items, or to mark one individual item as selected.
+ *
+ * https://react-spectrum.adobe.com/react-aria/Checkbox.html
+ */
+const Checkbox = ({ ref, ...props }: CheckboxProps) => {
 	return (
 		<AriaCheckbox
 			{...props}
@@ -41,13 +52,6 @@ const _Checkbox = (props: CheckboxProps, ref: ForwardedRef<HTMLLabelElement>) =>
 		</AriaCheckbox>
 	);
 };
-
-/**
- * A checkbox allows a user to select multiple items from a list of individual items, or to mark one individual item as selected.
- *
- * https://react-spectrum.adobe.com/react-aria/Checkbox.html
- */
-const Checkbox = forwardRef(_Checkbox);
 
 export { Checkbox, CheckboxInner, checkbox };
 export type { CheckboxProps };

--- a/packages/components/src/CheckboxGroup.tsx
+++ b/packages/components/src/CheckboxGroup.tsx
@@ -1,15 +1,23 @@
-import type { ForwardedRef } from 'react';
-import type { CheckboxGroupProps } from 'react-aria-components';
+import type { RefObject } from 'react';
+import type { CheckboxGroupProps as AriaCheckboxGroupProps } from 'react-aria-components';
 
 import { cva } from 'class-variance-authority';
-import { forwardRef } from 'react';
 import { CheckboxGroup as AriaCheckboxGroup, composeRenderProps } from 'react-aria-components';
 
 import styles from './styles/CheckboxGroup.module.css';
 
 const group = cva(styles.group);
 
-const _CheckboxGroup = (props: CheckboxGroupProps, ref: ForwardedRef<HTMLDivElement>) => {
+interface CheckboxGroupProps extends AriaCheckboxGroupProps {
+	ref?: RefObject<HTMLDivElement | null>;
+}
+
+/**
+ * A checkbox group allows a user to select multiple items from a list of options.
+ *
+ * https://react-spectrum.adobe.com/react-aria/CheckboxGroup.html
+ */
+const CheckboxGroup = ({ ref, ...props }: CheckboxGroupProps) => {
 	return (
 		<AriaCheckboxGroup
 			{...props}
@@ -20,13 +28,6 @@ const _CheckboxGroup = (props: CheckboxGroupProps, ref: ForwardedRef<HTMLDivElem
 		/>
 	);
 };
-
-/**
- * A checkbox group allows a user to select multiple items from a list of options.
- *
- * https://react-spectrum.adobe.com/react-aria/CheckboxGroup.html
- */
-const CheckboxGroup = forwardRef(_CheckboxGroup);
 
 export { CheckboxGroup };
 export type { CheckboxGroupProps };

--- a/packages/components/src/ComboBox.tsx
+++ b/packages/components/src/ComboBox.tsx
@@ -1,11 +1,10 @@
-import type { forwardRefType } from '@react-types/shared';
-import type { CSSProperties, ForwardedRef } from 'react';
-import type { ComboBoxProps, PopoverProps } from 'react-aria-components';
+import type { CSSProperties, RefObject } from 'react';
+import type { ComboBoxProps as AriaComboBoxProps, PopoverProps } from 'react-aria-components';
 import type { IconButtonProps } from './IconButton';
 
 import { useResizeObserver } from '@react-aria/utils';
 import { cva } from 'class-variance-authority';
-import { createContext, forwardRef, useCallback, useContext, useRef, useState } from 'react';
+import { createContext, useCallback, useContext, useRef, useState } from 'react';
 import {
 	ComboBox as AriaComboBox,
 	ComboBoxStateContext,
@@ -21,10 +20,18 @@ const box = cva(styles.box);
 
 const PopoverContext = createContext<PopoverProps>({});
 
-const _ComboBox = <T extends object>(
-	props: ComboBoxProps<T>,
-	ref: ForwardedRef<HTMLDivElement>,
-) => {
+interface ComboBoxProps<T extends object> extends AriaComboBoxProps<T> {
+	ref?: RefObject<HTMLDivElement | null>;
+}
+
+interface ComboBoxClearButtonProps extends Partial<IconButtonProps> {}
+
+/**
+ * A combo box combines a text input with a listbox, allowing users to filter a list of options to items matching a query.
+ *
+ * https://react-spectrum.adobe.com/react-aria/ComboBox.html
+ */
+const ComboBox = <T extends object>({ ref, ...props }: ComboBoxProps<T>) => {
 	const groupRef = useRef<HTMLDivElement>(null);
 	// https://github.com/adobe/react-spectrum/blob/main/packages/react-aria-components/src/ComboBox.tsx#L155-L170
 	const [groupWidth, setGroupWidth] = useState<string | null>(null);
@@ -68,17 +75,7 @@ const _ComboBox = <T extends object>(
 	);
 };
 
-/**
- * A combo box combines a text input with a listbox, allowing users to filter a list of options to items matching a query.
- *
- * https://react-spectrum.adobe.com/react-aria/ComboBox.html
- */
-const ComboBox = (forwardRef as forwardRefType)(_ComboBox);
-
-const _ComboBoxClearButton = (
-	props: Partial<IconButtonProps>,
-	ref: ForwardedRef<HTMLButtonElement>,
-) => {
+const ComboBoxClearButton = ({ ref, ...props }: ComboBoxClearButtonProps) => {
 	const state = useContext(ComboBoxStateContext);
 	return (
 		<IconButton
@@ -94,7 +91,5 @@ const _ComboBoxClearButton = (
 	);
 };
 
-const ComboBoxClearButton = forwardRef(_ComboBoxClearButton);
-
 export { ComboBox, ComboBoxClearButton, PopoverContext };
-export type { ComboBoxProps };
+export type { ComboBoxProps, ComboBoxClearButtonProps };

--- a/packages/components/src/DateField.tsx
+++ b/packages/components/src/DateField.tsx
@@ -1,15 +1,14 @@
-import type { ForwardedRef } from 'react';
+import type { RefObject } from 'react';
 import type {
-	DateFieldProps,
-	DateInputProps,
-	DateSegmentProps,
+	DateFieldProps as AriaDateFieldProps,
+	DateInputProps as AriaDateInputProps,
+	DateSegmentProps as AriaDateSegmentProps,
+	TimeFieldProps as AriaTimeFieldProps,
 	DateValue,
-	TimeFieldProps,
 	TimeValue,
 } from 'react-aria-components';
 
 import { cva, cx } from 'class-variance-authority';
-import { forwardRef } from 'react';
 import {
 	DateField as AriaDateField,
 	DateInput as AriaDateInput,
@@ -25,10 +24,28 @@ const field = cva(styles.field);
 const dateInput = cva(styles.input);
 const segment = cva(styles.segment);
 
-const _DateField = <T extends DateValue>(
-	props: DateFieldProps<T>,
-	ref: ForwardedRef<HTMLDivElement>,
-) => {
+interface DateFieldProps<T extends DateValue> extends AriaDateFieldProps<T> {
+	ref?: RefObject<HTMLDivElement | null>;
+}
+
+interface DateInputProps extends AriaDateInputProps {
+	ref?: RefObject<HTMLDivElement | null>;
+}
+
+interface DateSegmentProps extends AriaDateSegmentProps {
+	ref?: RefObject<HTMLDivElement | null>;
+}
+
+interface TimeFieldProps<T extends TimeValue> extends AriaTimeFieldProps<T> {
+	ref?: RefObject<HTMLDivElement | null>;
+}
+
+/**
+ * A date field allows users to enter and edit date and time values using a keyboard. Each part of a date value is displayed in an individually editable segment.
+ *
+ * https://react-spectrum.adobe.com/react-aria/DateField.html
+ */
+const DateField = <T extends DateValue>({ ref, ...props }: DateFieldProps<T>) => {
 	return (
 		<AriaDateField
 			shouldForceLeadingZeros={true}
@@ -42,13 +59,11 @@ const _DateField = <T extends DateValue>(
 };
 
 /**
- * A date field allows users to enter and edit date and time values using a keyboard. Each part of a date value is displayed in an individually editable segment.
+ * A date input groups the editable date segments within a date field.
  *
  * https://react-spectrum.adobe.com/react-aria/DateField.html
  */
-const DateField = forwardRef(_DateField);
-
-const _DateInput = (props: DateInputProps, ref: ForwardedRef<HTMLDivElement>) => {
+const DateInput = ({ ref, ...props }: DateInputProps) => {
 	return (
 		<AriaDateInput
 			{...props}
@@ -61,13 +76,11 @@ const _DateInput = (props: DateInputProps, ref: ForwardedRef<HTMLDivElement>) =>
 };
 
 /**
- * A date input groups the editable date segments within a date field.
+ * A date segment displays an individual unit of a date and time, and allows users to edit the value by typing or using the arrow keys to increment and decrement.
  *
  * https://react-spectrum.adobe.com/react-aria/DateField.html
  */
-const DateInput = forwardRef(_DateInput);
-
-const _DateSegment = (props: DateSegmentProps, ref: ForwardedRef<HTMLDivElement>) => {
+const DateSegment = ({ ref, ...props }: DateSegmentProps) => {
 	return (
 		<AriaDateSegment
 			{...props}
@@ -80,16 +93,11 @@ const _DateSegment = (props: DateSegmentProps, ref: ForwardedRef<HTMLDivElement>
 };
 
 /**
- * A date segment displays an individual unit of a date and time, and allows users to edit the value by typing or using the arrow keys to increment and decrement.
+ * A time field allows users to enter and edit time values using a keyboard. Each part of a time value is displayed in an individually editable segment.
  *
- * https://react-spectrum.adobe.com/react-aria/DateField.html
+ * https://react-spectrum.adobe.com/react-aria/TimeField.html
  */
-const DateSegment = forwardRef(_DateSegment);
-
-const _TimeField = <T extends TimeValue>(
-	props: TimeFieldProps<T>,
-	ref: ForwardedRef<HTMLDivElement>,
-) => {
+const TimeField = <T extends TimeValue>({ ref, ...props }: TimeFieldProps<T>) => {
 	return (
 		<AriaTimeField
 			{...props}
@@ -100,13 +108,6 @@ const _TimeField = <T extends TimeValue>(
 		/>
 	);
 };
-
-/**
- * A time field allows users to enter and edit time values using a keyboard. Each part of a time value is displayed in an individually editable segment.
- *
- * https://react-spectrum.adobe.com/react-aria/TimeField.html
- */
-const TimeField = forwardRef(_TimeField);
 
 export { DateField, DateInput, DateSegment, TimeField };
 export type { DateFieldProps, DateInputProps, DateSegmentProps, TimeFieldProps };

--- a/packages/components/src/DatePicker.tsx
+++ b/packages/components/src/DatePicker.tsx
@@ -1,8 +1,11 @@
-import type { ForwardedRef } from 'react';
-import type { DatePickerProps, DateRangePickerProps, DateValue } from 'react-aria-components';
+import type { RefObject } from 'react';
+import type {
+	DatePickerProps as AriaDatePickerProps,
+	DateRangePickerProps as AriaDateRangePickerProps,
+	DateValue,
+} from 'react-aria-components';
 
 import { cva } from 'class-variance-authority';
-import { forwardRef } from 'react';
 import {
 	DatePicker as AriaDatePicker,
 	DateRangePicker as AriaDateRangePicker,
@@ -13,35 +16,22 @@ import styles from './styles/DatePicker.module.css';
 
 const picker = cva(styles.picker);
 
-const _DatePicker = <T extends DateValue>(
-	props: DatePickerProps<T>,
-	ref: ForwardedRef<HTMLDivElement>,
-) => {
-	return (
-		<AriaDatePicker
-			shouldForceLeadingZeros={true}
-			{...props}
-			ref={ref}
-			className={composeRenderProps(props.className, (className, renderProps) =>
-				picker({ ...renderProps, className }),
-			)}
-		/>
-	);
-};
+interface DatePickerProps<T extends DateValue> extends AriaDatePickerProps<T> {
+	ref?: RefObject<HTMLDivElement | null>;
+}
+
+interface DateRangePickerProps<T extends DateValue> extends AriaDateRangePickerProps<T> {
+	ref?: RefObject<HTMLDivElement | null>;
+}
 
 /**
  * A date picker combines a DateField and a Calendar popover to allow users to enter or select a date and time value.
  *
  * https://react-spectrum.adobe.com/react-aria/DatePicker.html
  */
-const DatePicker = forwardRef(_DatePicker);
-
-const _DateRangePicker = <T extends DateValue>(
-	props: DateRangePickerProps<T>,
-	ref: ForwardedRef<HTMLDivElement>,
-) => {
+const DatePicker = <T extends DateValue>({ ref, ...props }: DatePickerProps<T>) => {
 	return (
-		<AriaDateRangePicker
+		<AriaDatePicker
 			shouldForceLeadingZeros={true}
 			{...props}
 			ref={ref}
@@ -57,7 +47,18 @@ const _DateRangePicker = <T extends DateValue>(
  *
  * https://react-spectrum.adobe.com/react-aria/DateRangePicker.html
  */
-const DateRangePicker = forwardRef(_DateRangePicker);
+const DateRangePicker = <T extends DateValue>({ ref, ...props }: DateRangePickerProps<T>) => {
+	return (
+		<AriaDateRangePicker
+			shouldForceLeadingZeros={true}
+			{...props}
+			ref={ref}
+			className={composeRenderProps(props.className, (className, renderProps) =>
+				picker({ ...renderProps, className }),
+			)}
+		/>
+	);
+};
 
 export { DatePicker, DateRangePicker };
 export type { DatePickerProps, DateRangePickerProps };

--- a/packages/components/src/Dialog.tsx
+++ b/packages/components/src/Dialog.tsx
@@ -1,9 +1,8 @@
-import type { ForwardedRef } from 'react';
-import type { DialogProps, DialogTriggerProps } from 'react-aria-components';
+import type { RefObject } from 'react';
+import type { DialogProps as AriaDialogProps, DialogTriggerProps } from 'react-aria-components';
 
 import { useSlotId } from '@react-aria/utils';
 import { cva } from 'class-variance-authority';
-import { forwardRef } from 'react';
 import {
 	Dialog as AriaDialog,
 	DialogTrigger,
@@ -16,7 +15,16 @@ import styles from './styles/Dialog.module.css';
 
 const dialog = cva(styles.dialog);
 
-const _Dialog = ({ className, ...props }: DialogProps, ref: ForwardedRef<HTMLElement>) => {
+interface DialogProps extends AriaDialogProps {
+	ref?: RefObject<HTMLElement | null>;
+}
+
+/**
+ * A dialog is an overlay shown above other content in an application.
+ *
+ * https://react-spectrum.adobe.com/react-aria/Dialog.html
+ */
+const Dialog = ({ className, ref, ...props }: DialogProps) => {
 	const descriptionId = useSlotId();
 	return (
 		<AriaDialog
@@ -44,13 +52,6 @@ const _Dialog = ({ className, ...props }: DialogProps, ref: ForwardedRef<HTMLEle
 		</AriaDialog>
 	);
 };
-
-/**
- * A dialog is an overlay shown above other content in an application.
- *
- * https://react-spectrum.adobe.com/react-aria/Dialog.html
- */
-const Dialog = forwardRef(_Dialog);
 
 export { Dialog, DialogTrigger };
 export type { DialogProps, DialogTriggerProps };

--- a/packages/components/src/Disclosure.tsx
+++ b/packages/components/src/Disclosure.tsx
@@ -1,8 +1,10 @@
-import type { ForwardedRef } from 'react';
-import type { DisclosurePanelProps, DisclosureProps } from 'react-aria-components';
+import type { RefObject } from 'react';
+import type {
+	DisclosurePanelProps as AriaDisclosurePanelProps,
+	DisclosureProps as AriaDisclosureProps,
+} from 'react-aria-components';
 
 import { cva } from 'class-variance-authority';
-import { forwardRef } from 'react';
 import {
 	Disclosure as AriaDisclosure,
 	DisclosurePanel as AriaDisclosurePanel,
@@ -13,25 +15,21 @@ import styles from './styles/Disclosure.module.css';
 const disclosure = cva(styles.disclosure);
 const panel = cva(styles.panel);
 
-const _Disclosure = (
-	{ className, ...props }: DisclosureProps,
-	ref: ForwardedRef<HTMLDivElement>,
-) => {
-	return <AriaDisclosure {...props} ref={ref} className={disclosure({ className })} />;
-};
+interface DisclosureProps extends AriaDisclosureProps {
+	ref?: RefObject<HTMLDivElement | null>;
+}
+
+interface DisclosurePanelProps extends AriaDisclosurePanelProps {
+	ref?: RefObject<HTMLDivElement | null>;
+}
 
 /**
  * A disclosure is a collapsible section of content. It is composed of a header with a heading and trigger button, and a panel that contains the content.
  *
  * https://react-spectrum.adobe.com/react-aria/Disclosure.html
  */
-const Disclosure = forwardRef(_Disclosure);
-
-const _DisclosurePanel = (
-	{ className, ...props }: DisclosurePanelProps,
-	ref: ForwardedRef<HTMLDivElement>,
-) => {
-	return <AriaDisclosurePanel {...props} ref={ref} className={panel({ className })} />;
+const Disclosure = ({ className, ref, ...props }: DisclosureProps) => {
+	return <AriaDisclosure {...props} ref={ref} className={disclosure({ className })} />;
 };
 
 /**
@@ -39,7 +37,9 @@ const _DisclosurePanel = (
  *
  * https://react-spectrum.adobe.com/react-aria/Disclosure.html
  */
-const DisclosurePanel = forwardRef(_DisclosurePanel);
+const DisclosurePanel = ({ className, ref, ...props }: DisclosurePanelProps) => {
+	return <AriaDisclosurePanel {...props} ref={ref} className={panel({ className })} />;
+};
 
 export { Disclosure, DisclosurePanel };
 export type { DisclosureProps, DisclosurePanelProps };

--- a/packages/components/src/DropIndicator.tsx
+++ b/packages/components/src/DropIndicator.tsx
@@ -1,15 +1,21 @@
-import type { ForwardedRef } from 'react';
-import type { DropIndicatorProps } from 'react-aria-components';
+import type { RefObject } from 'react';
+import type { DropIndicatorProps as AriaDropIndicatorProps } from 'react-aria-components';
 
 import { cva } from 'class-variance-authority';
-import { forwardRef } from 'react';
 import { DropIndicator as AriaDropIndicator, composeRenderProps } from 'react-aria-components';
 
 import styles from './styles/DropIndicator.module.css';
 
 const indicator = cva(styles.indicator);
 
-const _DropIndicator = (props: DropIndicatorProps, ref: ForwardedRef<HTMLElement>) => {
+interface DropIndicatorProps extends AriaDropIndicatorProps {
+	ref?: RefObject<HTMLElement | null>;
+}
+
+/**
+ * A DropIndicator is rendered between items in a collection to indicate where dropped data will be inserted.
+ */
+const DropIndicator = ({ ref, ...props }: DropIndicatorProps) => {
 	return (
 		<AriaDropIndicator
 			{...props}
@@ -20,11 +26,6 @@ const _DropIndicator = (props: DropIndicatorProps, ref: ForwardedRef<HTMLElement
 		/>
 	);
 };
-
-/**
- * A DropIndicator is rendered between items in a collection to indicate where dropped data will be inserted.
- */
-const DropIndicator = forwardRef(_DropIndicator);
 
 export { DropIndicator };
 export type { DropIndicatorProps };

--- a/packages/components/src/DropZone.tsx
+++ b/packages/components/src/DropZone.tsx
@@ -1,24 +1,25 @@
-import type { ForwardedRef } from 'react';
-import type { DropZoneProps } from 'react-aria-components';
+import type { RefObject } from 'react';
+import type { DropZoneProps as AriaDropZoneProps } from 'react-aria-components';
 
 import { cva } from 'class-variance-authority';
-import { forwardRef } from 'react';
 import { DropZone as AriaDropZone } from 'react-aria-components';
 
 import styles from './styles/DropZone.module.css';
 
 const zone = cva(styles.zone);
 
-const _DropZone = ({ className, ...props }: DropZoneProps, ref: ForwardedRef<HTMLDivElement>) => {
-	return <AriaDropZone {...props} ref={ref} className={zone({ className })} />;
-};
+interface DropZoneProps extends AriaDropZoneProps {
+	ref?: RefObject<HTMLDivElement | null>;
+}
 
 /**
  * A drop zone is an area into which one or multiple objects can be dragged and dropped.
  *
  * https://react-spectrum.adobe.com/react-aria/DropZone.html
  */
-const DropZone = forwardRef(_DropZone);
+const DropZone = ({ className, ref, ...props }: DropZoneProps) => {
+	return <AriaDropZone {...props} ref={ref} className={zone({ className })} />;
+};
 
 export { DropZone };
 export type { DropZoneProps };

--- a/packages/components/src/FieldError.tsx
+++ b/packages/components/src/FieldError.tsx
@@ -1,15 +1,21 @@
-import type { ForwardedRef } from 'react';
-import type { FieldErrorProps } from 'react-aria-components';
+import type { RefObject } from 'react';
+import type { FieldErrorProps as AriaFieldErrorProps } from 'react-aria-components';
 
 import { cva } from 'class-variance-authority';
-import { forwardRef } from 'react';
 import { FieldError as AriaFieldError, composeRenderProps } from 'react-aria-components';
 
 import styles from './styles/FieldError.module.css';
 
 const error = cva(styles.error);
 
-const _FieldError = (props: FieldErrorProps, ref: ForwardedRef<HTMLElement>) => {
+interface FieldErrorProps extends AriaFieldErrorProps {
+	ref?: RefObject<HTMLElement | null>;
+}
+
+/**
+ * A FieldError displays validation errors for a form field.
+ */
+const FieldError = ({ ref, ...props }: FieldErrorProps) => {
 	return (
 		<AriaFieldError
 			{...props}
@@ -20,11 +26,6 @@ const _FieldError = (props: FieldErrorProps, ref: ForwardedRef<HTMLElement>) => 
 		/>
 	);
 };
-
-/**
- * A FieldError displays validation errors for a form field.
- */
-const FieldError = forwardRef(_FieldError);
 
 export { FieldError };
 export type { FieldErrorProps };

--- a/packages/components/src/FieldGroup.tsx
+++ b/packages/components/src/FieldGroup.tsx
@@ -1,7 +1,7 @@
-import type { ContextType, FieldsetHTMLAttributes, ForwardedRef } from 'react';
+import type { ContextType, FieldsetHTMLAttributes, RefObject } from 'react';
 
 import { cva } from 'class-variance-authority';
-import { forwardRef, useId } from 'react';
+import { useId } from 'react';
 import {
 	ComboBoxContext,
 	DateFieldContext,
@@ -22,14 +22,23 @@ interface FieldGroupProps extends FieldsetHTMLAttributes<HTMLFieldSetElement> {
 	title?: string;
 	errorMessage?: string;
 	isDisabled?: boolean;
+	ref?: RefObject<HTMLFieldSetElement | null>;
 }
 
 const group = cva(styles.group);
 
-const _FieldGroup = (
-	{ title, children, errorMessage, isDisabled, className, ...props }: FieldGroupProps,
-	ref: ForwardedRef<HTMLFieldSetElement>,
-) => {
+/**
+ * A field group represents a set of related form elements in a form.
+ */
+const FieldGroup = ({
+	title,
+	children,
+	errorMessage,
+	isDisabled,
+	className,
+	ref,
+	...props
+}: FieldGroupProps) => {
 	const errorId = useId();
 	const state = {
 		isInvalid: !!errorMessage,
@@ -62,11 +71,6 @@ const _FieldGroup = (
 		</fieldset>
 	);
 };
-
-/**
- * A field group represents a set of related form elements in a form.
- */
-const FieldGroup = forwardRef(_FieldGroup);
 
 export { FieldGroup };
 export type { FieldGroupProps };

--- a/packages/components/src/GridList.tsx
+++ b/packages/components/src/GridList.tsx
@@ -1,9 +1,10 @@
-import type { forwardRefType } from '@react-types/shared';
-import type { ForwardedRef } from 'react';
-import type { GridListItemProps, GridListProps } from 'react-aria-components';
+import type { RefObject } from 'react';
+import type {
+	GridListItemProps as AriaGridListItemProps,
+	GridListProps as AriaGridListProps,
+} from 'react-aria-components';
 
 import { cva } from 'class-variance-authority';
-import { forwardRef } from 'react';
 import {
 	GridList as AriaGridList,
 	GridListItem as AriaGridListItem,
@@ -17,10 +18,20 @@ import styles from './styles/GridList.module.css';
 const list = cva(styles.list);
 const item = cva(styles.item);
 
-const _GridList = <T extends object>(
-	props: GridListProps<T>,
-	ref: ForwardedRef<HTMLDivElement>,
-) => {
+interface GridListProps<T extends object> extends AriaGridListProps<T> {
+	ref?: RefObject<HTMLDivElement | null>;
+}
+
+interface GridListItemProps<T extends object> extends AriaGridListItemProps<T> {
+	ref?: RefObject<T | null>;
+}
+
+/**
+ * A grid list displays a list of interactive items, with support for keyboard navigation, single or multiple selection, and row actions.
+ *
+ * https://react-spectrum.adobe.com/react-aria/GridList.html
+ */
+const GridList = <T extends object>({ ref, ...props }: GridListProps<T>) => {
 	return (
 		<AriaGridList
 			{...props}
@@ -33,13 +44,11 @@ const _GridList = <T extends object>(
 };
 
 /**
- * A grid list displays a list of interactive items, with support for keyboard navigation, single or multiple selection, and row actions.
+ * A GridListItem represents an individual item in a GridList.
  *
  * https://react-spectrum.adobe.com/react-aria/GridList.html
  */
-const GridList = (forwardRef as forwardRefType)(_GridList);
-
-const _GridListItem = <T extends object>(props: GridListItemProps<T>, ref: ForwardedRef<T>) => {
+const GridListItem = <T extends object>({ ref, ...props }: GridListItemProps<T>) => {
 	const textValue =
 		props.textValue || (typeof props.children === 'string' ? props.children : undefined);
 	return (
@@ -69,13 +78,6 @@ const _GridListItem = <T extends object>(props: GridListItemProps<T>, ref: Forwa
 		</AriaGridListItem>
 	);
 };
-
-/**
- * A GridListItem represents an individual item in a GridList.
- *
- * https://react-spectrum.adobe.com/react-aria/GridList.html
- */
-const GridListItem = (forwardRef as forwardRefType)(_GridListItem);
 
 export { GridList, GridListItem };
 export type { GridListProps, GridListItemProps };

--- a/packages/components/src/Group.tsx
+++ b/packages/components/src/Group.tsx
@@ -1,9 +1,8 @@
-import type { ForwardedRef } from 'react';
+import type { RefObject } from 'react';
 import type { GroupProps as AriaGroupProps } from 'react-aria-components';
 import type { InputVariants } from './Input';
 
 import { cva, cx } from 'class-variance-authority';
-import { forwardRef } from 'react';
 import { Group as AriaGroup, composeRenderProps } from 'react-aria-components';
 
 import { input } from './Input';
@@ -11,12 +10,16 @@ import styles from './styles/Group.module.css';
 
 const group = cva(styles.group);
 
-interface GroupProps extends AriaGroupProps, InputVariants {}
+interface GroupProps extends AriaGroupProps, InputVariants {
+	ref?: RefObject<HTMLDivElement | null>;
+}
 
-const _Group = (
-	{ variant = 'default', ...props }: GroupProps,
-	ref: ForwardedRef<HTMLDivElement>,
-) => {
+/**
+ * A group represents a set of related UI controls, and supports interactive states for styling.
+ *
+ * https://react-spectrum.adobe.com/react-aria/Group.html
+ */
+const Group = ({ variant = 'default', ref, ...props }: GroupProps) => {
 	return (
 		<AriaGroup
 			{...props}
@@ -27,13 +30,6 @@ const _Group = (
 		/>
 	);
 };
-
-/**
- * A group represents a set of related UI controls, and supports interactive states for styling.
- *
- * https://react-spectrum.adobe.com/react-aria/Group.html
- */
-const Group = forwardRef(_Group);
 
 export { Group };
 export type { GroupProps };

--- a/packages/components/src/Header.tsx
+++ b/packages/components/src/Header.tsx
@@ -1,20 +1,19 @@
-import type { ForwardedRef, HTMLAttributes } from 'react';
+import type { HTMLAttributes, RefObject } from 'react';
 
 import { cva } from 'class-variance-authority';
-import { forwardRef } from 'react';
 import { Header as AriaHeader } from 'react-aria-components';
 
 import styles from './styles/Header.module.css';
 
 const header = cva(styles.header);
 
-const _Header = (
-	{ className, ...props }: HTMLAttributes<HTMLElement>,
-	ref: ForwardedRef<HTMLElement>,
-) => {
+interface HeaderProps extends HTMLAttributes<HTMLElement> {
+	ref?: RefObject<HTMLElement | null>;
+}
+
+const Header = ({ className, ref, ...props }: HeaderProps) => {
 	return <AriaHeader {...props} ref={ref} className={header({ className })} />;
 };
 
-const Header = forwardRef(_Header);
-
 export { Header };
+export type { HeaderProps };

--- a/packages/components/src/Heading.tsx
+++ b/packages/components/src/Heading.tsx
@@ -1,19 +1,20 @@
-import type { ForwardedRef } from 'react';
-import type { HeadingProps } from 'react-aria-components';
+import type { RefObject } from 'react';
+import type { HeadingProps as AriaHeadingProps } from 'react-aria-components';
 
 import { cva } from 'class-variance-authority';
-import { forwardRef } from 'react';
 import { Heading as AriaHeading } from 'react-aria-components';
 
 import styles from './styles/Heading.module.css';
 
 const heading = cva(styles.heading);
 
-const _Heading = ({ className, ...props }: HeadingProps, ref: ForwardedRef<HTMLHeadingElement>) => {
+interface HeadingProps extends AriaHeadingProps {
+	ref?: RefObject<HTMLHeadingElement | null>;
+}
+
+const Heading = ({ className, ref, ...props }: HeadingProps) => {
 	return <AriaHeading {...props} ref={ref} className={heading({ className })} />;
 };
-
-const Heading = forwardRef(_Heading);
 
 export { Heading };
 export type { HeadingProps };

--- a/packages/components/src/IconButton.tsx
+++ b/packages/components/src/IconButton.tsx
@@ -1,13 +1,13 @@
 import type { IconProps } from '@launchpad-ui/icons';
 import type { AriaLabelingProps } from '@react-types/shared';
 import type { VariantProps } from 'class-variance-authority';
-import type { ForwardedRef } from 'react';
+import type { RefObject } from 'react';
 import type { ButtonProps as AriaButtonProps } from 'react-aria-components';
 import type { ButtonVariants } from './Button';
 
 import { Icon } from '@launchpad-ui/icons';
 import { cva, cx } from 'class-variance-authority';
-import { forwardRef, useContext } from 'react';
+import { useContext } from 'react';
 import { Button as AriaButton, composeRenderProps } from 'react-aria-components';
 
 import { button } from './Button';
@@ -38,12 +38,22 @@ interface IconButtonBaseProps
 }
 interface IconButtonProps
 	extends Omit<AriaButtonProps, 'children' | 'aria-label'>,
-		IconButtonBaseProps {}
+		IconButtonBaseProps {
+	ref?: RefObject<HTMLButtonElement | null>;
+}
 
-const _IconButton = (
-	{ size = 'medium', variant = 'default', icon, ...props }: IconButtonProps,
-	ref: ForwardedRef<HTMLButtonElement>,
-) => {
+/**
+ * A button allows a user to perform an action, with mouse, touch, and keyboard interactions.
+ *
+ * https://react-spectrum.adobe.com/react-aria/Button.html
+ */
+const IconButton = ({
+	size = 'medium',
+	variant = 'default',
+	icon,
+	ref,
+	...props
+}: IconButtonProps) => {
 	const ctx = useContext(PerceivableContext);
 	return (
 		<AriaButton
@@ -58,13 +68,6 @@ const _IconButton = (
 		</AriaButton>
 	);
 };
-
-/**
- * A button allows a user to perform an action, with mouse, touch, and keyboard interactions.
- *
- * https://react-spectrum.adobe.com/react-aria/Button.html
- */
-const IconButton = forwardRef(_IconButton);
 
 export { IconButton, iconButton };
 export type { IconButtonProps, IconButtonBaseProps };

--- a/packages/components/src/Input.tsx
+++ b/packages/components/src/Input.tsx
@@ -1,9 +1,8 @@
 import type { VariantProps } from 'class-variance-authority';
-import type { ForwardedRef } from 'react';
+import type { RefObject } from 'react';
 import type { InputProps as AriaInputProps } from 'react-aria-components';
 
 import { cva } from 'class-variance-authority';
-import { forwardRef } from 'react';
 import { Input as AriaInput, composeRenderProps } from 'react-aria-components';
 
 import styles from './styles/Input.module.css';
@@ -21,12 +20,16 @@ const input = cva(styles.base, {
 });
 
 interface InputVariants extends VariantProps<typeof input> {}
-interface InputProps extends AriaInputProps, InputVariants {}
+interface InputProps extends AriaInputProps, InputVariants {
+	ref?: RefObject<HTMLInputElement | null>;
+}
 
-const _Input = (
-	{ variant = 'default', ...props }: InputProps,
-	ref: ForwardedRef<HTMLInputElement>,
-) => {
+/**
+ * An input allows a user to input text.
+ *
+ * https://react-spectrum.adobe.com/react-aria/TextField.html
+ */
+const Input = ({ variant = 'default', ref, ...props }: InputProps) => {
 	return (
 		<AriaInput
 			{...props}
@@ -37,13 +40,6 @@ const _Input = (
 		/>
 	);
 };
-
-/**
- * An input allows a user to input text.
- *
- * https://react-spectrum.adobe.com/react-aria/TextField.html
- */
-const Input = forwardRef(_Input);
 
 export { Input, input };
 export type { InputProps, InputVariants };

--- a/packages/components/src/Label.tsx
+++ b/packages/components/src/Label.tsx
@@ -1,19 +1,20 @@
-import type { ForwardedRef } from 'react';
-import type { LabelProps } from 'react-aria-components';
+import type { RefObject } from 'react';
+import type { LabelProps as AriaLabelProps } from 'react-aria-components';
 
 import { cva } from 'class-variance-authority';
-import { forwardRef } from 'react';
 import { Label as AriaLabel } from 'react-aria-components';
 
 import styles from './styles/Label.module.css';
 
 const label = cva(styles.label);
 
-const _Label = ({ className, ...props }: LabelProps, ref: ForwardedRef<HTMLLabelElement>) => {
+interface LabelProps extends AriaLabelProps {
+	ref?: RefObject<HTMLLabelElement | null>;
+}
+
+const Label = ({ className, ref, ...props }: LabelProps) => {
 	return <AriaLabel {...props} ref={ref} className={label({ className })} />;
 };
-
-const Label = forwardRef(_Label);
 
 export { Label };
 export type { LabelProps };

--- a/packages/components/src/Link.tsx
+++ b/packages/components/src/Link.tsx
@@ -1,11 +1,10 @@
 import type { DOMProps } from '@react-types/shared';
 import type { VariantProps } from 'class-variance-authority';
-import type { ForwardedRef } from 'react';
+import type { RefObject } from 'react';
 import type { LinkProps as AriaLinkProps } from 'react-aria-components';
 
 import { Icon } from '@launchpad-ui/icons';
 import { cva } from 'class-variance-authority';
-import { forwardRef } from 'react';
 import { Link as AriaLink, composeRenderProps, useSlottedContext } from 'react-aria-components';
 
 import { LinkContext } from './Breadcrumbs';
@@ -23,12 +22,16 @@ const link = cva(styles.base, {
 	},
 });
 
-interface LinkProps extends AriaLinkProps, VariantProps<typeof link>, DOMProps {}
+interface LinkProps extends AriaLinkProps, VariantProps<typeof link>, DOMProps {
+	ref?: RefObject<HTMLAnchorElement | null>;
+}
 
-const _Link = (
-	{ variant = 'default', href, ...props }: LinkProps,
-	ref: ForwardedRef<HTMLAnchorElement>,
-) => {
+/**
+ * A link allows a user to navigate to another page or resource within a web page or application.
+ *
+ * https://react-spectrum.adobe.com/react-aria/Link.html
+ */
+const Link = ({ variant = 'default', href, ref, ...props }: LinkProps) => {
 	const linkProps = useSlottedContext(LinkContext);
 
 	return (
@@ -46,13 +49,6 @@ const _Link = (
 		</>
 	);
 };
-
-/**
- * A link allows a user to navigate to another page or resource within a web page or application.
- *
- * https://react-spectrum.adobe.com/react-aria/Link.html
- */
-const Link = forwardRef(_Link);
 
 export { Link };
 export type { LinkProps };

--- a/packages/components/src/LinkButton.tsx
+++ b/packages/components/src/LinkButton.tsx
@@ -1,8 +1,6 @@
-import type { ForwardedRef } from 'react';
 import type { ButtonVariants } from './Button';
 import type { LinkProps } from './Link';
 
-import { forwardRef } from 'react';
 import { composeRenderProps } from 'react-aria-components';
 
 import { button } from './Button';
@@ -10,10 +8,12 @@ import { Link } from './Link';
 
 interface LinkButtonProps extends Omit<LinkProps, 'variant'>, ButtonVariants {}
 
-const _LinkButton = (
-	{ size = 'medium', variant = 'default', ...props }: LinkButtonProps,
-	ref: ForwardedRef<HTMLAnchorElement>,
-) => {
+/**
+ * A link allows a user to navigate to another page or resource within a web page or application.
+ *
+ * https://react-spectrum.adobe.com/react-aria/Link.html
+ */
+const LinkButton = ({ size = 'medium', variant = 'default', ref, ...props }: LinkButtonProps) => {
 	return (
 		<Link
 			{...props}
@@ -25,13 +25,6 @@ const _LinkButton = (
 		/>
 	);
 };
-
-/**
- * A link allows a user to navigate to another page or resource within a web page or application.
- *
- * https://react-spectrum.adobe.com/react-aria/Link.html
- */
-const LinkButton = forwardRef(_LinkButton);
 
 export { LinkButton };
 export type { LinkButtonProps };

--- a/packages/components/src/LinkIconButton.tsx
+++ b/packages/components/src/LinkIconButton.tsx
@@ -1,10 +1,8 @@
-import type { ForwardedRef } from 'react';
 import type { IconButtonBaseProps } from './IconButton';
 import type { LinkProps } from './Link';
 
 import { Icon } from '@launchpad-ui/icons';
 import { cx } from 'class-variance-authority';
-import { forwardRef } from 'react';
 import { composeRenderProps } from 'react-aria-components';
 
 import { button } from './Button';
@@ -15,10 +13,18 @@ interface LinkIconButtonProps
 	extends Omit<LinkProps, 'variant' | 'children' | 'aria-label'>,
 		IconButtonBaseProps {}
 
-const _LinkIconButton = (
-	{ size = 'medium', variant = 'default', icon, ...props }: LinkIconButtonProps,
-	ref: ForwardedRef<HTMLAnchorElement>,
-) => {
+/**
+ * A link allows a user to navigate to another page or resource within a web page or application.
+ *
+ * https://react-spectrum.adobe.com/react-aria/Link.html
+ */
+const LinkIconButton = ({
+	size = 'medium',
+	variant = 'default',
+	icon,
+	ref,
+	...props
+}: LinkIconButtonProps) => {
 	return (
 		<Link
 			{...props}
@@ -32,13 +38,6 @@ const _LinkIconButton = (
 		</Link>
 	);
 };
-
-/**
- * A link allows a user to navigate to another page or resource within a web page or application.
- *
- * https://react-spectrum.adobe.com/react-aria/Link.html
- */
-const LinkIconButton = forwardRef(_LinkIconButton);
 
 export { LinkIconButton };
 export type { LinkIconButtonProps };

--- a/packages/components/src/ListBox.tsx
+++ b/packages/components/src/ListBox.tsx
@@ -1,10 +1,11 @@
-import type { forwardRefType } from '@react-types/shared';
-import type { ForwardedRef } from 'react';
-import type { ListBoxItemProps, ListBoxProps } from 'react-aria-components';
+import type { RefObject } from 'react';
+import type {
+	ListBoxItemProps as AriaListBoxItemProps,
+	ListBoxProps as AriaListBoxProps,
+} from 'react-aria-components';
 
 import { Icon } from '@launchpad-ui/icons';
 import { cva } from 'class-variance-authority';
-import { forwardRef } from 'react';
 import {
 	ListBox as AriaListBox,
 	ListBoxItem as AriaListBoxItem,
@@ -16,7 +17,19 @@ import styles from './styles/ListBox.module.css';
 const box = cva(styles.box);
 const item = cva(styles.item);
 
-const _ListBox = <T extends object>(props: ListBoxProps<T>, ref: ForwardedRef<HTMLDivElement>) => {
+interface ListBoxProps<T> extends AriaListBoxProps<T> {
+	ref?: RefObject<HTMLDivElement | null>;
+}
+interface ListBoxItemProps<T> extends AriaListBoxItemProps<T> {
+	ref?: RefObject<T | null>;
+}
+
+/**
+ * A listbox displays a list of options and allows a user to select one or more of them.
+ *
+ * https://react-spectrum.adobe.com/react-aria/ListBox.html
+ */
+const ListBox = <T extends object>({ ref, ...props }: ListBoxProps<T>) => {
 	return (
 		<AriaListBox
 			{...props}
@@ -29,13 +42,11 @@ const _ListBox = <T extends object>(props: ListBoxProps<T>, ref: ForwardedRef<HT
 };
 
 /**
- * A listbox displays a list of options and allows a user to select one or more of them.
+ * A ListBoxItem represents an individual option in a ListBox.
  *
  * https://react-spectrum.adobe.com/react-aria/ListBox.html
  */
-const ListBox = (forwardRef as forwardRefType)(_ListBox);
-
-const _ListBoxItem = <T extends object>(props: ListBoxItemProps<T>, ref: ForwardedRef<T>) => {
+const ListBoxItem = <T extends object>({ ref, ...props }: ListBoxItemProps<T>) => {
 	const textValue =
 		props.textValue || (typeof props.children === 'string' ? props.children : undefined);
 	return (
@@ -56,13 +67,6 @@ const _ListBoxItem = <T extends object>(props: ListBoxItemProps<T>, ref: Forward
 		</AriaListBoxItem>
 	);
 };
-
-/**
- * A ListBoxItem represents an individual option in a ListBox.
- *
- * https://react-spectrum.adobe.com/react-aria/ListBox.html
- */
-const ListBoxItem = (forwardRef as forwardRefType)(_ListBoxItem);
 
 export { ListBox, ListBoxItem };
 export type { ListBoxProps, ListBoxItemProps };

--- a/packages/components/src/Menu.tsx
+++ b/packages/components/src/Menu.tsx
@@ -1,6 +1,5 @@
-import type { forwardRefType } from '@react-types/shared';
 import type { VariantProps } from 'class-variance-authority';
-import type { ForwardedRef } from 'react';
+import type { RefObject } from 'react';
 import type {
 	MenuItemProps as AriaMenuItemProps,
 	MenuProps as AriaMenuProps,
@@ -10,7 +9,6 @@ import type {
 
 import { Icon } from '@launchpad-ui/icons';
 import { cva } from 'class-variance-authority';
-import { forwardRef } from 'react';
 import {
 	Menu as AriaMenu,
 	MenuItem as AriaMenuItem,
@@ -36,27 +34,26 @@ const item = cva(styles.item, {
 	},
 });
 
-interface MenuProps<T> extends AriaMenuProps<T> {}
-interface MenuItemProps<T> extends AriaMenuItemProps<T>, VariantProps<typeof item> {}
-
-const _Menu = <T extends object>(
-	{ className, ...props }: MenuProps<T>,
-	ref: ForwardedRef<HTMLDivElement>,
-) => {
-	return <AriaMenu {...props} ref={ref} className={menu({ className })} />;
-};
+interface MenuProps<T> extends AriaMenuProps<T> {
+	ref?: RefObject<HTMLDivElement | null>;
+}
+interface MenuItemProps<T> extends AriaMenuItemProps<T>, VariantProps<typeof item> {
+	ref?: RefObject<T | null>;
+}
 
 /**
  * A menu displays a list of actions or options that a user can choose.
  *
  * https://react-spectrum.adobe.com/react-aria/Menu.html
  */
-const Menu = (forwardRef as forwardRefType)(_Menu);
+const Menu = <T extends object>({ className, ref, ...props }: MenuProps<T>) => {
+	return <AriaMenu {...props} ref={ref} className={menu({ className })} />;
+};
 
-const _MenuItem = <T extends object>(
-	{ variant = 'default', ...props }: MenuItemProps<T>,
-	ref: ForwardedRef<T>,
-) => {
+/**
+ * A MenuItem represents an individual action in a Menu.
+ */
+const MenuItem = <T extends object>({ variant = 'default', ref, ...props }: MenuItemProps<T>) => {
 	return (
 		<AriaMenuItem
 			{...props}
@@ -91,11 +88,6 @@ const _MenuItem = <T extends object>(
 		</AriaMenuItem>
 	);
 };
-
-/**
- * A MenuItem represents an individual action in a Menu.
- */
-const MenuItem = (forwardRef as forwardRefType)(_MenuItem);
 
 export { Menu, MenuItem, MenuTrigger, SubmenuTrigger };
 export type { MenuProps, MenuItemProps, MenuTriggerProps, SubmenuTriggerProps };

--- a/packages/components/src/Meter.tsx
+++ b/packages/components/src/Meter.tsx
@@ -1,8 +1,7 @@
-import type { ForwardedRef } from 'react';
-import type { MeterProps } from 'react-aria-components';
+import type { RefObject } from 'react';
+import type { MeterProps as AriaMeterProps } from 'react-aria-components';
 
 import { cva } from 'class-variance-authority';
-import { forwardRef } from 'react';
 import { Meter as AriaMeter, composeRenderProps } from 'react-aria-components';
 import styles from './styles/Meter.module.css';
 
@@ -10,7 +9,16 @@ const meter = cva(styles.meter);
 
 const icon = cva(styles.base);
 
-const _Meter = (props: MeterProps, ref: ForwardedRef<HTMLDivElement>) => {
+interface MeterProps extends AriaMeterProps {
+	ref?: RefObject<HTMLDivElement | null>;
+}
+
+/**
+ * A meter represents a quantity within a known range, or a fractional value.
+ *
+ * https://react-spectrum.adobe.com/react-aria/Meter.html
+ */
+const Meter = ({ ref, ...props }: MeterProps) => {
 	const center = 64;
 	const strokeWidth = 8;
 	const r = 64 - strokeWidth;
@@ -52,13 +60,6 @@ const _Meter = (props: MeterProps, ref: ForwardedRef<HTMLDivElement>) => {
 		</AriaMeter>
 	);
 };
-
-/**
- * A meter represents a quantity within a known range, or a fractional value.
- *
- * https://react-spectrum.adobe.com/react-aria/Meter.html
- */
-const Meter = forwardRef(_Meter);
 
 export { Meter };
 export type { MeterProps };

--- a/packages/components/src/Modal.tsx
+++ b/packages/components/src/Modal.tsx
@@ -1,9 +1,8 @@
 import type { VariantProps } from 'class-variance-authority';
-import type { ForwardedRef } from 'react';
-import type { ModalOverlayProps } from 'react-aria-components';
+import type { RefObject } from 'react';
+import type { ModalOverlayProps as AriaModalOverlayProps } from 'react-aria-components';
 
 import { cva } from 'class-variance-authority';
-import { forwardRef } from 'react';
 import {
 	Modal as AriaModal,
 	ModalOverlay as AriaModalOverlay,
@@ -31,12 +30,20 @@ const modal = cva(styles.base, {
 });
 const overlay = cva(styles.overlay);
 
-interface ModalProps extends ModalOverlayProps, VariantProps<typeof modal> {}
+interface ModalProps extends AriaModalOverlayProps, VariantProps<typeof modal> {
+	ref?: RefObject<HTMLDivElement | null>;
+}
 
-const _Modal = (
-	{ size = 'medium', variant = 'default', ...props }: ModalProps,
-	ref: ForwardedRef<HTMLDivElement>,
-) => {
+interface ModalOverlayProps extends AriaModalOverlayProps, VariantProps<typeof modal> {
+	ref?: RefObject<HTMLDivElement | null>;
+}
+
+/**
+ * A modal is an overlay element which blocks interaction with elements outside it.
+ *
+ * https://react-spectrum.adobe.com/react-aria/Modal.html
+ */
+const Modal = ({ size = 'medium', variant = 'default', ref, ...props }: ModalProps) => {
 	return (
 		<AriaModal
 			{...props}
@@ -49,16 +56,9 @@ const _Modal = (
 };
 
 /**
- * A modal is an overlay element which blocks interaction with elements outside it.
- *
- * https://react-spectrum.adobe.com/react-aria/Modal.html
+ * A ModalOverlay is a wrapper for a Modal which allows customizing the backdrop element.
  */
-const Modal = forwardRef(_Modal);
-
-const _ModalOverlay = (
-	{ isDismissable = true, ...props }: ModalOverlayProps,
-	ref: ForwardedRef<HTMLDivElement>,
-) => {
+const ModalOverlay = ({ isDismissable = true, ref, ...props }: ModalOverlayProps) => {
 	return (
 		<AriaModalOverlay
 			isDismissable={isDismissable}
@@ -70,11 +70,6 @@ const _ModalOverlay = (
 		/>
 	);
 };
-
-/**
- * A ModalOverlay is a wrapper for a Modal which allows customizing the backdrop element.
- */
-const ModalOverlay = forwardRef(_ModalOverlay);
 
 export { Modal, ModalOverlay };
 export type { ModalProps, ModalOverlayProps };

--- a/packages/components/src/NumberField.tsx
+++ b/packages/components/src/NumberField.tsx
@@ -1,15 +1,23 @@
-import type { ForwardedRef } from 'react';
-import type { NumberFieldProps } from 'react-aria-components';
+import type { RefObject } from 'react';
+import type { NumberFieldProps as AriaNumberFieldProps } from 'react-aria-components';
 
 import { cva } from 'class-variance-authority';
-import { forwardRef } from 'react';
 import { NumberField as AriaNumberField, composeRenderProps } from 'react-aria-components';
 
 import styles from './styles/NumberField.module.css';
 
 const number = cva(styles.number);
 
-const _NumberField = (props: NumberFieldProps, ref: ForwardedRef<HTMLDivElement>) => {
+interface NumberFieldProps extends AriaNumberFieldProps {
+	ref?: RefObject<HTMLDivElement | null>;
+}
+
+/**
+ * A number field allows a user to enter a number, and increment or decrement the value using stepper buttons.
+ *
+ * https://react-spectrum.adobe.com/react-aria/NumberField.html
+ */
+const NumberField = ({ ref, ...props }: NumberFieldProps) => {
 	return (
 		<AriaNumberField
 			{...props}
@@ -25,13 +33,6 @@ const _NumberField = (props: NumberFieldProps, ref: ForwardedRef<HTMLDivElement>
 		/>
 	);
 };
-
-/**
- * A number field allows a user to enter a number, and increment or decrement the value using stepper buttons.
- *
- * https://react-spectrum.adobe.com/react-aria/NumberField.html
- */
-const NumberField = forwardRef(_NumberField);
 
 export { NumberField };
 export type { NumberFieldProps };

--- a/packages/components/src/Popover.tsx
+++ b/packages/components/src/Popover.tsx
@@ -1,11 +1,11 @@
-import type { ForwardedRef } from 'react';
+import type { RefObject } from 'react';
 import type {
 	OverlayArrowProps as AriaOverlayArrowProps,
 	PopoverProps as AriaPopoverProps,
 } from 'react-aria-components';
 
 import { cva } from 'class-variance-authority';
-import { forwardRef, useContext } from 'react';
+import { useContext } from 'react';
 import {
 	OverlayArrow as AriaOverlayArrow,
 	Popover as AriaPopover,
@@ -15,13 +15,22 @@ import {
 import { PopoverContext } from './ComboBox';
 import styles from './styles/Popover.module.css';
 
-interface PopoverProps extends AriaPopoverProps {}
-interface OverlayArrowProps extends Omit<AriaOverlayArrowProps, 'children'> {}
+interface PopoverProps extends AriaPopoverProps {
+	ref?: RefObject<HTMLElement | null>;
+}
+interface OverlayArrowProps extends Omit<AriaOverlayArrowProps, 'children'> {
+	ref?: RefObject<HTMLDivElement | null>;
+}
 
 const popover = cva(styles.popover);
 const arrow = cva(styles.arrow);
 
-const _Popover = (props: PopoverProps, ref: ForwardedRef<HTMLElement>) => {
+/**
+ * A popover is an overlay element positioned relative to a trigger.
+ *
+ * https://react-spectrum.adobe.com/react-aria/Popover.html
+ */
+const Popover = ({ ref, ...props }: PopoverProps) => {
 	const popoverProps = useContext(PopoverContext);
 
 	return (
@@ -39,13 +48,11 @@ const _Popover = (props: PopoverProps, ref: ForwardedRef<HTMLElement>) => {
 };
 
 /**
- * A popover is an overlay element positioned relative to a trigger.
+ * An OverlayArrow renders a custom arrow element relative to an overlay element such as a popover or tooltip such that it aligns with a trigger element.
  *
  * https://react-spectrum.adobe.com/react-aria/Popover.html
  */
-const Popover = forwardRef(_Popover);
-
-const _OverlayArrow = (props: OverlayArrowProps, ref: ForwardedRef<HTMLDivElement>) => {
+const OverlayArrow = ({ ref, ...props }: OverlayArrowProps) => {
 	return (
 		<AriaOverlayArrow
 			{...props}
@@ -61,13 +68,6 @@ const _OverlayArrow = (props: OverlayArrowProps, ref: ForwardedRef<HTMLDivElemen
 		</AriaOverlayArrow>
 	);
 };
-
-/**
- * An OverlayArrow renders a custom arrow element relative to an overlay element such as a popover or tooltip such that it aligns with a trigger element.
- *
- * https://react-spectrum.adobe.com/react-aria/Popover.html
- */
-const OverlayArrow = forwardRef(_OverlayArrow);
 
 export { OverlayArrow, Popover };
 export type { OverlayArrowProps, PopoverProps };

--- a/packages/components/src/Pressable.tsx
+++ b/packages/components/src/Pressable.tsx
@@ -1,9 +1,8 @@
-import type { ElementType, ForwardedRef, HTMLAttributes } from 'react';
+import type { ElementType, HTMLAttributes, RefObject } from 'react';
 import type { AriaButtonProps, HoverEvents } from 'react-aria';
 
 import { useObjectRef } from '@react-aria/utils';
 import { cva } from 'class-variance-authority';
-import { forwardRef } from 'react';
 import { mergeProps, useButton, useFocusRing, useHover } from 'react-aria';
 
 import styles from './styles/Pressable.module.css';
@@ -13,12 +12,17 @@ const pressable = cva(styles.pressable);
 interface PressableProps<T extends ElementType = 'button'>
 	extends AriaButtonProps<T>,
 		HoverEvents,
-		Pick<HTMLAttributes<T>, 'className'> {}
+		Pick<HTMLAttributes<T>, 'className'> {
+	ref?: RefObject<HTMLElement | null>;
+}
 
-const _Pressable = <T extends ElementType = 'span'>(
-	{ children, elementType, className, ...props }: PressableProps<T>,
-	ref: ForwardedRef<HTMLElement>,
-) => {
+const Pressable = <T extends ElementType = 'span'>({
+	children,
+	elementType,
+	className,
+	ref,
+	...props
+}: PressableProps<T>) => {
 	const domRef = useObjectRef(ref);
 	const ElementType = elementType || 'span';
 
@@ -47,8 +51,6 @@ const _Pressable = <T extends ElementType = 'span'>(
 		</ElementType>
 	);
 };
-
-const Pressable = forwardRef(_Pressable);
 
 export { Pressable };
 export type { PressableProps };

--- a/packages/components/src/ProgressBar.tsx
+++ b/packages/components/src/ProgressBar.tsx
@@ -1,9 +1,8 @@
 import type { VariantProps } from 'class-variance-authority';
-import type { ForwardedRef } from 'react';
+import type { RefObject } from 'react';
 import type { ProgressBarProps as AriaProgressBarProps } from 'react-aria-components';
 
 import { cva, cx } from 'class-variance-authority';
-import { forwardRef } from 'react';
 import { ProgressBar as AriaProgressBar, composeRenderProps } from 'react-aria-components';
 
 import styles from './styles/ProgressBar.module.css';
@@ -23,12 +22,16 @@ const icon = cva(styles.base, {
 	},
 });
 
-interface ProgressBarProps extends AriaProgressBarProps, VariantProps<typeof icon> {}
+interface ProgressBarProps extends AriaProgressBarProps, VariantProps<typeof icon> {
+	ref?: RefObject<HTMLDivElement | null>;
+}
 
-const _ProgressBar = (
-	{ size = 'small', ...props }: ProgressBarProps,
-	ref: ForwardedRef<HTMLDivElement>,
-) => {
+/**
+ * Progress bars show either determinate or indeterminate progress of an operation over time.
+ *
+ * https://react-spectrum.adobe.com/react-aria/ProgressBar.html
+ */
+const ProgressBar = ({ size = 'small', ref, ...props }: ProgressBarProps) => {
 	const center = 16;
 	const strokeWidth = 4;
 	const r = 16 - strokeWidth;
@@ -71,13 +74,6 @@ const _ProgressBar = (
 		</AriaProgressBar>
 	);
 };
-
-/**
- * Progress bars show either determinate or indeterminate progress of an operation over time.
- *
- * https://react-spectrum.adobe.com/react-aria/ProgressBar.html
- */
-const ProgressBar = forwardRef(_ProgressBar);
 
 export { ProgressBar };
 export type { ProgressBarProps };

--- a/packages/components/src/Radio.tsx
+++ b/packages/components/src/Radio.tsx
@@ -1,9 +1,8 @@
-import type { ForwardedRef } from 'react';
-import type { RadioProps, RadioRenderProps } from 'react-aria-components';
+import type { RefObject } from 'react';
+import type { RadioProps as AriaRadioProps, RadioRenderProps } from 'react-aria-components';
 
 import { Icon } from '@launchpad-ui/icons';
 import { cva } from 'class-variance-authority';
-import { forwardRef } from 'react';
 import { Radio as AriaRadio, composeRenderProps } from 'react-aria-components';
 
 import styles from './styles/Radio.module.css';
@@ -11,13 +10,22 @@ import styles from './styles/Radio.module.css';
 const radio = cva(styles.radio);
 const circle = cva(styles.circle);
 
+interface RadioProps extends AriaRadioProps {
+	ref?: RefObject<HTMLLabelElement | null>;
+}
+
 const RadioInner = ({ isSelected }: Partial<RadioRenderProps>) => (
 	<div className={circle()}>
 		{isSelected ? <Icon name="circle" className={styles.icon} /> : null}
 	</div>
 );
 
-const _Radio = (props: RadioProps, ref: ForwardedRef<HTMLLabelElement>) => {
+/**
+ * A radio represents an individual option within a radio group.
+ *
+ * https://react-spectrum.adobe.com/react-aria/RadioGroup.html
+ */
+const Radio = ({ ref, ...props }: RadioProps) => {
 	return (
 		<AriaRadio
 			{...props}
@@ -35,13 +43,6 @@ const _Radio = (props: RadioProps, ref: ForwardedRef<HTMLLabelElement>) => {
 		</AriaRadio>
 	);
 };
-
-/**
- * A radio represents an individual option within a radio group.
- *
- * https://react-spectrum.adobe.com/react-aria/RadioGroup.html
- */
-const Radio = forwardRef(_Radio);
 
 export { Radio, RadioInner, radio };
 export type { RadioProps };

--- a/packages/components/src/RadioButton.tsx
+++ b/packages/components/src/RadioButton.tsx
@@ -1,18 +1,21 @@
-import type { ForwardedRef } from 'react';
+import type { RefObject } from 'react';
 import type { RadioProps } from 'react-aria-components';
 import type { ButtonVariants } from './Button';
 
-import { forwardRef } from 'react';
 import { Radio as AriaRadio, composeRenderProps } from 'react-aria-components';
 
 import { button } from './Button';
 
-interface RadioButtonProps extends RadioProps, ButtonVariants {}
+interface RadioButtonProps extends RadioProps, ButtonVariants {
+	ref?: RefObject<HTMLLabelElement | null>;
+}
 
-const _RadioButton = (
-	{ size = 'medium', variant = 'default', ...props }: RadioButtonProps,
-	ref: ForwardedRef<HTMLLabelElement>,
-) => {
+/**
+ * A radio represents an individual option within a radio group.
+ *
+ * https://react-spectrum.adobe.com/react-aria/RadioGroup.html
+ */
+const RadioButton = ({ size = 'medium', variant = 'default', ref, ...props }: RadioButtonProps) => {
 	return (
 		<AriaRadio
 			{...props}
@@ -23,13 +26,6 @@ const _RadioButton = (
 		/>
 	);
 };
-
-/**
- * A radio represents an individual option within a radio group.
- *
- * https://react-spectrum.adobe.com/react-aria/RadioGroup.html
- */
-const RadioButton = forwardRef(_RadioButton);
 
 export { RadioButton };
 export type { RadioButtonProps };

--- a/packages/components/src/RadioGroup.tsx
+++ b/packages/components/src/RadioGroup.tsx
@@ -1,15 +1,23 @@
-import type { ForwardedRef } from 'react';
-import type { RadioGroupProps } from 'react-aria-components';
+import type { RefObject } from 'react';
+import type { RadioGroupProps as AriaRadioGroupProps } from 'react-aria-components';
 
 import { cva } from 'class-variance-authority';
-import { forwardRef } from 'react';
 import { RadioGroup as AriaRadioGroup, composeRenderProps } from 'react-aria-components';
 
 import styles from './styles/RadioGroup.module.css';
 
 const group = cva(styles.group);
 
-const _RadioGroup = (props: RadioGroupProps, ref: ForwardedRef<HTMLDivElement>) => {
+interface RadioGroupProps extends AriaRadioGroupProps {
+	ref?: RefObject<HTMLDivElement | null>;
+}
+
+/**
+ * A radio group allows a user to select a single item from a list of mutually exclusive options.
+ *
+ * https://react-spectrum.adobe.com/react-aria/RadioGroup.html
+ */
+const RadioGroup = ({ ref, ...props }: RadioGroupProps) => {
 	return (
 		<AriaRadioGroup
 			{...props}
@@ -20,13 +28,6 @@ const _RadioGroup = (props: RadioGroupProps, ref: ForwardedRef<HTMLDivElement>) 
 		/>
 	);
 };
-
-/**
- * A radio group allows a user to select a single item from a list of mutually exclusive options.
- *
- * https://react-spectrum.adobe.com/react-aria/RadioGroup.html
- */
-const RadioGroup = forwardRef(_RadioGroup);
 
 export { RadioGroup };
 export type { RadioGroupProps };

--- a/packages/components/src/RadioIconButton.tsx
+++ b/packages/components/src/RadioIconButton.tsx
@@ -1,10 +1,9 @@
-import type { ForwardedRef } from 'react';
+import type { RefObject } from 'react';
 import type { RadioProps } from 'react-aria-components';
 import type { IconButtonBaseProps } from './IconButton';
 
 import { Icon } from '@launchpad-ui/icons';
 import { cx } from 'class-variance-authority';
-import { forwardRef } from 'react';
 import { Radio as AriaRadio, composeRenderProps } from 'react-aria-components';
 
 import { button } from './Button';
@@ -12,12 +11,22 @@ import { iconButton } from './IconButton';
 
 interface RadioIconButtonProps
 	extends Omit<RadioProps, 'children' | 'aria-label'>,
-		IconButtonBaseProps {}
+		IconButtonBaseProps {
+	ref?: RefObject<HTMLLabelElement | null>;
+}
 
-const _RadioIconButton = (
-	{ size = 'medium', variant = 'default', icon, ...props }: RadioIconButtonProps,
-	ref: ForwardedRef<HTMLLabelElement>,
-) => {
+/**
+ * A radio represents an individual option within a radio group.
+ *
+ * https://react-spectrum.adobe.com/react-aria/RadioGroup.html
+ */
+const RadioIconButton = ({
+	size = 'medium',
+	variant = 'default',
+	icon,
+	ref,
+	...props
+}: RadioIconButtonProps) => {
 	return (
 		<AriaRadio
 			{...props}
@@ -30,13 +39,6 @@ const _RadioIconButton = (
 		</AriaRadio>
 	);
 };
-
-/**
- * A radio represents an individual option within a radio group.
- *
- * https://react-spectrum.adobe.com/react-aria/RadioGroup.html
- */
-const RadioIconButton = forwardRef(_RadioIconButton);
 
 export { RadioIconButton };
 export type { RadioIconButtonProps };

--- a/packages/components/src/SearchField.tsx
+++ b/packages/components/src/SearchField.tsx
@@ -1,15 +1,23 @@
-import type { ForwardedRef } from 'react';
-import type { SearchFieldProps } from 'react-aria-components';
+import type { RefObject } from 'react';
+import type { SearchFieldProps as AriaSearchFieldProps } from 'react-aria-components';
 
 import { cva } from 'class-variance-authority';
-import { forwardRef } from 'react';
 import { SearchField as AriaSearchField, composeRenderProps } from 'react-aria-components';
 
 import styles from './styles/SearchField.module.css';
 
 const search = cva(styles.search);
 
-const _SearchField = (props: SearchFieldProps, ref: ForwardedRef<HTMLDivElement>) => {
+interface SearchFieldProps extends AriaSearchFieldProps {
+	ref?: RefObject<HTMLDivElement | null>;
+}
+
+/**
+ * A search field allows a user to enter and clear a search query.
+ *
+ * https://react-spectrum.adobe.com/react-aria/SearchField.html
+ */
+const SearchField = ({ ref, ...props }: SearchFieldProps) => {
 	return (
 		<AriaSearchField
 			{...props}
@@ -20,13 +28,6 @@ const _SearchField = (props: SearchFieldProps, ref: ForwardedRef<HTMLDivElement>
 		/>
 	);
 };
-
-/**
- * A search field allows a user to enter and clear a search query.
- *
- * https://react-spectrum.adobe.com/react-aria/SearchField.html
- */
-const SearchField = forwardRef(_SearchField);
 
 export { SearchField };
 export type { SearchFieldProps };

--- a/packages/components/src/Section.tsx
+++ b/packages/components/src/Section.tsx
@@ -1,9 +1,10 @@
-import type { forwardRefType } from '@react-types/shared';
-import type { ForwardedRef } from 'react';
-import type { ListBoxSectionProps, MenuSectionProps } from 'react-aria-components';
+import type { RefObject } from 'react';
+import type {
+	ListBoxSectionProps as AriaListBoxSectionProps,
+	MenuSectionProps as AriaMenuSectionProps,
+} from 'react-aria-components';
 
 import { cva } from 'class-variance-authority';
-import { forwardRef } from 'react';
 import {
 	ListBoxSection as AriaListBoxSection,
 	MenuSection as AriaMenuSection,
@@ -13,29 +14,27 @@ import styles from './styles/Section.module.css';
 
 const section = cva(styles.section);
 
-const _ListBoxSection = <T extends object>(
-	{ className, ...props }: ListBoxSectionProps<T>,
-	ref: ForwardedRef<HTMLElement>,
-) => {
-	return <AriaListBoxSection {...props} ref={ref} className={section({ className })} />;
-};
+interface ListBoxSectionProps<T extends object> extends AriaListBoxSectionProps<T> {
+	ref?: RefObject<HTMLElement | null>;
+}
+
+interface MenuSectionProps<T extends object> extends AriaMenuSectionProps<T> {
+	ref?: RefObject<HTMLElement | null>;
+}
 
 /**
  * A ListBoxSection represents a section within a ListBox.
  */
-const ListBoxSection = (forwardRef as forwardRefType)(_ListBoxSection);
-
-const _MenuSection = <T extends object>(
-	{ className, ...props }: MenuSectionProps<T>,
-	ref: ForwardedRef<HTMLElement>,
-) => {
-	return <AriaMenuSection {...props} ref={ref} className={section({ className })} />;
+const ListBoxSection = <T extends object>({ className, ref, ...props }: ListBoxSectionProps<T>) => {
+	return <AriaListBoxSection {...props} ref={ref} className={section({ className })} />;
 };
 
 /**
  * A MenuSection represents a section within a Menu.
  */
-const MenuSection = (forwardRef as forwardRefType)(_MenuSection);
+const MenuSection = <T extends object>({ className, ref, ...props }: MenuSectionProps<T>) => {
+	return <AriaMenuSection {...props} ref={ref} className={section({ className })} />;
+};
 
 export { ListBoxSection, MenuSection };
 export type { ListBoxSectionProps, MenuSectionProps };

--- a/packages/components/src/Select.tsx
+++ b/packages/components/src/Select.tsx
@@ -1,9 +1,10 @@
-import type { forwardRefType } from '@react-types/shared';
-import type { ForwardedRef } from 'react';
-import type { SelectProps, SelectValueProps } from 'react-aria-components';
+import type { RefObject } from 'react';
+import type {
+	SelectProps as AriaSelectProps,
+	SelectValueProps as AriaSelectValueProps,
+} from 'react-aria-components';
 
 import { cva } from 'class-variance-authority';
-import { forwardRef } from 'react';
 import {
 	Select as AriaSelect,
 	SelectValue as AriaSelectValue,
@@ -15,7 +16,20 @@ import styles from './styles/Select.module.css';
 const select = cva(styles.select);
 const value = cva(styles.value);
 
-const _Select = <T extends object>(props: SelectProps<T>, ref: ForwardedRef<HTMLDivElement>) => {
+interface SelectProps<T extends object> extends AriaSelectProps<T> {
+	ref?: RefObject<HTMLDivElement | null>;
+}
+
+interface SelectValueProps<T extends object> extends AriaSelectValueProps<T> {
+	ref?: RefObject<HTMLSpanElement | null>;
+}
+
+/**
+ * A select displays a collapsible list of options and allows a user to select one of them.
+ *
+ * https://react-spectrum.adobe.com/react-aria/Select.html
+ */
+const Select = <T extends object>({ ref, ...props }: SelectProps<T>) => {
 	return (
 		<AriaSelect
 			{...props}
@@ -28,16 +42,11 @@ const _Select = <T extends object>(props: SelectProps<T>, ref: ForwardedRef<HTML
 };
 
 /**
- * A select displays a collapsible list of options and allows a user to select one of them.
+ * SelectValue renders the current value of a Select, or a placeholder if no value is selected. It is usually placed within the button element.
  *
  * https://react-spectrum.adobe.com/react-aria/Select.html
  */
-const Select = (forwardRef as forwardRefType)(_Select);
-
-const _SelectValue = <T extends object>(
-	props: SelectValueProps<T>,
-	ref: ForwardedRef<HTMLSpanElement>,
-) => {
+const SelectValue = <T extends object>({ ref, ...props }: SelectValueProps<T>) => {
 	return (
 		<AriaSelectValue
 			{...props}
@@ -48,13 +57,6 @@ const _SelectValue = <T extends object>(
 		/>
 	);
 };
-
-/**
- * SelectValue renders the current value of a Select, or a placeholder if no value is selected. It is usually placed within the button element.
- *
- * https://react-spectrum.adobe.com/react-aria/Select.html
- */
-const SelectValue = (forwardRef as forwardRefType)(_SelectValue);
 
 export { Select, SelectValue };
 export type { SelectProps, SelectValueProps };

--- a/packages/components/src/Separator.tsx
+++ b/packages/components/src/Separator.tsx
@@ -1,19 +1,20 @@
-import type { ForwardedRef } from 'react';
-import type { SeparatorProps } from 'react-aria-components';
+import type { RefObject } from 'react';
+import type { SeparatorProps as AriaSeparatorProps } from 'react-aria-components';
 
 import { cva } from 'class-variance-authority';
-import { forwardRef } from 'react';
 import { Separator as AriaSeparator } from 'react-aria-components';
 
 import styles from './styles/Separator.module.css';
 
 const separator = cva(styles.separator);
 
-const _Separator = ({ className, ...props }: SeparatorProps, ref: ForwardedRef<HTMLElement>) => {
+interface SeparatorProps extends AriaSeparatorProps {
+	ref?: RefObject<HTMLElement | null>;
+}
+
+const Separator = ({ className, ref, ...props }: SeparatorProps) => {
 	return <AriaSeparator {...props} ref={ref} className={separator({ className })} />;
 };
-
-const Separator = forwardRef(_Separator);
 
 export { Separator };
 export type { SeparatorProps };

--- a/packages/components/src/Switch.tsx
+++ b/packages/components/src/Switch.tsx
@@ -1,8 +1,7 @@
-import type { ForwardedRef, ReactNode } from 'react';
+import type { ReactNode, RefObject } from 'react';
 import type { SwitchProps as AriaSwitchProps } from 'react-aria-components';
 
 import { cva } from 'class-variance-authority';
-import { forwardRef } from 'react';
 import { Switch as AriaSwitch, composeRenderProps } from 'react-aria-components';
 
 import styles from './styles/Switch.module.css';
@@ -11,9 +10,15 @@ const _switch = cva(styles.switch);
 
 interface SwitchProps extends Omit<AriaSwitchProps, 'children'> {
 	children?: ReactNode;
+	ref?: RefObject<HTMLLabelElement | null>;
 }
 
-const _Switch = (props: SwitchProps, ref: ForwardedRef<HTMLLabelElement>) => {
+/**
+ * A switch allows a user to turn a setting on or off.
+ *
+ * https://react-spectrum.adobe.com/react-aria/Switch.html
+ */
+const Switch = ({ ref, ...props }: SwitchProps) => {
 	return (
 		<AriaSwitch
 			{...props}
@@ -35,13 +40,6 @@ const _Switch = (props: SwitchProps, ref: ForwardedRef<HTMLLabelElement>) => {
 		</AriaSwitch>
 	);
 };
-
-/**
- * A switch allows a user to turn a setting on or off.
- *
- * https://react-spectrum.adobe.com/react-aria/Switch.html
- */
-const Switch = forwardRef(_Switch);
 
 export { Switch };
 export type { SwitchProps };

--- a/packages/components/src/Table.tsx
+++ b/packages/components/src/Table.tsx
@@ -1,19 +1,18 @@
-import type { forwardRefType } from '@react-types/shared';
-import type { ForwardedRef } from 'react';
+import type { RefObject } from 'react';
 import type {
-	CellProps,
-	ColumnProps,
-	ColumnResizerProps,
-	ResizableTableContainerProps,
-	RowProps,
-	TableBodyProps,
-	TableHeaderProps,
-	TableProps,
+	CellProps as AriaCellProps,
+	ColumnProps as AriaColumnProps,
+	ColumnResizerProps as AriaColumnResizerProps,
+	ResizableTableContainerProps as AriaResizableTableContainerProps,
+	RowProps as AriaRowProps,
+	TableBodyProps as AriaTableBodyProps,
+	TableHeaderProps as AriaTableHeaderProps,
+	TableProps as AriaTableProps,
 } from 'react-aria-components';
 
 import { Icon } from '@launchpad-ui/icons';
 import { cva } from 'class-variance-authority';
-import { createContext, forwardRef, useContext } from 'react';
+import { createContext, useContext } from 'react';
 import { VisuallyHidden } from 'react-aria';
 import {
 	Cell as AriaCell,
@@ -46,7 +45,44 @@ const ResizableTableContainerContext = createContext<{ resizable: boolean } | nu
 	resizable: false,
 });
 
-const _Table = (props: TableProps, ref: ForwardedRef<HTMLTableElement>) => {
+interface TableProps extends AriaTableProps {
+	ref?: RefObject<HTMLTableElement | null>;
+}
+
+interface ColumnProps extends AriaColumnProps {
+	ref?: RefObject<HTMLTableCellElement | null>;
+}
+
+interface TableHeaderProps<T extends object> extends AriaTableHeaderProps<T> {
+	ref?: RefObject<HTMLTableSectionElement | null>;
+}
+
+interface TableBodyProps<T extends object> extends AriaTableBodyProps<T> {
+	ref?: RefObject<HTMLTableSectionElement | null>;
+}
+
+interface RowProps<T extends object> extends AriaRowProps<T> {
+	ref?: RefObject<HTMLTableRowElement | null>;
+}
+
+interface CellProps extends AriaCellProps {
+	ref?: RefObject<HTMLTableCellElement | null>;
+}
+
+interface ColumnResizerProps extends AriaColumnResizerProps {
+	ref?: RefObject<HTMLDivElement | null>;
+}
+
+interface ResizableTableContainerProps extends AriaResizableTableContainerProps {
+	ref?: RefObject<HTMLDivElement | null>;
+}
+
+/**
+ * A table displays data in rows and columns and enables a user to navigate its contents via directional navigation keys, and optionally supports row selection and sorting.
+ *
+ * https://react-spectrum.adobe.com/react-aria/Table.html
+ */
+const Table = ({ ref, ...props }: TableProps) => {
 	return (
 		<AriaTable
 			{...props}
@@ -59,13 +95,11 @@ const _Table = (props: TableProps, ref: ForwardedRef<HTMLTableElement>) => {
 };
 
 /**
- * A table displays data in rows and columns and enables a user to navigate its contents via directional navigation keys, and optionally supports row selection and sorting.
+ * A column within a `<Table>`.
  *
  * https://react-spectrum.adobe.com/react-aria/Table.html
  */
-const Table = forwardRef(_Table);
-
-const _Column = (props: ColumnProps, ref: ForwardedRef<HTMLTableCellElement>) => {
+const Column = ({ ref, ...props }: ColumnProps) => {
 	const ctx = useContext(ResizableTableContainerContext);
 	return (
 		<AriaColumn
@@ -89,16 +123,11 @@ const _Column = (props: ColumnProps, ref: ForwardedRef<HTMLTableCellElement>) =>
 };
 
 /**
- * A column within a `<Table>`.
+ * A header within a `<Table>`, containing the table columns.
  *
  * https://react-spectrum.adobe.com/react-aria/Table.html
  */
-const Column = forwardRef(_Column);
-
-const _TableHeader = <T extends object>(
-	{ className, ...props }: TableHeaderProps<T>,
-	ref: ForwardedRef<HTMLTableSectionElement>,
-) => {
+const TableHeader = <T extends object>({ className, ref, ...props }: TableHeaderProps<T>) => {
 	const { selectionBehavior, selectionMode, allowsDragging } = useTableOptions();
 	return (
 		<AriaTableHeader {...props} ref={ref} className={header({ className })}>
@@ -116,16 +145,11 @@ const _TableHeader = <T extends object>(
 };
 
 /**
- * A header within a `<Table>`, containing the table columns.
+ * The body of a `<Table>`, containing the table rows.
  *
  * https://react-spectrum.adobe.com/react-aria/Table.html
  */
-const TableHeader = (forwardRef as forwardRefType)(_TableHeader);
-
-const _TableBody = <T extends object>(
-	props: TableBodyProps<T>,
-	ref: ForwardedRef<HTMLTableSectionElement>,
-) => {
+const TableBody = <T extends object>({ ref, ...props }: TableBodyProps<T>) => {
 	return (
 		<AriaTableBody
 			{...props}
@@ -138,16 +162,11 @@ const _TableBody = <T extends object>(
 };
 
 /**
- * The body of a `<Table>`, containing the table rows.
+ * A row within a `<Table>`.
  *
  * https://react-spectrum.adobe.com/react-aria/Table.html
  */
-const TableBody = (forwardRef as forwardRefType)(_TableBody);
-
-const _Row = <T extends object>(
-	{ columns, children, ...props }: RowProps<T>,
-	ref: ForwardedRef<HTMLTableRowElement>,
-) => {
+const Row = <T extends object>({ columns, children, ref, ...props }: RowProps<T>) => {
 	const { selectionBehavior, allowsDragging } = useTableOptions();
 
 	return (
@@ -175,13 +194,11 @@ const _Row = <T extends object>(
 };
 
 /**
- * A row within a `<Table>`.
+ * A cell within a table row.
  *
  * https://react-spectrum.adobe.com/react-aria/Table.html
  */
-const Row = (forwardRef as forwardRefType)(_Row);
-
-const _Cell = (props: CellProps, ref: ForwardedRef<HTMLTableCellElement>) => {
+const Cell = ({ ref, ...props }: CellProps) => {
 	return (
 		<AriaCell
 			{...props}
@@ -193,14 +210,7 @@ const _Cell = (props: CellProps, ref: ForwardedRef<HTMLTableCellElement>) => {
 	);
 };
 
-/**
- * A cell within a table row.
- *
- * https://react-spectrum.adobe.com/react-aria/Table.html
- */
-const Cell = forwardRef(_Cell);
-
-const _ColumnResizer = (props: ColumnResizerProps, ref: ForwardedRef<HTMLDivElement>) => {
+const ColumnResizer = ({ ref, ...props }: ColumnResizerProps) => {
 	return (
 		<AriaColumnResizer
 			{...props}
@@ -212,12 +222,7 @@ const _ColumnResizer = (props: ColumnResizerProps, ref: ForwardedRef<HTMLDivElem
 	);
 };
 
-const ColumnResizer = forwardRef(_ColumnResizer);
-
-const _ResizableTableContainer = (
-	{ children, ...props }: ResizableTableContainerProps,
-	ref: ForwardedRef<HTMLDivElement>,
-) => {
+const ResizableTableContainer = ({ children, ref, ...props }: ResizableTableContainerProps) => {
 	return (
 		<AriaResizableTableContainer {...props} ref={ref}>
 			<Provider values={[[ResizableTableContainerContext, { resizable: true }]]}>
@@ -226,8 +231,6 @@ const _ResizableTableContainer = (
 		</AriaResizableTableContainer>
 	);
 };
-
-const ResizableTableContainer = forwardRef(_ResizableTableContainer);
 
 export { Cell, Column, ColumnResizer, ResizableTableContainer, Row, Table, TableBody, TableHeader };
 export type {

--- a/packages/components/src/Tabs.tsx
+++ b/packages/components/src/Tabs.tsx
@@ -1,9 +1,12 @@
-import type { forwardRefType } from '@react-types/shared';
-import type { ForwardedRef } from 'react';
-import type { TabListProps, TabPanelProps, TabProps, TabsProps } from 'react-aria-components';
+import type { RefObject } from 'react';
+import type {
+	TabListProps as AriaTabListProps,
+	TabPanelProps as AriaTabPanelProps,
+	TabProps as AriaTabProps,
+	TabsProps as AriaTabsProps,
+} from 'react-aria-components';
 
 import { cva } from 'class-variance-authority';
-import { forwardRef } from 'react';
 import {
 	Tab as AriaTab,
 	TabList as AriaTabList,
@@ -19,7 +22,28 @@ const panel = cva(styles.panel);
 const tab = cva(styles.tab);
 const tabs = cva(styles.tabs);
 
-const _Tabs = (props: TabsProps, ref: ForwardedRef<HTMLDivElement>) => {
+interface TabsProps extends AriaTabsProps {
+	ref?: RefObject<HTMLDivElement | null>;
+}
+
+interface TabListProps<T extends object> extends AriaTabListProps<T> {
+	ref?: RefObject<HTMLDivElement | null>;
+}
+
+interface TabProps extends AriaTabProps {
+	ref?: RefObject<HTMLDivElement | null>;
+}
+
+interface TabPanelProps extends AriaTabPanelProps {
+	ref?: RefObject<HTMLDivElement | null>;
+}
+
+/**
+ * Tabs organize content into multiple sections and allow users to navigate between them.
+ *
+ * https://react-spectrum.adobe.com/react-aria/Tabs.html
+ */
+const Tabs = ({ ref, ...props }: TabsProps) => {
 	return (
 		<AriaTabs
 			{...props}
@@ -32,13 +56,12 @@ const _Tabs = (props: TabsProps, ref: ForwardedRef<HTMLDivElement>) => {
 };
 
 /**
- * Tabs organize content into multiple sections and allow users to navigate between them.
+ * A TabList is used within Tabs to group tabs that a user can switch between.
+ * The ids of the items within the `<TabList>` must match up with a corresponding item inside the `<TabPanels>`.
  *
  * https://react-spectrum.adobe.com/react-aria/Tabs.html
  */
-const Tabs = forwardRef(_Tabs);
-
-const _TabList = <T extends object>(props: TabListProps<T>, ref: ForwardedRef<HTMLDivElement>) => {
+const TabList = <T extends object>({ ref, ...props }: TabListProps<T>) => {
 	return (
 		<AriaTabList
 			{...props}
@@ -51,14 +74,11 @@ const _TabList = <T extends object>(props: TabListProps<T>, ref: ForwardedRef<HT
 };
 
 /**
- * A TabList is used within Tabs to group tabs that a user can switch between.
- * The ids of the items within the `<TabList>` must match up with a corresponding item inside the `<TabPanels>`.
+ * A Tab provides a title for an individual item within a TabList.
  *
  * https://react-spectrum.adobe.com/react-aria/Tabs.html
  */
-const TabList = (forwardRef as forwardRefType)(_TabList);
-
-const _Tab = (props: TabProps, ref: ForwardedRef<HTMLDivElement>) => {
+const Tab = ({ ref, ...props }: TabProps) => {
 	return (
 		<AriaTab
 			{...props}
@@ -71,13 +91,11 @@ const _Tab = (props: TabProps, ref: ForwardedRef<HTMLDivElement>) => {
 };
 
 /**
- * A Tab provides a title for an individual item within a TabList.
+ * A TabPanel provides the content for a tab.
  *
  * https://react-spectrum.adobe.com/react-aria/Tabs.html
  */
-const Tab = forwardRef(_Tab);
-
-const _TabPanel = (props: TabPanelProps, ref: ForwardedRef<HTMLDivElement>) => {
+const TabPanel = ({ ref, ...props }: TabPanelProps) => {
 	return (
 		<AriaTabPanel
 			{...props}
@@ -88,13 +106,6 @@ const _TabPanel = (props: TabPanelProps, ref: ForwardedRef<HTMLDivElement>) => {
 		/>
 	);
 };
-
-/**
- * A TabPanel provides the content for a tab.
- *
- * https://react-spectrum.adobe.com/react-aria/Tabs.html
- */
-const TabPanel = forwardRef(_TabPanel);
 
 export { Tab, Tabs, TabList, TabPanel };
 export type { TabProps, TabsProps, TabListProps, TabPanelProps };

--- a/packages/components/src/TagButton.tsx
+++ b/packages/components/src/TagButton.tsx
@@ -1,19 +1,22 @@
-import type { ForwardedRef } from 'react';
+import type { RefObject } from 'react';
 import type { ButtonProps } from 'react-aria-components';
 import type { TagVariants } from './TagGroup';
 
-import { forwardRef } from 'react';
 import { composeRenderProps } from 'react-aria-components';
 
 import { Button } from './Button';
 import { tag } from './TagGroup';
 
-interface TagButtonProps extends ButtonProps, Omit<TagVariants, 'variant'> {}
+interface TagButtonProps extends ButtonProps, Omit<TagVariants, 'variant'> {
+	ref?: RefObject<HTMLButtonElement | null>;
+}
 
-const _TagButton = (
-	{ size = 'medium', ...props }: TagButtonProps,
-	ref: ForwardedRef<HTMLButtonElement>,
-) => {
+/**
+ * A button allows a user to perform an action, with mouse, touch, and keyboard interactions.
+ *
+ * https://react-spectrum.adobe.com/react-aria/Button.html
+ */
+const TagButton = ({ size = 'medium', ref, ...props }: TagButtonProps) => {
 	return (
 		<Button
 			{...props}
@@ -26,13 +29,6 @@ const _TagButton = (
 		/>
 	);
 };
-
-/**
- * A button allows a user to perform an action, with mouse, touch, and keyboard interactions.
- *
- * https://react-spectrum.adobe.com/react-aria/Button.html
- */
-const TagButton = forwardRef(_TagButton);
 
 export { TagButton };
 export type { TagButtonProps };

--- a/packages/components/src/TagGroup.tsx
+++ b/packages/components/src/TagGroup.tsx
@@ -1,10 +1,12 @@
-import type { forwardRefType } from '@react-types/shared';
 import type { VariantProps } from 'class-variance-authority';
-import type { ForwardedRef } from 'react';
-import type { TagProps as AriaTagProps, TagGroupProps, TagListProps } from 'react-aria-components';
+import type { RefObject } from 'react';
+import type {
+	TagGroupProps as AriaTagGroupProps,
+	TagListProps as AriaTagListProps,
+	TagProps as AriaTagProps,
+} from 'react-aria-components';
 
 import { cva } from 'class-variance-authority';
-import { forwardRef } from 'react';
 import {
 	Tag as AriaTag,
 	TagGroup as AriaTagGroup,
@@ -40,20 +42,31 @@ const tag = cva(styles.tag, {
 });
 
 interface TagVariants extends VariantProps<typeof tag> {}
-interface TagProps extends AriaTagProps, TagVariants {}
+interface TagProps extends AriaTagProps, TagVariants {
+	ref?: RefObject<HTMLDivElement | null>;
+}
 
-const _TagGroup = ({ className, ...props }: TagGroupProps, ref: ForwardedRef<HTMLDivElement>) => {
-	return <AriaTagGroup {...props} ref={ref} className={group({ className })} />;
-};
+interface TagGroupProps extends AriaTagGroupProps {
+	ref?: RefObject<HTMLDivElement | null>;
+}
+
+interface TagListProps<T> extends AriaTagListProps<T> {
+	ref?: RefObject<HTMLDivElement | null>;
+}
 
 /**
  * A tag group is a focusable list of labels, categories, keywords, filters, or other items, with support for keyboard navigation, selection, and removal.
  *
  * https://react-spectrum.adobe.com/react-aria/TagGroup.html
  */
-const TagGroup = forwardRef(_TagGroup);
+const TagGroup = ({ className, ref, ...props }: TagGroupProps) => {
+	return <AriaTagGroup {...props} ref={ref} className={group({ className })} />;
+};
 
-const _TagList = <T extends object>(props: TagListProps<T>, ref: ForwardedRef<HTMLDivElement>) => {
+/**
+ * A tag list is a container for tags within a TagGroup.
+ */
+const TagList = <T extends object>({ ref, ...props }: TagListProps<T>) => {
 	return (
 		<AriaTagList
 			{...props}
@@ -66,14 +79,9 @@ const _TagList = <T extends object>(props: TagListProps<T>, ref: ForwardedRef<HT
 };
 
 /**
- * A tag list is a container for tags within a TagGroup.
+ * A Tag is an individual item within a TagList.
  */
-const TagList = (forwardRef as forwardRefType)(_TagList);
-
-const _Tag = (
-	{ size = 'medium', variant = 'default', ...props }: TagProps,
-	ref: ForwardedRef<HTMLDivElement>,
-) => {
+const Tag = ({ size = 'medium', variant = 'default', ref, ...props }: TagProps) => {
 	const textValue = typeof props.children === 'string' ? props.children : undefined;
 
 	return (
@@ -102,11 +110,6 @@ const _Tag = (
 		</AriaTag>
 	);
 };
-
-/**
- * A Tag is an individual item within a TagList.
- */
-const Tag = forwardRef(_Tag);
 
 export { TagGroup, TagList, Tag, tag };
 export type { TagGroupProps, TagListProps, TagProps, TagVariants };

--- a/packages/components/src/Text.tsx
+++ b/packages/components/src/Text.tsx
@@ -1,19 +1,20 @@
-import type { ForwardedRef } from 'react';
-import type { TextProps } from 'react-aria-components';
+import type { RefObject } from 'react';
+import type { TextProps as AriaTextProps } from 'react-aria-components';
 
 import { cva } from 'class-variance-authority';
-import { forwardRef } from 'react';
 import { Text as AriaText } from 'react-aria-components';
 
 import styles from './styles/Text.module.css';
 
 const text = cva(styles.text);
 
-const _Text = ({ className, ...props }: TextProps, ref: ForwardedRef<HTMLElement>) => {
+interface TextProps extends AriaTextProps {
+	ref?: RefObject<HTMLElement | null>;
+}
+
+const Text = ({ className, ref, ...props }: TextProps) => {
 	return <AriaText {...props} ref={ref} className={text({ className })} />;
 };
-
-const Text = forwardRef(_Text);
 
 export { Text };
 export type { TextProps };

--- a/packages/components/src/TextArea.tsx
+++ b/packages/components/src/TextArea.tsx
@@ -1,9 +1,8 @@
-import type { ForwardedRef } from 'react';
+import type { RefObject } from 'react';
 import type { TextAreaProps as AriaTextAreaProps } from 'react-aria-components';
 import type { InputVariants } from './Input';
 
 import { cva, cx } from 'class-variance-authority';
-import { forwardRef } from 'react';
 import { TextArea as AriaTextArea, composeRenderProps } from 'react-aria-components';
 
 import { input } from './Input';
@@ -11,12 +10,16 @@ import styles from './styles/TextArea.module.css';
 
 const area = cva(styles.area);
 
-interface TextAreaProps extends AriaTextAreaProps, InputVariants {}
+interface TextAreaProps extends AriaTextAreaProps, InputVariants {
+	ref?: RefObject<HTMLTextAreaElement | null>;
+}
 
-const _TextArea = (
-	{ variant = 'default', ...props }: TextAreaProps,
-	ref: ForwardedRef<HTMLTextAreaElement>,
-) => {
+/**
+ * A textarea allows a user to input mult-line text.
+ *
+ * https://react-spectrum.adobe.com/react-aria/TextField.html
+ */
+const TextArea = ({ variant = 'default', ref, ...props }: TextAreaProps) => {
 	return (
 		<AriaTextArea
 			{...props}
@@ -27,13 +30,6 @@ const _TextArea = (
 		/>
 	);
 };
-
-/**
- * A textarea allows a user to input mult-line text.
- *
- * https://react-spectrum.adobe.com/react-aria/TextField.html
- */
-const TextArea = forwardRef(_TextArea);
 
 export { TextArea };
 export type { TextAreaProps };

--- a/packages/components/src/TextField.tsx
+++ b/packages/components/src/TextField.tsx
@@ -1,8 +1,7 @@
-import type { ForwardedRef } from 'react';
-import type { TextFieldProps } from 'react-aria-components';
+import type { RefObject } from 'react';
+import type { TextFieldProps as AriaTextFieldProps } from 'react-aria-components';
 
 import { cva } from 'class-variance-authority';
-import { forwardRef } from 'react';
 import {
 	TextField as AriaTextField,
 	GroupContext,
@@ -14,7 +13,16 @@ import styles from './styles/TextField.module.css';
 
 const field = cva(styles.field);
 
-const _TextField = (props: TextFieldProps, ref: ForwardedRef<HTMLDivElement>) => {
+interface TextFieldProps extends AriaTextFieldProps {
+	ref?: RefObject<HTMLDivElement | null>;
+}
+
+/**
+ * A text field allows a user to enter a plain text value with a keyboard.
+ *
+ * https://react-spectrum.adobe.com/react-aria/TextField.html
+ */
+const TextField = ({ ref, ...props }: TextFieldProps) => {
 	return (
 		<AriaTextField
 			{...props}
@@ -29,13 +37,6 @@ const _TextField = (props: TextFieldProps, ref: ForwardedRef<HTMLDivElement>) =>
 		</AriaTextField>
 	);
 };
-
-/**
- * A text field allows a user to enter a plain text value with a keyboard.
- *
- * https://react-spectrum.adobe.com/react-aria/TextField.html
- */
-const TextField = forwardRef(_TextField);
 
 export { TextField };
 export type { TextFieldProps };

--- a/packages/components/src/ToggleButton.tsx
+++ b/packages/components/src/ToggleButton.tsx
@@ -1,18 +1,26 @@
-import type { ForwardedRef } from 'react';
+import type { RefObject } from 'react';
 import type { ToggleButtonProps as AriaToggleButtonProps } from 'react-aria-components';
 import type { ButtonVariants } from './Button';
 
-import { forwardRef } from 'react';
 import { ToggleButton as AriaToggleButton, composeRenderProps } from 'react-aria-components';
 
 import { button } from './Button';
 
-interface ToggleButtonProps extends AriaToggleButtonProps, ButtonVariants {}
+interface ToggleButtonProps extends AriaToggleButtonProps, ButtonVariants {
+	ref?: RefObject<HTMLButtonElement | null>;
+}
 
-const _ToggleButton = (
-	{ size = 'medium', variant = 'default', ...props }: ToggleButtonProps,
-	ref: ForwardedRef<HTMLButtonElement>,
-) => {
+/**
+ * A toggle button allows a user to toggle a selection on or off, for example switching between two states or modes.
+ *
+ * https://react-spectrum.adobe.com/react-aria/ToggleButton.html
+ */
+const ToggleButton = ({
+	size = 'medium',
+	variant = 'default',
+	ref,
+	...props
+}: ToggleButtonProps) => {
 	return (
 		<AriaToggleButton
 			{...props}
@@ -23,13 +31,6 @@ const _ToggleButton = (
 		/>
 	);
 };
-
-/**
- * A toggle button allows a user to toggle a selection on or off, for example switching between two states or modes.
- *
- * https://react-spectrum.adobe.com/react-aria/ToggleButton.html
- */
-const ToggleButton = forwardRef(_ToggleButton);
 
 export { ToggleButton };
 export type { ToggleButtonProps };

--- a/packages/components/src/ToggleButtonGroup.tsx
+++ b/packages/components/src/ToggleButtonGroup.tsx
@@ -1,8 +1,7 @@
-import type { ForwardedRef } from 'react';
-import type { ToggleButtonGroupProps } from 'react-aria-components';
+import type { RefObject } from 'react';
+import type { ToggleButtonGroupProps as AriaToggleButtonGroupProps } from 'react-aria-components';
 
 import { cva } from 'class-variance-authority';
-import { forwardRef } from 'react';
 import {
 	ToggleButtonGroup as AriaToggleButtonGroup,
 	composeRenderProps,
@@ -12,7 +11,16 @@ import styles from './styles/ToggleButtonGroup.module.css';
 
 const group = cva(styles.group);
 
-const _ToggleButtonGroup = (props: ToggleButtonGroupProps, ref: ForwardedRef<HTMLDivElement>) => {
+interface ToggleButtonGroupProps extends AriaToggleButtonGroupProps {
+	ref?: RefObject<HTMLDivElement | null>;
+}
+
+/**
+ * A toggle button group allows a user to toggle multiple options, with single or multiple selection.
+ *
+ * https://react-spectrum.adobe.com/react-aria/ToggleButtonGroup.html
+ */
+const ToggleButtonGroup = ({ ref, ...props }: ToggleButtonGroupProps) => {
 	return (
 		<AriaToggleButtonGroup
 			{...props}
@@ -23,13 +31,6 @@ const _ToggleButtonGroup = (props: ToggleButtonGroupProps, ref: ForwardedRef<HTM
 		/>
 	);
 };
-
-/**
- * A toggle button group allows a user to toggle multiple options, with single or multiple selection.
- *
- * https://react-spectrum.adobe.com/react-aria/ToggleButtonGroup.html
- */
-const ToggleButtonGroup = forwardRef(_ToggleButtonGroup);
 
 export { ToggleButtonGroup };
 export type { ToggleButtonGroupProps };

--- a/packages/components/src/ToggleIconButton.tsx
+++ b/packages/components/src/ToggleIconButton.tsx
@@ -1,10 +1,9 @@
-import type { ForwardedRef } from 'react';
+import type { RefObject } from 'react';
 import type { ToggleButtonProps } from 'react-aria-components';
 import type { IconButtonBaseProps } from './IconButton';
 
 import { Icon } from '@launchpad-ui/icons';
 import { cx } from 'class-variance-authority';
-import { forwardRef } from 'react';
 import { ToggleButton, composeRenderProps } from 'react-aria-components';
 
 import { button } from './Button';
@@ -12,12 +11,22 @@ import { iconButton } from './IconButton';
 
 interface ToggleIconButtonProps
 	extends Omit<ToggleButtonProps, 'children' | 'aria-label'>,
-		IconButtonBaseProps {}
+		IconButtonBaseProps {
+	ref?: RefObject<HTMLButtonElement | null>;
+}
 
-const _ToggleIconButton = (
-	{ size = 'medium', variant = 'default', icon, ...props }: ToggleIconButtonProps,
-	ref: ForwardedRef<HTMLButtonElement>,
-) => {
+/**
+ * A toggle button allows a user to toggle a selection on or off, for example switching between two states or modes.
+ *
+ * https://react-spectrum.adobe.com/react-aria/ToggleButton.html
+ */
+const ToggleIconButton = ({
+	size = 'medium',
+	variant = 'default',
+	icon,
+	ref,
+	...props
+}: ToggleIconButtonProps) => {
 	return (
 		<ToggleButton
 			{...props}
@@ -30,13 +39,6 @@ const _ToggleIconButton = (
 		</ToggleButton>
 	);
 };
-
-/**
- * A toggle button allows a user to toggle a selection on or off, for example switching between two states or modes.
- *
- * https://react-spectrum.adobe.com/react-aria/ToggleButton.html
- */
-const ToggleIconButton = forwardRef(_ToggleIconButton);
 
 export { ToggleIconButton };
 export type { ToggleIconButtonProps };

--- a/packages/components/src/Toolbar.tsx
+++ b/packages/components/src/Toolbar.tsx
@@ -1,9 +1,8 @@
 import type { VariantProps } from 'class-variance-authority';
-import type { ForwardedRef } from 'react';
+import type { RefObject } from 'react';
 import type { ToolbarProps as AriaToolbarProps } from 'react-aria-components';
 
 import { cva } from 'class-variance-authority';
-import { forwardRef } from 'react';
 import { Toolbar as AriaToolbar, composeRenderProps } from 'react-aria-components';
 
 import styles from './styles/Toolbar.module.css';
@@ -21,12 +20,16 @@ const toolbar = cva(styles.base, {
 	},
 });
 
-interface ToolbarProps extends AriaToolbarProps, VariantProps<typeof toolbar> {}
+interface ToolbarProps extends AriaToolbarProps, VariantProps<typeof toolbar> {
+	ref?: RefObject<HTMLDivElement | null>;
+}
 
-const _Toolbar = (
-	{ spacing = 'basic', ...props }: ToolbarProps,
-	ref: ForwardedRef<HTMLDivElement>,
-) => {
+/**
+ * A toolbar is a container for a set of interactive controls, such as buttons, dropdown menus, or checkboxes, with arrow key navigation.
+ *
+ * https://react-spectrum.adobe.com/react-aria/Toolbar.html
+ */
+const Toolbar = ({ spacing = 'basic', ref, ...props }: ToolbarProps) => {
 	return (
 		<AriaToolbar
 			{...props}
@@ -37,13 +40,6 @@ const _Toolbar = (
 		/>
 	);
 };
-
-/**
- * A toolbar is a container for a set of interactive controls, such as buttons, dropdown menus, or checkboxes, with arrow key navigation.
- *
- * https://react-spectrum.adobe.com/react-aria/Toolbar.html
- */
-const Toolbar = forwardRef(_Toolbar);
 
 export { Toolbar };
 export type { ToolbarProps };

--- a/packages/components/src/Tooltip.tsx
+++ b/packages/components/src/Tooltip.tsx
@@ -1,12 +1,11 @@
 import type { VariantProps } from 'class-variance-authority';
-import type { ForwardedRef } from 'react';
+import type { RefObject } from 'react';
 import type {
 	TooltipProps as AriaTooltipProps,
 	TooltipTriggerComponentProps,
 } from 'react-aria-components';
 
 import { cva } from 'class-variance-authority';
-import { forwardRef } from 'react';
 import {
 	Tooltip as AriaTooltip,
 	TooltipTrigger as AriaTooltipTrigger,
@@ -16,7 +15,9 @@ import {
 import popoverStyles from './styles/Popover.module.css';
 import styles from './styles/Tooltip.module.css';
 
-interface TooltipProps extends AriaTooltipProps, VariantProps<typeof tooltip> {}
+interface TooltipProps extends AriaTooltipProps, VariantProps<typeof tooltip> {
+	ref?: RefObject<HTMLDivElement | null>;
+}
 interface TooltipTriggerProps extends TooltipTriggerComponentProps {}
 
 const tooltip = cva(styles.base, {
@@ -31,10 +32,12 @@ const tooltip = cva(styles.base, {
 	},
 });
 
-const _Tooltip = (
-	{ variant = 'default', ...props }: TooltipProps,
-	ref: ForwardedRef<HTMLDivElement>,
-) => {
+/**
+ * A tooltip displays a description of an element on hover or focus.
+ *
+ * https://react-spectrum.adobe.com/react-aria/Tooltip.html
+ */
+const Tooltip = ({ variant = 'default', ref, ...props }: TooltipProps) => {
 	return (
 		<AriaTooltip
 			data-theme={variant === 'default' ? 'dark' : undefined}
@@ -49,13 +52,6 @@ const _Tooltip = (
 		/>
 	);
 };
-
-/**
- * A tooltip displays a description of an element on hover or focus.
- *
- * https://react-spectrum.adobe.com/react-aria/Tooltip.html
- */
-const Tooltip = forwardRef(_Tooltip);
 
 const TooltipTrigger = (props: TooltipTriggerProps) => {
 	return <AriaTooltipTrigger delay={500} closeDelay={250} {...props} />;

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -39,8 +39,8 @@
 		"class-variance-authority": "0.7.0"
 	},
 	"peerDependencies": {
-		"react": "^18.0.0 || ^19.0.0",
-		"react-dom": "^18.0.0 || ^19.0.0"
+		"react": "^19.0.0",
+		"react-dom": "^19.0.0"
 	},
 	"devDependencies": {
 		"react": "19.0.0",

--- a/packages/icons/src/Icon.tsx
+++ b/packages/icons/src/Icon.tsx
@@ -1,5 +1,5 @@
 import type { VariantProps } from 'class-variance-authority';
-import type { SVGAttributes } from 'react';
+import type { RefObject, SVGAttributes } from 'react';
 import type { IconName } from './types';
 
 import { cva } from 'class-variance-authority';
@@ -30,6 +30,7 @@ const IconContext = createContext<IconProps>({});
 
 interface IconProps extends SVGAttributes<SVGElement>, VariantProps<typeof icon> {
 	name?: IconName;
+	ref?: RefObject<SVGSVGElement | null>;
 }
 
 const Icon = ({
@@ -40,6 +41,7 @@ const Icon = ({
 	role = 'img',
 	size = 'medium',
 	variant = 'default',
+	ref,
 	...props
 }: IconProps) => {
 	const ctx = useContext(IconContext);
@@ -50,6 +52,7 @@ const Icon = ({
 			role={role}
 			className={icon({ size: ctx.size || size, variant, className })}
 			data-icon={name}
+			ref={ref}
 			{...props}
 		>
 			{name && <use href={`#lp-icon-${name}`} />}


### PR DESCRIPTION
## Summary

Drop React 18 support for `components` and `icons` packages.