### PR TITLE
fix: support `RefCallback` on refs

### DIFF
--- a/.changeset/friendly-dolphins-warn.md
+++ b/.changeset/friendly-dolphins-warn.md
@@ -1,0 +1,6 @@
+---
+"@launchpad-ui/components": patch
+"@launchpad-ui/icons": patch
+---
+
+Support `RefCallback` on refs

--- a/packages/components/src/Alert.tsx
+++ b/packages/components/src/Alert.tsx
@@ -1,5 +1,5 @@
 import type { VariantProps } from 'class-variance-authority';
-import type { HTMLAttributes, RefObject } from 'react';
+import type { HTMLAttributes, Ref } from 'react';
 
 import { StatusIcon } from '@launchpad-ui/icons';
 import { useControlledState } from '@react-stately/utils';
@@ -36,7 +36,7 @@ interface AlertProps extends HTMLAttributes<HTMLDivElement>, AlertVariants {
 	isDismissable?: boolean;
 	isOpen?: boolean;
 	onDismiss?: () => void;
-	ref?: RefObject<HTMLDivElement | null>;
+	ref?: Ref<HTMLDivElement>;
 }
 
 const Alert = ({

--- a/packages/components/src/Avatar.tsx
+++ b/packages/components/src/Avatar.tsx
@@ -1,5 +1,5 @@
 import type { VariantProps } from 'class-variance-authority';
-import type { ImgHTMLAttributes, RefObject, SVGAttributes } from 'react';
+import type { ImgHTMLAttributes, Ref, SVGAttributes } from 'react';
 
 import { cva, cx } from 'class-variance-authority';
 
@@ -34,7 +34,7 @@ const colors = cva(null, {
 interface AvatarVariants extends VariantProps<typeof avatar> {}
 
 interface AvatarProps extends ImgHTMLAttributes<HTMLImageElement>, AvatarVariants {
-	ref?: RefObject<HTMLImageElement | null>;
+	ref?: Ref<HTMLImageElement>;
 }
 
 interface InitialsAvatarProps extends SVGAttributes<SVGElement>, AvatarVariants {}

--- a/packages/components/src/Breadcrumbs.tsx
+++ b/packages/components/src/Breadcrumbs.tsx
@@ -1,4 +1,4 @@
-import type { RefObject } from 'react';
+import type { Ref } from 'react';
 import type {
 	BreadcrumbProps as AriaBreadcrumbProps,
 	BreadcrumbsProps as AriaBreadcrumbsProps,
@@ -23,11 +23,11 @@ const crumb = cva(styles.crumb);
 const LinkContext = createContext<ContextValue<LinkProps, HTMLAnchorElement>>(null);
 
 interface BreadcrumbsProps<T extends object> extends AriaBreadcrumbsProps<T> {
-	ref?: RefObject<HTMLOListElement | null>;
+	ref?: Ref<HTMLOListElement>;
 }
 
 interface BreadcrumbProps extends AriaBreadcrumbProps {
-	ref?: RefObject<HTMLLIElement | null>;
+	ref?: Ref<HTMLLIElement>;
 }
 
 /**

--- a/packages/components/src/Button.tsx
+++ b/packages/components/src/Button.tsx
@@ -1,5 +1,5 @@
 import type { VariantProps } from 'class-variance-authority';
-import type { RefObject } from 'react';
+import type { Ref } from 'react';
 import type { ButtonProps as AriaButtonProps } from 'react-aria-components';
 
 import { cva, cx } from 'class-variance-authority';
@@ -41,7 +41,7 @@ const button = cva(styles.base, {
 
 interface ButtonVariants extends VariantProps<typeof button> {}
 interface ButtonProps extends AriaButtonProps, ButtonVariants {
-	ref?: RefObject<HTMLButtonElement | null>;
+	ref?: Ref<HTMLButtonElement>;
 }
 
 /**

--- a/packages/components/src/ButtonGroup.tsx
+++ b/packages/components/src/ButtonGroup.tsx
@@ -1,6 +1,6 @@
 import type { Orientation } from '@react-types/shared';
 import type { VariantProps } from 'class-variance-authority';
-import type { RefObject } from 'react';
+import type { Ref } from 'react';
 import type { GroupProps } from 'react-aria-components';
 
 import { cva } from 'class-variance-authority';
@@ -33,7 +33,7 @@ const buttonGroup = cva(styles.base, {
 
 interface ButtonGroupProps extends GroupProps, VariantProps<typeof buttonGroup> {
 	orientation?: Orientation | null;
-	ref?: RefObject<HTMLDivElement | null>;
+	ref?: Ref<HTMLDivElement>;
 }
 
 const ButtonGroup = ({

--- a/packages/components/src/Calendar.tsx
+++ b/packages/components/src/Calendar.tsx
@@ -1,6 +1,6 @@
 import type { CalendarDate } from '@internationalized/date';
 import type { RangeValue } from '@react-types/shared';
-import type { HTMLAttributes, RefObject } from 'react';
+import type { HTMLAttributes, Ref } from 'react';
 import type {
 	CalendarCellProps as AriaCalendarCellProps,
 	CalendarProps as AriaCalendarProps,
@@ -36,12 +36,12 @@ import { Button, button } from './Button';
 import styles from './styles/Calendar.module.css';
 
 interface CalendarPickerProps extends HTMLAttributes<HTMLDivElement> {
-	ref?: RefObject<HTMLDivElement | null>;
+	ref?: Ref<HTMLDivElement>;
 }
 
 interface PresetProps extends Omit<ButtonProps, 'value'> {
 	value: CalendarDate | RangeValue<CalendarDate>;
-	ref?: RefObject<HTMLButtonElement | null>;
+	ref?: Ref<HTMLButtonElement>;
 }
 
 const calendar = cva(styles.calendar);
@@ -49,15 +49,15 @@ const cell = cva(styles.cell);
 const range = cva(styles.range);
 
 interface CalendarProps<T extends DateValue> extends AriaCalendarProps<T> {
-	ref?: RefObject<HTMLDivElement | null>;
+	ref?: Ref<HTMLDivElement>;
 }
 
 interface CalendarCellProps extends AriaCalendarCellProps {
-	ref?: RefObject<HTMLTableCellElement | null>;
+	ref?: Ref<HTMLTableCellElement>;
 }
 
 interface RangeCalendarProps<T extends DateValue> extends AriaRangeCalendarProps<T> {
-	ref?: RefObject<HTMLDivElement | null>;
+	ref?: Ref<HTMLDivElement>;
 }
 
 /**

--- a/packages/components/src/Checkbox.tsx
+++ b/packages/components/src/Checkbox.tsx
@@ -1,4 +1,4 @@
-import type { RefObject } from 'react';
+import type { Ref } from 'react';
 import type {
 	CheckboxProps as AriaCheckboxProps,
 	CheckboxRenderProps,
@@ -24,7 +24,7 @@ const CheckboxInner = ({ isSelected, isIndeterminate }: Partial<CheckboxRenderPr
 );
 
 interface CheckboxProps extends AriaCheckboxProps {
-	ref?: RefObject<HTMLLabelElement | null>;
+	ref?: Ref<HTMLLabelElement>;
 }
 
 /**

--- a/packages/components/src/CheckboxGroup.tsx
+++ b/packages/components/src/CheckboxGroup.tsx
@@ -1,4 +1,4 @@
-import type { RefObject } from 'react';
+import type { Ref } from 'react';
 import type { CheckboxGroupProps as AriaCheckboxGroupProps } from 'react-aria-components';
 
 import { cva } from 'class-variance-authority';
@@ -9,7 +9,7 @@ import styles from './styles/CheckboxGroup.module.css';
 const group = cva(styles.group);
 
 interface CheckboxGroupProps extends AriaCheckboxGroupProps {
-	ref?: RefObject<HTMLDivElement | null>;
+	ref?: Ref<HTMLDivElement>;
 }
 
 /**

--- a/packages/components/src/ComboBox.tsx
+++ b/packages/components/src/ComboBox.tsx
@@ -1,4 +1,4 @@
-import type { CSSProperties, RefObject } from 'react';
+import type { CSSProperties, Ref } from 'react';
 import type { ComboBoxProps as AriaComboBoxProps, PopoverProps } from 'react-aria-components';
 import type { IconButtonProps } from './IconButton';
 
@@ -21,7 +21,7 @@ const box = cva(styles.box);
 const PopoverContext = createContext<PopoverProps>({});
 
 interface ComboBoxProps<T extends object> extends AriaComboBoxProps<T> {
-	ref?: RefObject<HTMLDivElement | null>;
+	ref?: Ref<HTMLDivElement>;
 }
 
 interface ComboBoxClearButtonProps extends Partial<IconButtonProps> {}

--- a/packages/components/src/DateField.tsx
+++ b/packages/components/src/DateField.tsx
@@ -1,4 +1,4 @@
-import type { RefObject } from 'react';
+import type { Ref } from 'react';
 import type {
 	DateFieldProps as AriaDateFieldProps,
 	DateInputProps as AriaDateInputProps,
@@ -25,19 +25,19 @@ const dateInput = cva(styles.input);
 const segment = cva(styles.segment);
 
 interface DateFieldProps<T extends DateValue> extends AriaDateFieldProps<T> {
-	ref?: RefObject<HTMLDivElement | null>;
+	ref?: Ref<HTMLDivElement>;
 }
 
 interface DateInputProps extends AriaDateInputProps {
-	ref?: RefObject<HTMLDivElement | null>;
+	ref?: Ref<HTMLDivElement>;
 }
 
 interface DateSegmentProps extends AriaDateSegmentProps {
-	ref?: RefObject<HTMLDivElement | null>;
+	ref?: Ref<HTMLDivElement>;
 }
 
 interface TimeFieldProps<T extends TimeValue> extends AriaTimeFieldProps<T> {
-	ref?: RefObject<HTMLDivElement | null>;
+	ref?: Ref<HTMLDivElement>;
 }
 
 /**

--- a/packages/components/src/DatePicker.tsx
+++ b/packages/components/src/DatePicker.tsx
@@ -1,4 +1,4 @@
-import type { RefObject } from 'react';
+import type { Ref } from 'react';
 import type {
 	DatePickerProps as AriaDatePickerProps,
 	DateRangePickerProps as AriaDateRangePickerProps,
@@ -17,11 +17,11 @@ import styles from './styles/DatePicker.module.css';
 const picker = cva(styles.picker);
 
 interface DatePickerProps<T extends DateValue> extends AriaDatePickerProps<T> {
-	ref?: RefObject<HTMLDivElement | null>;
+	ref?: Ref<HTMLDivElement>;
 }
 
 interface DateRangePickerProps<T extends DateValue> extends AriaDateRangePickerProps<T> {
-	ref?: RefObject<HTMLDivElement | null>;
+	ref?: Ref<HTMLDivElement>;
 }
 
 /**

--- a/packages/components/src/Dialog.tsx
+++ b/packages/components/src/Dialog.tsx
@@ -1,4 +1,4 @@
-import type { RefObject } from 'react';
+import type { Ref } from 'react';
 import type { DialogProps as AriaDialogProps, DialogTriggerProps } from 'react-aria-components';
 
 import { useSlotId } from '@react-aria/utils';
@@ -16,7 +16,7 @@ import styles from './styles/Dialog.module.css';
 const dialog = cva(styles.dialog);
 
 interface DialogProps extends AriaDialogProps {
-	ref?: RefObject<HTMLElement | null>;
+	ref?: Ref<HTMLElement>;
 }
 
 /**

--- a/packages/components/src/Disclosure.tsx
+++ b/packages/components/src/Disclosure.tsx
@@ -1,4 +1,4 @@
-import type { RefObject } from 'react';
+import type { Ref } from 'react';
 import type {
 	DisclosurePanelProps as AriaDisclosurePanelProps,
 	DisclosureProps as AriaDisclosureProps,
@@ -16,11 +16,11 @@ const disclosure = cva(styles.disclosure);
 const panel = cva(styles.panel);
 
 interface DisclosureProps extends AriaDisclosureProps {
-	ref?: RefObject<HTMLDivElement | null>;
+	ref?: Ref<HTMLDivElement>;
 }
 
 interface DisclosurePanelProps extends AriaDisclosurePanelProps {
-	ref?: RefObject<HTMLDivElement | null>;
+	ref?: Ref<HTMLDivElement>;
 }
 
 /**

--- a/packages/components/src/DropIndicator.tsx
+++ b/packages/components/src/DropIndicator.tsx
@@ -1,4 +1,4 @@
-import type { RefObject } from 'react';
+import type { Ref } from 'react';
 import type { DropIndicatorProps as AriaDropIndicatorProps } from 'react-aria-components';
 
 import { cva } from 'class-variance-authority';
@@ -9,7 +9,7 @@ import styles from './styles/DropIndicator.module.css';
 const indicator = cva(styles.indicator);
 
 interface DropIndicatorProps extends AriaDropIndicatorProps {
-	ref?: RefObject<HTMLElement | null>;
+	ref?: Ref<HTMLElement>;
 }
 
 /**

--- a/packages/components/src/DropZone.tsx
+++ b/packages/components/src/DropZone.tsx
@@ -1,4 +1,4 @@
-import type { RefObject } from 'react';
+import type { Ref } from 'react';
 import type { DropZoneProps as AriaDropZoneProps } from 'react-aria-components';
 
 import { cva } from 'class-variance-authority';
@@ -9,7 +9,7 @@ import styles from './styles/DropZone.module.css';
 const zone = cva(styles.zone);
 
 interface DropZoneProps extends AriaDropZoneProps {
-	ref?: RefObject<HTMLDivElement | null>;
+	ref?: Ref<HTMLDivElement>;
 }
 
 /**

--- a/packages/components/src/FieldError.tsx
+++ b/packages/components/src/FieldError.tsx
@@ -1,4 +1,4 @@
-import type { RefObject } from 'react';
+import type { Ref } from 'react';
 import type { FieldErrorProps as AriaFieldErrorProps } from 'react-aria-components';
 
 import { cva } from 'class-variance-authority';
@@ -9,7 +9,7 @@ import styles from './styles/FieldError.module.css';
 const error = cva(styles.error);
 
 interface FieldErrorProps extends AriaFieldErrorProps {
-	ref?: RefObject<HTMLElement | null>;
+	ref?: Ref<HTMLElement>;
 }
 
 /**

--- a/packages/components/src/FieldGroup.tsx
+++ b/packages/components/src/FieldGroup.tsx
@@ -1,4 +1,4 @@
-import type { ContextType, FieldsetHTMLAttributes, RefObject } from 'react';
+import type { ContextType, FieldsetHTMLAttributes, Ref } from 'react';
 
 import { cva } from 'class-variance-authority';
 import { useId } from 'react';
@@ -22,7 +22,7 @@ interface FieldGroupProps extends FieldsetHTMLAttributes<HTMLFieldSetElement> {
 	title?: string;
 	errorMessage?: string;
 	isDisabled?: boolean;
-	ref?: RefObject<HTMLFieldSetElement | null>;
+	ref?: Ref<HTMLFieldSetElement>;
 }
 
 const group = cva(styles.group);

--- a/packages/components/src/GridList.tsx
+++ b/packages/components/src/GridList.tsx
@@ -1,4 +1,4 @@
-import type { RefObject } from 'react';
+import type { Ref } from 'react';
 import type {
 	GridListItemProps as AriaGridListItemProps,
 	GridListProps as AriaGridListProps,
@@ -19,11 +19,11 @@ const list = cva(styles.list);
 const item = cva(styles.item);
 
 interface GridListProps<T extends object> extends AriaGridListProps<T> {
-	ref?: RefObject<HTMLDivElement | null>;
+	ref?: Ref<HTMLDivElement>;
 }
 
 interface GridListItemProps<T extends object> extends AriaGridListItemProps<T> {
-	ref?: RefObject<T | null>;
+	ref?: Ref<T>;
 }
 
 /**

--- a/packages/components/src/Group.tsx
+++ b/packages/components/src/Group.tsx
@@ -1,4 +1,4 @@
-import type { RefObject } from 'react';
+import type { Ref } from 'react';
 import type { GroupProps as AriaGroupProps } from 'react-aria-components';
 import type { InputVariants } from './Input';
 
@@ -11,7 +11,7 @@ import styles from './styles/Group.module.css';
 const group = cva(styles.group);
 
 interface GroupProps extends AriaGroupProps, InputVariants {
-	ref?: RefObject<HTMLDivElement | null>;
+	ref?: Ref<HTMLDivElement>;
 }
 
 /**

--- a/packages/components/src/Header.tsx
+++ b/packages/components/src/Header.tsx
@@ -1,4 +1,4 @@
-import type { HTMLAttributes, RefObject } from 'react';
+import type { HTMLAttributes, Ref } from 'react';
 
 import { cva } from 'class-variance-authority';
 import { Header as AriaHeader } from 'react-aria-components';
@@ -8,7 +8,7 @@ import styles from './styles/Header.module.css';
 const header = cva(styles.header);
 
 interface HeaderProps extends HTMLAttributes<HTMLElement> {
-	ref?: RefObject<HTMLElement | null>;
+	ref?: Ref<HTMLElement>;
 }
 
 const Header = ({ className, ref, ...props }: HeaderProps) => {

--- a/packages/components/src/Heading.tsx
+++ b/packages/components/src/Heading.tsx
@@ -1,4 +1,4 @@
-import type { RefObject } from 'react';
+import type { Ref } from 'react';
 import type { HeadingProps as AriaHeadingProps } from 'react-aria-components';
 
 import { cva } from 'class-variance-authority';
@@ -9,7 +9,7 @@ import styles from './styles/Heading.module.css';
 const heading = cva(styles.heading);
 
 interface HeadingProps extends AriaHeadingProps {
-	ref?: RefObject<HTMLHeadingElement | null>;
+	ref?: Ref<HTMLHeadingElement>;
 }
 
 const Heading = ({ className, ref, ...props }: HeadingProps) => {

--- a/packages/components/src/IconButton.tsx
+++ b/packages/components/src/IconButton.tsx
@@ -1,7 +1,7 @@
 import type { IconProps } from '@launchpad-ui/icons';
 import type { AriaLabelingProps } from '@react-types/shared';
 import type { VariantProps } from 'class-variance-authority';
-import type { RefObject } from 'react';
+import type { Ref } from 'react';
 import type { ButtonProps as AriaButtonProps } from 'react-aria-components';
 import type { ButtonVariants } from './Button';
 
@@ -39,7 +39,7 @@ interface IconButtonBaseProps
 interface IconButtonProps
 	extends Omit<AriaButtonProps, 'children' | 'aria-label'>,
 		IconButtonBaseProps {
-	ref?: RefObject<HTMLButtonElement | null>;
+	ref?: Ref<HTMLButtonElement>;
 }
 
 /**

--- a/packages/components/src/Input.tsx
+++ b/packages/components/src/Input.tsx
@@ -1,5 +1,5 @@
 import type { VariantProps } from 'class-variance-authority';
-import type { RefObject } from 'react';
+import type { Ref } from 'react';
 import type { InputProps as AriaInputProps } from 'react-aria-components';
 
 import { cva } from 'class-variance-authority';
@@ -21,7 +21,7 @@ const input = cva(styles.base, {
 
 interface InputVariants extends VariantProps<typeof input> {}
 interface InputProps extends AriaInputProps, InputVariants {
-	ref?: RefObject<HTMLInputElement | null>;
+	ref?: Ref<HTMLInputElement>;
 }
 
 /**

--- a/packages/components/src/Label.tsx
+++ b/packages/components/src/Label.tsx
@@ -1,4 +1,4 @@
-import type { RefObject } from 'react';
+import type { Ref } from 'react';
 import type { LabelProps as AriaLabelProps } from 'react-aria-components';
 
 import { cva } from 'class-variance-authority';
@@ -9,7 +9,7 @@ import styles from './styles/Label.module.css';
 const label = cva(styles.label);
 
 interface LabelProps extends AriaLabelProps {
-	ref?: RefObject<HTMLLabelElement | null>;
+	ref?: Ref<HTMLLabelElement>;
 }
 
 const Label = ({ className, ref, ...props }: LabelProps) => {

--- a/packages/components/src/Link.tsx
+++ b/packages/components/src/Link.tsx
@@ -1,6 +1,6 @@
 import type { DOMProps } from '@react-types/shared';
 import type { VariantProps } from 'class-variance-authority';
-import type { RefObject } from 'react';
+import type { Ref } from 'react';
 import type { LinkProps as AriaLinkProps } from 'react-aria-components';
 
 import { Icon } from '@launchpad-ui/icons';
@@ -23,7 +23,7 @@ const link = cva(styles.base, {
 });
 
 interface LinkProps extends AriaLinkProps, VariantProps<typeof link>, DOMProps {
-	ref?: RefObject<HTMLAnchorElement | null>;
+	ref?: Ref<HTMLAnchorElement>;
 }
 
 /**

--- a/packages/components/src/ListBox.tsx
+++ b/packages/components/src/ListBox.tsx
@@ -1,4 +1,4 @@
-import type { RefObject } from 'react';
+import type { Ref } from 'react';
 import type {
 	ListBoxItemProps as AriaListBoxItemProps,
 	ListBoxProps as AriaListBoxProps,
@@ -18,10 +18,10 @@ const box = cva(styles.box);
 const item = cva(styles.item);
 
 interface ListBoxProps<T> extends AriaListBoxProps<T> {
-	ref?: RefObject<HTMLDivElement | null>;
+	ref?: Ref<HTMLDivElement>;
 }
 interface ListBoxItemProps<T> extends AriaListBoxItemProps<T> {
-	ref?: RefObject<T | null>;
+	ref?: Ref<T>;
 }
 
 /**

--- a/packages/components/src/Menu.tsx
+++ b/packages/components/src/Menu.tsx
@@ -1,5 +1,5 @@
 import type { VariantProps } from 'class-variance-authority';
-import type { RefObject } from 'react';
+import type { Ref } from 'react';
 import type {
 	MenuItemProps as AriaMenuItemProps,
 	MenuProps as AriaMenuProps,
@@ -35,10 +35,10 @@ const item = cva(styles.item, {
 });
 
 interface MenuProps<T> extends AriaMenuProps<T> {
-	ref?: RefObject<HTMLDivElement | null>;
+	ref?: Ref<HTMLDivElement>;
 }
 interface MenuItemProps<T> extends AriaMenuItemProps<T>, VariantProps<typeof item> {
-	ref?: RefObject<T | null>;
+	ref?: Ref<T>;
 }
 
 /**

--- a/packages/components/src/Meter.tsx
+++ b/packages/components/src/Meter.tsx
@@ -1,4 +1,4 @@
-import type { RefObject } from 'react';
+import type { Ref } from 'react';
 import type { MeterProps as AriaMeterProps } from 'react-aria-components';
 
 import { cva } from 'class-variance-authority';
@@ -10,7 +10,7 @@ const meter = cva(styles.meter);
 const icon = cva(styles.base);
 
 interface MeterProps extends AriaMeterProps {
-	ref?: RefObject<HTMLDivElement | null>;
+	ref?: Ref<HTMLDivElement>;
 }
 
 /**

--- a/packages/components/src/Modal.tsx
+++ b/packages/components/src/Modal.tsx
@@ -1,5 +1,5 @@
 import type { VariantProps } from 'class-variance-authority';
-import type { RefObject } from 'react';
+import type { Ref } from 'react';
 import type { ModalOverlayProps as AriaModalOverlayProps } from 'react-aria-components';
 
 import { cva } from 'class-variance-authority';
@@ -31,11 +31,11 @@ const modal = cva(styles.base, {
 const overlay = cva(styles.overlay);
 
 interface ModalProps extends AriaModalOverlayProps, VariantProps<typeof modal> {
-	ref?: RefObject<HTMLDivElement | null>;
+	ref?: Ref<HTMLDivElement>;
 }
 
 interface ModalOverlayProps extends AriaModalOverlayProps, VariantProps<typeof modal> {
-	ref?: RefObject<HTMLDivElement | null>;
+	ref?: Ref<HTMLDivElement>;
 }
 
 /**

--- a/packages/components/src/NumberField.tsx
+++ b/packages/components/src/NumberField.tsx
@@ -1,4 +1,4 @@
-import type { RefObject } from 'react';
+import type { Ref } from 'react';
 import type { NumberFieldProps as AriaNumberFieldProps } from 'react-aria-components';
 
 import { cva } from 'class-variance-authority';
@@ -9,7 +9,7 @@ import styles from './styles/NumberField.module.css';
 const number = cva(styles.number);
 
 interface NumberFieldProps extends AriaNumberFieldProps {
-	ref?: RefObject<HTMLDivElement | null>;
+	ref?: Ref<HTMLDivElement>;
 }
 
 /**

--- a/packages/components/src/Popover.tsx
+++ b/packages/components/src/Popover.tsx
@@ -1,4 +1,4 @@
-import type { RefObject } from 'react';
+import type { Ref } from 'react';
 import type {
 	OverlayArrowProps as AriaOverlayArrowProps,
 	PopoverProps as AriaPopoverProps,
@@ -16,10 +16,10 @@ import { PopoverContext } from './ComboBox';
 import styles from './styles/Popover.module.css';
 
 interface PopoverProps extends AriaPopoverProps {
-	ref?: RefObject<HTMLElement | null>;
+	ref?: Ref<HTMLElement>;
 }
 interface OverlayArrowProps extends Omit<AriaOverlayArrowProps, 'children'> {
-	ref?: RefObject<HTMLDivElement | null>;
+	ref?: Ref<HTMLDivElement>;
 }
 
 const popover = cva(styles.popover);

--- a/packages/components/src/Pressable.tsx
+++ b/packages/components/src/Pressable.tsx
@@ -1,4 +1,4 @@
-import type { ElementType, HTMLAttributes, RefObject } from 'react';
+import type { ElementType, HTMLAttributes, Ref } from 'react';
 import type { AriaButtonProps, HoverEvents } from 'react-aria';
 
 import { useObjectRef } from '@react-aria/utils';
@@ -13,7 +13,7 @@ interface PressableProps<T extends ElementType = 'button'>
 	extends AriaButtonProps<T>,
 		HoverEvents,
 		Pick<HTMLAttributes<T>, 'className'> {
-	ref?: RefObject<HTMLElement | null>;
+	ref?: Ref<HTMLElement>;
 }
 
 const Pressable = <T extends ElementType = 'span'>({

--- a/packages/components/src/ProgressBar.tsx
+++ b/packages/components/src/ProgressBar.tsx
@@ -1,5 +1,5 @@
 import type { VariantProps } from 'class-variance-authority';
-import type { RefObject } from 'react';
+import type { Ref } from 'react';
 import type { ProgressBarProps as AriaProgressBarProps } from 'react-aria-components';
 
 import { cva, cx } from 'class-variance-authority';
@@ -23,7 +23,7 @@ const icon = cva(styles.base, {
 });
 
 interface ProgressBarProps extends AriaProgressBarProps, VariantProps<typeof icon> {
-	ref?: RefObject<HTMLDivElement | null>;
+	ref?: Ref<HTMLDivElement>;
 }
 
 /**

--- a/packages/components/src/Radio.tsx
+++ b/packages/components/src/Radio.tsx
@@ -1,4 +1,4 @@
-import type { RefObject } from 'react';
+import type { Ref } from 'react';
 import type { RadioProps as AriaRadioProps, RadioRenderProps } from 'react-aria-components';
 
 import { Icon } from '@launchpad-ui/icons';
@@ -11,7 +11,7 @@ const radio = cva(styles.radio);
 const circle = cva(styles.circle);
 
 interface RadioProps extends AriaRadioProps {
-	ref?: RefObject<HTMLLabelElement | null>;
+	ref?: Ref<HTMLLabelElement>;
 }
 
 const RadioInner = ({ isSelected }: Partial<RadioRenderProps>) => (

--- a/packages/components/src/RadioButton.tsx
+++ b/packages/components/src/RadioButton.tsx
@@ -1,4 +1,4 @@
-import type { RefObject } from 'react';
+import type { Ref } from 'react';
 import type { RadioProps } from 'react-aria-components';
 import type { ButtonVariants } from './Button';
 
@@ -7,7 +7,7 @@ import { Radio as AriaRadio, composeRenderProps } from 'react-aria-components';
 import { button } from './Button';
 
 interface RadioButtonProps extends RadioProps, ButtonVariants {
-	ref?: RefObject<HTMLLabelElement | null>;
+	ref?: Ref<HTMLLabelElement>;
 }
 
 /**

--- a/packages/components/src/RadioGroup.tsx
+++ b/packages/components/src/RadioGroup.tsx
@@ -1,4 +1,4 @@
-import type { RefObject } from 'react';
+import type { Ref } from 'react';
 import type { RadioGroupProps as AriaRadioGroupProps } from 'react-aria-components';
 
 import { cva } from 'class-variance-authority';
@@ -9,7 +9,7 @@ import styles from './styles/RadioGroup.module.css';
 const group = cva(styles.group);
 
 interface RadioGroupProps extends AriaRadioGroupProps {
-	ref?: RefObject<HTMLDivElement | null>;
+	ref?: Ref<HTMLDivElement>;
 }
 
 /**

--- a/packages/components/src/RadioIconButton.tsx
+++ b/packages/components/src/RadioIconButton.tsx
@@ -1,4 +1,4 @@
-import type { RefObject } from 'react';
+import type { Ref } from 'react';
 import type { RadioProps } from 'react-aria-components';
 import type { IconButtonBaseProps } from './IconButton';
 
@@ -12,7 +12,7 @@ import { iconButton } from './IconButton';
 interface RadioIconButtonProps
 	extends Omit<RadioProps, 'children' | 'aria-label'>,
 		IconButtonBaseProps {
-	ref?: RefObject<HTMLLabelElement | null>;
+	ref?: Ref<HTMLLabelElement>;
 }
 
 /**

--- a/packages/components/src/SearchField.tsx
+++ b/packages/components/src/SearchField.tsx
@@ -1,4 +1,4 @@
-import type { RefObject } from 'react';
+import type { Ref } from 'react';
 import type { SearchFieldProps as AriaSearchFieldProps } from 'react-aria-components';
 
 import { cva } from 'class-variance-authority';
@@ -9,7 +9,7 @@ import styles from './styles/SearchField.module.css';
 const search = cva(styles.search);
 
 interface SearchFieldProps extends AriaSearchFieldProps {
-	ref?: RefObject<HTMLDivElement | null>;
+	ref?: Ref<HTMLDivElement>;
 }
 
 /**

--- a/packages/components/src/Section.tsx
+++ b/packages/components/src/Section.tsx
@@ -1,4 +1,4 @@
-import type { RefObject } from 'react';
+import type { Ref } from 'react';
 import type {
 	ListBoxSectionProps as AriaListBoxSectionProps,
 	MenuSectionProps as AriaMenuSectionProps,
@@ -15,11 +15,11 @@ import styles from './styles/Section.module.css';
 const section = cva(styles.section);
 
 interface ListBoxSectionProps<T extends object> extends AriaListBoxSectionProps<T> {
-	ref?: RefObject<HTMLElement | null>;
+	ref?: Ref<HTMLElement>;
 }
 
 interface MenuSectionProps<T extends object> extends AriaMenuSectionProps<T> {
-	ref?: RefObject<HTMLElement | null>;
+	ref?: Ref<HTMLElement>;
 }
 
 /**

--- a/packages/components/src/Select.tsx
+++ b/packages/components/src/Select.tsx
@@ -1,4 +1,4 @@
-import type { RefObject } from 'react';
+import type { Ref } from 'react';
 import type {
 	SelectProps as AriaSelectProps,
 	SelectValueProps as AriaSelectValueProps,
@@ -17,11 +17,11 @@ const select = cva(styles.select);
 const value = cva(styles.value);
 
 interface SelectProps<T extends object> extends AriaSelectProps<T> {
-	ref?: RefObject<HTMLDivElement | null>;
+	ref?: Ref<HTMLDivElement>;
 }
 
 interface SelectValueProps<T extends object> extends AriaSelectValueProps<T> {
-	ref?: RefObject<HTMLSpanElement | null>;
+	ref?: Ref<HTMLSpanElement>;
 }
 
 /**

--- a/packages/components/src/Separator.tsx
+++ b/packages/components/src/Separator.tsx
@@ -1,4 +1,4 @@
-import type { RefObject } from 'react';
+import type { Ref } from 'react';
 import type { SeparatorProps as AriaSeparatorProps } from 'react-aria-components';
 
 import { cva } from 'class-variance-authority';
@@ -9,7 +9,7 @@ import styles from './styles/Separator.module.css';
 const separator = cva(styles.separator);
 
 interface SeparatorProps extends AriaSeparatorProps {
-	ref?: RefObject<HTMLElement | null>;
+	ref?: Ref<HTMLElement>;
 }
 
 const Separator = ({ className, ref, ...props }: SeparatorProps) => {

--- a/packages/components/src/Switch.tsx
+++ b/packages/components/src/Switch.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode, RefObject } from 'react';
+import type { ReactNode, Ref } from 'react';
 import type { SwitchProps as AriaSwitchProps } from 'react-aria-components';
 
 import { cva } from 'class-variance-authority';
@@ -10,7 +10,7 @@ const _switch = cva(styles.switch);
 
 interface SwitchProps extends Omit<AriaSwitchProps, 'children'> {
 	children?: ReactNode;
-	ref?: RefObject<HTMLLabelElement | null>;
+	ref?: Ref<HTMLLabelElement>;
 }
 
 /**

--- a/packages/components/src/Table.tsx
+++ b/packages/components/src/Table.tsx
@@ -1,4 +1,4 @@
-import type { RefObject } from 'react';
+import type { Ref } from 'react';
 import type {
 	CellProps as AriaCellProps,
 	ColumnProps as AriaColumnProps,
@@ -46,35 +46,35 @@ const ResizableTableContainerContext = createContext<{ resizable: boolean } | nu
 });
 
 interface TableProps extends AriaTableProps {
-	ref?: RefObject<HTMLTableElement | null>;
+	ref?: Ref<HTMLTableElement>;
 }
 
 interface ColumnProps extends AriaColumnProps {
-	ref?: RefObject<HTMLTableCellElement | null>;
+	ref?: Ref<HTMLTableCellElement>;
 }
 
 interface TableHeaderProps<T extends object> extends AriaTableHeaderProps<T> {
-	ref?: RefObject<HTMLTableSectionElement | null>;
+	ref?: Ref<HTMLTableSectionElement>;
 }
 
 interface TableBodyProps<T extends object> extends AriaTableBodyProps<T> {
-	ref?: RefObject<HTMLTableSectionElement | null>;
+	ref?: Ref<HTMLTableSectionElement>;
 }
 
 interface RowProps<T extends object> extends AriaRowProps<T> {
-	ref?: RefObject<HTMLTableRowElement | null>;
+	ref?: Ref<HTMLTableRowElement>;
 }
 
 interface CellProps extends AriaCellProps {
-	ref?: RefObject<HTMLTableCellElement | null>;
+	ref?: Ref<HTMLTableCellElement>;
 }
 
 interface ColumnResizerProps extends AriaColumnResizerProps {
-	ref?: RefObject<HTMLDivElement | null>;
+	ref?: Ref<HTMLDivElement>;
 }
 
 interface ResizableTableContainerProps extends AriaResizableTableContainerProps {
-	ref?: RefObject<HTMLDivElement | null>;
+	ref?: Ref<HTMLDivElement>;
 }
 
 /**

--- a/packages/components/src/Tabs.tsx
+++ b/packages/components/src/Tabs.tsx
@@ -1,4 +1,4 @@
-import type { RefObject } from 'react';
+import type { Ref } from 'react';
 import type {
 	TabListProps as AriaTabListProps,
 	TabPanelProps as AriaTabPanelProps,
@@ -23,19 +23,19 @@ const tab = cva(styles.tab);
 const tabs = cva(styles.tabs);
 
 interface TabsProps extends AriaTabsProps {
-	ref?: RefObject<HTMLDivElement | null>;
+	ref?: Ref<HTMLDivElement>;
 }
 
 interface TabListProps<T extends object> extends AriaTabListProps<T> {
-	ref?: RefObject<HTMLDivElement | null>;
+	ref?: Ref<HTMLDivElement>;
 }
 
 interface TabProps extends AriaTabProps {
-	ref?: RefObject<HTMLDivElement | null>;
+	ref?: Ref<HTMLDivElement>;
 }
 
 interface TabPanelProps extends AriaTabPanelProps {
-	ref?: RefObject<HTMLDivElement | null>;
+	ref?: Ref<HTMLDivElement>;
 }
 
 /**

--- a/packages/components/src/TagButton.tsx
+++ b/packages/components/src/TagButton.tsx
@@ -1,4 +1,4 @@
-import type { RefObject } from 'react';
+import type { Ref } from 'react';
 import type { ButtonProps } from 'react-aria-components';
 import type { TagVariants } from './TagGroup';
 
@@ -8,7 +8,7 @@ import { Button } from './Button';
 import { tag } from './TagGroup';
 
 interface TagButtonProps extends ButtonProps, Omit<TagVariants, 'variant'> {
-	ref?: RefObject<HTMLButtonElement | null>;
+	ref?: Ref<HTMLButtonElement>;
 }
 
 /**

--- a/packages/components/src/TagGroup.tsx
+++ b/packages/components/src/TagGroup.tsx
@@ -1,5 +1,5 @@
 import type { VariantProps } from 'class-variance-authority';
-import type { RefObject } from 'react';
+import type { Ref } from 'react';
 import type {
 	TagGroupProps as AriaTagGroupProps,
 	TagListProps as AriaTagListProps,
@@ -43,15 +43,15 @@ const tag = cva(styles.tag, {
 
 interface TagVariants extends VariantProps<typeof tag> {}
 interface TagProps extends AriaTagProps, TagVariants {
-	ref?: RefObject<HTMLDivElement | null>;
+	ref?: Ref<HTMLDivElement>;
 }
 
 interface TagGroupProps extends AriaTagGroupProps {
-	ref?: RefObject<HTMLDivElement | null>;
+	ref?: Ref<HTMLDivElement>;
 }
 
 interface TagListProps<T> extends AriaTagListProps<T> {
-	ref?: RefObject<HTMLDivElement | null>;
+	ref?: Ref<HTMLDivElement>;
 }
 
 /**

--- a/packages/components/src/Text.tsx
+++ b/packages/components/src/Text.tsx
@@ -1,4 +1,4 @@
-import type { RefObject } from 'react';
+import type { Ref } from 'react';
 import type { TextProps as AriaTextProps } from 'react-aria-components';
 
 import { cva } from 'class-variance-authority';
@@ -9,7 +9,7 @@ import styles from './styles/Text.module.css';
 const text = cva(styles.text);
 
 interface TextProps extends AriaTextProps {
-	ref?: RefObject<HTMLElement | null>;
+	ref?: Ref<HTMLElement>;
 }
 
 const Text = ({ className, ref, ...props }: TextProps) => {

--- a/packages/components/src/TextArea.tsx
+++ b/packages/components/src/TextArea.tsx
@@ -1,4 +1,4 @@
-import type { RefObject } from 'react';
+import type { Ref } from 'react';
 import type { TextAreaProps as AriaTextAreaProps } from 'react-aria-components';
 import type { InputVariants } from './Input';
 
@@ -11,7 +11,7 @@ import styles from './styles/TextArea.module.css';
 const area = cva(styles.area);
 
 interface TextAreaProps extends AriaTextAreaProps, InputVariants {
-	ref?: RefObject<HTMLTextAreaElement | null>;
+	ref?: Ref<HTMLTextAreaElement>;
 }
 
 /**

--- a/packages/components/src/TextField.tsx
+++ b/packages/components/src/TextField.tsx
@@ -1,4 +1,4 @@
-import type { RefObject } from 'react';
+import type { Ref } from 'react';
 import type { TextFieldProps as AriaTextFieldProps } from 'react-aria-components';
 
 import { cva } from 'class-variance-authority';
@@ -14,7 +14,7 @@ import styles from './styles/TextField.module.css';
 const field = cva(styles.field);
 
 interface TextFieldProps extends AriaTextFieldProps {
-	ref?: RefObject<HTMLDivElement | null>;
+	ref?: Ref<HTMLDivElement>;
 }
 
 /**

--- a/packages/components/src/ToggleButton.tsx
+++ b/packages/components/src/ToggleButton.tsx
@@ -1,4 +1,4 @@
-import type { RefObject } from 'react';
+import type { Ref } from 'react';
 import type { ToggleButtonProps as AriaToggleButtonProps } from 'react-aria-components';
 import type { ButtonVariants } from './Button';
 
@@ -7,7 +7,7 @@ import { ToggleButton as AriaToggleButton, composeRenderProps } from 'react-aria
 import { button } from './Button';
 
 interface ToggleButtonProps extends AriaToggleButtonProps, ButtonVariants {
-	ref?: RefObject<HTMLButtonElement | null>;
+	ref?: Ref<HTMLButtonElement>;
 }
 
 /**

--- a/packages/components/src/ToggleButtonGroup.tsx
+++ b/packages/components/src/ToggleButtonGroup.tsx
@@ -1,4 +1,4 @@
-import type { RefObject } from 'react';
+import type { Ref } from 'react';
 import type { ToggleButtonGroupProps as AriaToggleButtonGroupProps } from 'react-aria-components';
 
 import { cva } from 'class-variance-authority';
@@ -12,7 +12,7 @@ import styles from './styles/ToggleButtonGroup.module.css';
 const group = cva(styles.group);
 
 interface ToggleButtonGroupProps extends AriaToggleButtonGroupProps {
-	ref?: RefObject<HTMLDivElement | null>;
+	ref?: Ref<HTMLDivElement>;
 }
 
 /**

--- a/packages/components/src/ToggleIconButton.tsx
+++ b/packages/components/src/ToggleIconButton.tsx
@@ -1,4 +1,4 @@
-import type { RefObject } from 'react';
+import type { Ref } from 'react';
 import type { ToggleButtonProps } from 'react-aria-components';
 import type { IconButtonBaseProps } from './IconButton';
 
@@ -12,7 +12,7 @@ import { iconButton } from './IconButton';
 interface ToggleIconButtonProps
 	extends Omit<ToggleButtonProps, 'children' | 'aria-label'>,
 		IconButtonBaseProps {
-	ref?: RefObject<HTMLButtonElement | null>;
+	ref?: Ref<HTMLButtonElement>;
 }
 
 /**

--- a/packages/components/src/Toolbar.tsx
+++ b/packages/components/src/Toolbar.tsx
@@ -1,5 +1,5 @@
 import type { VariantProps } from 'class-variance-authority';
-import type { RefObject } from 'react';
+import type { Ref } from 'react';
 import type { ToolbarProps as AriaToolbarProps } from 'react-aria-components';
 
 import { cva } from 'class-variance-authority';
@@ -21,7 +21,7 @@ const toolbar = cva(styles.base, {
 });
 
 interface ToolbarProps extends AriaToolbarProps, VariantProps<typeof toolbar> {
-	ref?: RefObject<HTMLDivElement | null>;
+	ref?: Ref<HTMLDivElement>;
 }
 
 /**

--- a/packages/components/src/Tooltip.tsx
+++ b/packages/components/src/Tooltip.tsx
@@ -1,5 +1,5 @@
 import type { VariantProps } from 'class-variance-authority';
-import type { RefObject } from 'react';
+import type { Ref } from 'react';
 import type {
 	TooltipProps as AriaTooltipProps,
 	TooltipTriggerComponentProps,
@@ -16,7 +16,7 @@ import popoverStyles from './styles/Popover.module.css';
 import styles from './styles/Tooltip.module.css';
 
 interface TooltipProps extends AriaTooltipProps, VariantProps<typeof tooltip> {
-	ref?: RefObject<HTMLDivElement | null>;
+	ref?: Ref<HTMLDivElement>;
 }
 interface TooltipTriggerProps extends TooltipTriggerComponentProps {}
 

--- a/packages/icons/src/Icon.tsx
+++ b/packages/icons/src/Icon.tsx
@@ -1,5 +1,5 @@
 import type { VariantProps } from 'class-variance-authority';
-import type { RefObject, SVGAttributes } from 'react';
+import type { Ref, SVGAttributes } from 'react';
 import type { IconName } from './types';
 
 import { cva } from 'class-variance-authority';
@@ -30,7 +30,7 @@ const IconContext = createContext<IconProps>({});
 
 interface IconProps extends SVGAttributes<SVGElement>, VariantProps<typeof icon> {
 	name?: IconName;
-	ref?: RefObject<SVGSVGElement | null>;
+	ref?: Ref<SVGSVGElement>;
 }
 
 const Icon = ({


### PR DESCRIPTION
## Summary

Support both `RefObject` and `RefCallback` with `Ref` type.