### PR TITLE
feat(tokens): build variables data

### DIFF
--- a/.changeset/dry-birds-tan.md
+++ b/.changeset/dry-birds-tan.md
@@ -1,0 +1,7 @@
+---
+"@launchpad-ui/tokens": patch
+"@launchpad-ui/icons": patch
+"@launchpad-ui/box": patch
+---
+
+Remove `color` prefix from `gradient` tokens

--- a/apps/vscode/src/server.ts
+++ b/apps/vscode/src/server.ts
@@ -52,6 +52,7 @@ const groupPatterns = {
 	duration: /animation-duration|transition/,
 	fontFamily: /font-family/,
 	fontSize: /font-size/,
+	gradient: /background/,
 	lineHeight: /line-height/,
 	size: /height|min-height|max-height|width|min-width|max-width/,
 	spacing: /margin|padding|gap|top|left|right|bottom/,

--- a/packages/box/src/styles/rainbow-sprinkles.css.ts
+++ b/packages/box/src/styles/rainbow-sprinkles.css.ts
@@ -3,8 +3,8 @@ import { vars } from '@launchpad-ui/vars';
 import { flatten } from 'flat';
 import { createRainbowSprinkles, defineProperties } from 'rainbow-sprinkles';
 
-const { bg, border, fill, shadow, text, gradient, ...global } = vars.color;
-const { text: typography } = vars;
+const { bg, border, fill, shadow, text, ...global } = vars.color;
+const { text: typography, gradient } = vars;
 
 type FlattenObjectKeys<T extends Record<string, unknown>, Key = keyof T> = Key extends string
 	? T[Key] extends Record<string, unknown>
@@ -13,7 +13,6 @@ type FlattenObjectKeys<T extends Record<string, unknown>, Key = keyof T> = Key e
 	: never;
 
 type GlobalKeys = FlattenObjectKeys<typeof global>;
-type GradientKeys = FlattenObjectKeys<typeof gradient>;
 type BackgroundKeys = FlattenObjectKeys<typeof bg>;
 type BorderKeys = FlattenObjectKeys<typeof border>;
 type FillKeys = FlattenObjectKeys<typeof fill>;
@@ -21,7 +20,6 @@ type TextKeys = FlattenObjectKeys<typeof text>;
 type TypographyKeys = FlattenObjectKeys<typeof typography>;
 
 const colors = flatten<typeof global, Record<GlobalKeys, string>>(global);
-const gradients = flatten<typeof gradient, Record<GradientKeys, string>>(gradient);
 const backgrounds = flatten<typeof bg, Record<BackgroundKeys, string>>(bg);
 const borders = flatten<typeof border, Record<BorderKeys, string>>(border);
 const fills = flatten<typeof fill, Record<FillKeys, string>>(fill);
@@ -115,7 +113,7 @@ const themedProperties = defineProperties({
 	defaultCondition: 'default',
 	dynamicProperties: {
 		color: { ...colors, ...texts },
-		background: gradients,
+		background: gradient,
 		backgroundColor: { ...colors, ...backgrounds },
 		borderColor: { ...colors, ...borders },
 		fill: { ...colors, ...fills },

--- a/packages/icons/src/styles/BadgeIcon.module.css
+++ b/packages/icons/src/styles/BadgeIcon.module.css
@@ -58,31 +58,31 @@
 }
 
 .gradient1 {
-	background: var(--lp-color-gradient-yellow-cyan);
+	background: var(--lp-gradient-yellow-cyan);
 }
 
 .gradient2 {
-	background: var(--lp-color-gradient-yellow-pink);
+	background: var(--lp-gradient-yellow-pink);
 }
 
 .gradient3 {
-	background: var(--lp-color-gradient-cyan-purple);
+	background: var(--lp-gradient-cyan-purple);
 }
 
 .gradient4 {
-	background: var(--lp-color-gradient-cyan-blue);
+	background: var(--lp-gradient-cyan-blue);
 }
 
 .gradient5 {
-	background: var(--lp-color-gradient-purple-blue);
+	background: var(--lp-gradient-purple-blue);
 }
 
 .gradient6 {
-	background: var(--lp-color-gradient-purple-pink);
+	background: var(--lp-gradient-purple-pink);
 }
 
 .gradient7 {
-	background: var(--lp-color-gradient-yellow-blue-pale);
+	background: var(--lp-gradient-yellow-blue-pale);
 }
 
 .blue,

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -44,6 +44,7 @@
 		"test": "vitest run"
 	},
 	"devDependencies": {
+		"@figma/rest-api-spec": "^0.22.0",
 		"json-to-ts": "^2.1.0",
 		"style-dictionary": "^4.3.0",
 		"tsx": "^4.19.0"

--- a/packages/tokens/src/build.ts
+++ b/packages/tokens/src/build.ts
@@ -1,4 +1,4 @@
-import type { RGBA } from '@figma/rest-api-spec';
+import type { LocalVariable, RGBA, VariableValue } from '@figma/rest-api-spec';
 import type {
 	Config,
 	DesignToken,
@@ -13,6 +13,10 @@ import { formats, transformGroups, transforms } from 'style-dictionary/enums';
 import { fileHeader, minifyDictionary } from 'style-dictionary/utils';
 
 import { css, themes } from './themes';
+
+interface Variable extends Partial<LocalVariable> {
+	value: VariableValue;
+}
 
 const configs = themes.map(css);
 
@@ -298,8 +302,8 @@ sd.registerFormat({
 				value: token.$type === 'color' ? { r: r / 255, g: g / 255, b: b / 255, a } : token.$value,
 				hiddenFromPublishing,
 				scopes,
-				codeSyntax: `var(--lp-${token.name})`,
-			};
+				codeSyntax: { WEB: `var(--lp-${token.name})` },
+			} satisfies Variable;
 		});
 		return `${JSON.stringify(tokens, null, 2)}\n`;
 	},

--- a/packages/tokens/src/build.ts
+++ b/packages/tokens/src/build.ts
@@ -1,4 +1,11 @@
-import type { Config, TransformedToken } from 'style-dictionary/types';
+import type { RGBA } from '@figma/rest-api-spec';
+import type {
+	Config,
+	DesignToken,
+	DesignTokens,
+	PreprocessedTokens,
+	TransformedToken,
+} from 'style-dictionary/types';
 
 import JsonToTS from 'json-to-ts';
 import StyleDictionary from 'style-dictionary';
@@ -17,8 +24,57 @@ const runSD = async (cfg: Config) => {
 
 const aliasTokens = Object.fromEntries(await Promise.all(configs.map(runSD)));
 
+/**
+ * [$extensions](https://tr.designtokens.org/format/#extensions-0)
+ *
+ * https://github.com/amzn/style-dictionary/blob/main/lib/utils/typeDtcgDelegate.js
+ */
+const extensionsDtcgDelegate = (tokens: DesignTokens): PreprocessedTokens => {
+	const clone = structuredClone(tokens);
+
+	const recurse = (slice: DesignTokens | DesignToken, _extensions: string) => {
+		let extensions = _extensions;
+		const keys = Object.keys(slice);
+		if (!keys.includes('$extensions') && extensions && keys.includes('$value')) {
+			slice.$extensions = extensions;
+		}
+
+		if (slice.$extensions) {
+			extensions = slice.$extensions;
+			if (slice.$value === undefined) {
+				delete slice.$extensions;
+			}
+		}
+
+		for (const val of Object.values(slice)) {
+			if (typeof val === 'object') {
+				recurse(val, extensions);
+			}
+		}
+	};
+	//@ts-ignore
+	recurse(clone);
+	return clone as PreprocessedTokens;
+};
+
+const removeExtensions = (slice: DesignTokens | DesignToken): PreprocessedTokens => {
+	delete slice.$extensions;
+	for (const value of Object.values(slice)) {
+		if (typeof value === 'object') {
+			removeExtensions(value);
+		}
+	}
+	return slice as PreprocessedTokens;
+};
+
 const sd = new StyleDictionary({
 	source: ['tokens/*.json'],
+	hooks: {
+		preprocessors: {
+			extensions: extensionsDtcgDelegate,
+			'strip-extensions': removeExtensions,
+		},
+	},
 	platforms: {
 		css: {
 			prefix: 'lp',
@@ -82,20 +138,6 @@ const sd = new StyleDictionary({
 				},
 			],
 		},
-		json: {
-			buildPath: 'dist/',
-			transforms: [transforms.nameKebab, 'custom/value/name'],
-			options: {
-				outputReferences: true,
-				usesDtcg: true,
-			},
-			files: [
-				{
-					destination: 'contract.json',
-					format: 'custom/json',
-				},
-			],
-		},
 		vscode: {
 			basePxFontSize: 16,
 			buildPath: 'dist/',
@@ -109,6 +151,37 @@ const sd = new StyleDictionary({
 				{
 					destination: 'tokens.json',
 					format: 'json/category',
+				},
+			],
+		},
+		figma: {
+			buildPath: 'dist/',
+			transforms: [transforms.nameKebab, transforms.attributeColor],
+			preprocessors: ['extensions'],
+			options: {
+				outputReferences: true,
+				usesDtcg: true,
+			},
+			files: [
+				{
+					destination: 'figma.json',
+					format: 'json/figma',
+					filter: (token) => token.$extensions,
+				},
+			],
+		},
+		json: {
+			buildPath: 'dist/',
+			transforms: [transforms.nameKebab, 'custom/value/name'],
+			preprocessors: ['strip-extensions'],
+			options: {
+				outputReferences: true,
+				usesDtcg: true,
+			},
+			files: [
+				{
+					destination: 'contract.json',
+					format: 'custom/json',
 				},
 			],
 		},
@@ -208,6 +281,27 @@ sd.registerFormat({
 			return { ...acc, [key]: [...group, obj] };
 		}, {} as TransformedToken);
 		return `${JSON.stringify(groups, null, 2)}\n`;
+	},
+});
+
+sd.registerFormat({
+	name: 'json/figma',
+	format: async ({ dictionary }) => {
+		const tokens = dictionary.allTokens.map((token) => {
+			const { attributes, $description: description, $extensions } = token;
+			const { hiddenFromPublishing, scopes } = $extensions['com.figma'];
+			const { r, g, b, a } = { ...(attributes?.rgb as RGBA) };
+
+			return {
+				name: token.name.replaceAll('-', '/'),
+				description,
+				value: token.$type === 'color' ? { r: r / 255, g: g / 255, b: b / 255, a } : token.$value,
+				hiddenFromPublishing,
+				scopes,
+				codeSyntax: `var(--lp-${token.name})`,
+			};
+		});
+		return `${JSON.stringify(tokens, null, 2)}\n`;
 	},
 });
 

--- a/packages/tokens/stories/color.stories.tsx
+++ b/packages/tokens/stories/color.stories.tsx
@@ -75,13 +75,15 @@ const TokenTable = ({ tokens }: { tokens: Record<string, string> }) => {
 									<TooltipTrigger>
 										<Button
 											onPress={() => {
-												navigator.clipboard.writeText(`--lp-color-${key}`);
+												navigator.clipboard.writeText(
+													value.substring(value.lastIndexOf('--'), value.lastIndexOf(')')),
+												);
 												ToastQueue.success('Copied!');
 											}}
 											style={{ font: 'var(--lp-text-code-1-regular)' }}
 											variant="minimal"
 										>
-											{`--lp-color-${key}`}
+											{value.substring(value.lastIndexOf('--'), value.lastIndexOf(')'))}
 										</Button>
 										<Tooltip placement="bottom">Copy to clipboard</Tooltip>
 									</TooltipTrigger>
@@ -98,9 +100,7 @@ const TokenTable = ({ tokens }: { tokens: Record<string, string> }) => {
 };
 
 const global = Object.keys(vars.color)
-	.filter((key) =>
-		['black', 'blue', 'green', 'gray', 'red', 'purple', 'white', 'brand', 'gradient'].includes(key),
-	)
+	.filter((key) => !['bg', 'border', 'fill', 'shadow', 'text'].includes(key))
 	.reduce((obj, key) => {
 		// @ts-expect-error fixme
 		obj[key] = vars.color[key];
@@ -108,7 +108,7 @@ const global = Object.keys(vars.color)
 	}, {});
 
 export const Global = {
-	render: () => <TokenTable tokens={flatten(global)} />,
+	render: () => <TokenTable tokens={{ ...flatten(global), ...vars.gradient }} />,
 };
 
 const alias = Object.keys(vars.color)

--- a/packages/tokens/tokens/border.json
+++ b/packages/tokens/tokens/border.json
@@ -1,6 +1,13 @@
 {
 	"borderRadius": {
 		"$type": "dimension",
+		"$extensions": {
+			"com.figma": {
+				"hiddenFromPublishing": false,
+				"scopes": ["CORNER_RADIUS"],
+				"codeSyntax": {}
+			}
+		},
 		"regular": {
 			"$value": "{size.3}"
 		},
@@ -13,6 +20,13 @@
 	},
 	"borderWidth": {
 		"$type": "dimension",
+		"$extensions": {
+			"com.figma": {
+				"hiddenFromPublishing": false,
+				"scopes": ["STROKE_FLOAT"],
+				"codeSyntax": {}
+			}
+		},
 		"100": {
 			"$value": "{size.0}"
 		},

--- a/packages/tokens/tokens/color-aliases.default.json
+++ b/packages/tokens/tokens/color-aliases.default.json
@@ -2,6 +2,13 @@
 	"color": {
 		"$type": "color",
 		"bg": {
+			"$extensions": {
+				"com.figma": {
+					"hiddenFromPublishing": false,
+					"scopes": ["FRAME_FILL", "SHAPE_FILL"],
+					"codeSyntax": {}
+				}
+			},
 			"feedback": {
 				"primary": {
 					"$value": "{color.gray.800}"
@@ -120,6 +127,13 @@
 			}
 		},
 		"border": {
+			"$extensions": {
+				"com.figma": {
+					"hiddenFromPublishing": false,
+					"scopes": ["STROKE_COLOR"],
+					"codeSyntax": {}
+				}
+			},
 			"feedback": {
 				"error": {
 					"$value": "{color.red.500}"
@@ -200,6 +214,13 @@
 			}
 		},
 		"fill": {
+			"$extensions": {
+				"com.figma": {
+					"hiddenFromPublishing": false,
+					"scopes": ["FRAME_FILL", "SHAPE_FILL"],
+					"codeSyntax": {}
+				}
+			},
 			"feedback": {
 				"error": {
 					"$value": "{color.red.500}"
@@ -234,6 +255,13 @@
 			}
 		},
 		"shadow": {
+			"$extensions": {
+				"com.figma": {
+					"hiddenFromPublishing": false,
+					"scopes": ["EFFECT_COLOR"],
+					"codeSyntax": {}
+				}
+			},
 			"interactive": {
 				"focus": {
 					"$value": "{color.blue.600}"
@@ -252,6 +280,13 @@
 			}
 		},
 		"text": {
+			"$extensions": {
+				"com.figma": {
+					"hiddenFromPublishing": false,
+					"scopes": ["TEXT_FILL"],
+					"codeSyntax": {}
+				}
+			},
 			"feedback": {
 				"base": {
 					"$value": "{color.text.ui.primary.base}"

--- a/packages/tokens/tokens/color-primitives.json
+++ b/packages/tokens/tokens/color-primitives.json
@@ -1,6 +1,13 @@
 {
 	"color": {
 		"$type": "color",
+		"$extensions": {
+			"com.figma": {
+				"hiddenFromPublishing": false,
+				"scopes": ["ALL_SCOPES"],
+				"codeSyntax": {}
+			}
+		},
 		"gray": {
 			"0": {
 				"$value": "#F7F9FB"
@@ -344,29 +351,6 @@
 				"dark": {
 					"$value": "#439000"
 				}
-			}
-		},
-		"gradient": {
-			"yellow-cyan": {
-				"$value": "linear-gradient(127deg, {color.brand.yellow.base} -38.66%, {color.brand.cyan.base} 83.73%)"
-			},
-			"yellow-pink": {
-				"$value": "linear-gradient(148deg, {color.brand.yellow.base} 13.5%, {color.brand.pink.base} 90.96%)"
-			},
-			"yellow-blue-pale": {
-				"$value": "linear-gradient(0deg, {color.white.50} 0%, {color.white.50} 100%), linear-gradient(151deg, {color.brand.yellow.light} 5.75%, {color.brand.blue.light} 90%)"
-			},
-			"cyan-blue": {
-				"$value": "linear-gradient(136deg, {color.brand.cyan.base} 22.68%, {color.brand.blue.base} 127.6%)"
-			},
-			"cyan-purple": {
-				"$value": "linear-gradient(323deg, {color.brand.purple.base} -11.93%, {color.brand.cyan.base} 125.4%)"
-			},
-			"purple-blue": {
-				"$value": "linear-gradient(131deg, {color.brand.purple.base} -15.82%, {color.brand.blue.base} 118.85%)"
-			},
-			"purple-pink": {
-				"$value": "linear-gradient(326deg, {color.brand.purple.base} -9.86%, {color.brand.pink.base} 112.59%)"
 			}
 		}
 	}

--- a/packages/tokens/tokens/font.json
+++ b/packages/tokens/tokens/font.json
@@ -1,6 +1,13 @@
 {
 	"fontFamily": {
 		"$type": "fontFamily",
+		"$extensions": {
+			"com.figma": {
+				"hiddenFromPublishing": false,
+				"scopes": ["FONT_FAMILY"],
+				"codeSyntax": {}
+			}
+		},
 		"base": {
 			"$value": "Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, Helvetica, Arial, sans-serif"
 		},
@@ -13,6 +20,13 @@
 	},
 	"fontSize": {
 		"$type": "dimension",
+		"$extensions": {
+			"com.figma": {
+				"hiddenFromPublishing": false,
+				"scopes": ["FONT_SIZE"],
+				"codeSyntax": {}
+			}
+		},
 		"100": {
 			"$value": "{size.11}"
 		},
@@ -40,6 +54,13 @@
 	},
 	"fontWeight": {
 		"$type": "fontWeight",
+		"$extensions": {
+			"com.figma": {
+				"hiddenFromPublishing": false,
+				"scopes": ["FONT_WEIGHT"],
+				"codeSyntax": {}
+			}
+		},
 		"light": {
 			"$value": 300
 		},

--- a/packages/tokens/tokens/gradient.json
+++ b/packages/tokens/tokens/gradient.json
@@ -1,0 +1,26 @@
+{
+	"gradient": {
+		"$type": "gradient",
+		"yellow-cyan": {
+			"$value": "linear-gradient(127deg, {color.brand.yellow.base} -38.66%, {color.brand.cyan.base} 83.73%)"
+		},
+		"yellow-pink": {
+			"$value": "linear-gradient(148deg, {color.brand.yellow.base} 13.5%, {color.brand.pink.base} 90.96%)"
+		},
+		"yellow-blue-pale": {
+			"$value": "linear-gradient(0deg, {color.white.50} 0%, {color.white.50} 100%), linear-gradient(151deg, {color.brand.yellow.light} 5.75%, {color.brand.blue.light} 90%)"
+		},
+		"cyan-blue": {
+			"$value": "linear-gradient(136deg, {color.brand.cyan.base} 22.68%, {color.brand.blue.base} 127.6%)"
+		},
+		"cyan-purple": {
+			"$value": "linear-gradient(323deg, {color.brand.purple.base} -11.93%, {color.brand.cyan.base} 125.4%)"
+		},
+		"purple-blue": {
+			"$value": "linear-gradient(131deg, {color.brand.purple.base} -15.82%, {color.brand.blue.base} 118.85%)"
+		},
+		"purple-pink": {
+			"$value": "linear-gradient(326deg, {color.brand.purple.base} -9.86%, {color.brand.pink.base} 112.59%)"
+		}
+	}
+}

--- a/packages/tokens/tokens/line-height.json
+++ b/packages/tokens/tokens/line-height.json
@@ -1,6 +1,13 @@
 {
 	"lineHeight": {
 		"$type": "number",
+		"$extensions": {
+			"com.figma": {
+				"hiddenFromPublishing": false,
+				"scopes": ["LINE_HEIGHT"],
+				"codeSyntax": {}
+			}
+		},
 		"100": {
 			"$value": "{size.16}"
 		},

--- a/packages/tokens/tokens/size.json
+++ b/packages/tokens/tokens/size.json
@@ -1,6 +1,13 @@
 {
 	"size": {
 		"$type": "dimension",
+		"$extensions": {
+			"com.figma": {
+				"hiddenFromPublishing": false,
+				"scopes": ["WIDTH_HEIGHT", "GAP"],
+				"codeSyntax": {}
+			}
+		},
 		"0": {
 			"$value": 0
 		},

--- a/packages/tokens/tokens/spacing.json
+++ b/packages/tokens/tokens/spacing.json
@@ -1,6 +1,13 @@
 {
 	"spacing": {
 		"$type": "dimension",
+		"$extensions": {
+			"com.figma": {
+				"hiddenFromPublishing": false,
+				"scopes": ["GAP"],
+				"codeSyntax": {}
+			}
+		},
 		"100": {
 			"$value": "{size.0}"
 		},

--- a/packages/tokens/tokens/viewport.json
+++ b/packages/tokens/tokens/viewport.json
@@ -1,6 +1,13 @@
 {
 	"viewport": {
 		"$type": "dimension",
+		"$extensions": {
+			"com.figma": {
+				"hiddenFromPublishing": false,
+				"scopes": ["WIDTH_HEIGHT"],
+				"codeSyntax": {}
+			}
+		},
 		"mobile": {
 			"$value": "{size.0}"
 		},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1223,6 +1223,9 @@ importers:
 
   packages/tokens:
     devDependencies:
+      '@figma/rest-api-spec':
+        specifier: ^0.22.0
+        version: 0.22.0
       json-to-ts:
         specifier: ^2.1.0
         version: 2.1.0
@@ -2034,6 +2037,9 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
+
+  '@figma/rest-api-spec@0.22.0':
+    resolution: {integrity: sha512-8XEdN41ahdUXMTR+E3CMmtXqlJYzuHun4VYUCElrkGsd6g1BFEYTiNCwIHy34Ooct2O8/zwpysnkw52EzVKdtQ==}
 
   '@figspec/components@1.0.3':
     resolution: {integrity: sha512-fBwHzJ4ouuOUJEi+yBZIrOy+0/fAjB3AeTcIHTT1PRxLz8P63xwC7R0EsIJXhScIcc+PljGmqbbVJCjLsnaGYA==}
@@ -7353,6 +7359,8 @@ snapshots:
 
   '@esbuild/win32-x64@0.24.2':
     optional: true
+
+  '@figma/rest-api-spec@0.22.0': {}
 
   '@figspec/components@1.0.3':
     dependencies:


### PR DESCRIPTION
## Summary

Prepare tokens data for use with Figma variables API:

- Build `figma.json` with token data needed to compare with Figma variables
- Support [$extensions](https://tr.designtokens.org/format/#extensions) for tooling metadata on tokens
- Move gradients to separate file and [set as composite type](https://tr.designtokens.org/format/#gradient)