### PR TITLE
fix(tag): update styles to truncate text content to one line

### DIFF
--- a/.changeset/rich-rings-divide.md
+++ b/.changeset/rich-rings-divide.md
@@ -1,0 +1,5 @@
+---
+"@launchpad-ui/tag": patch
+---
+
+Update Tag styles to truncate text content to one line

--- a/packages/tag/src/Tag.tsx
+++ b/packages/tag/src/Tag.tsx
@@ -65,7 +65,7 @@ const Tag = <T extends object>(props: TagProps<T>) => {
 			onClick={onClick && (() => onClick(item.key))}
 			data-test-id="tag"
 		>
-			<div className={cx(styles.tagCell)} {...gridCellProps}>
+			<div className={styles.tagCell} {...gridCellProps}>
 				<span className={styles.tagContent}>{children}</span>
 				{allowsRemoving && (
 					<Tooltip content="Remove" allowBoundaryElementOverflow>

--- a/packages/tag/src/styles/Tag.module.css
+++ b/packages/tag/src/styles/Tag.module.css
@@ -53,10 +53,13 @@ a.tag,
 .tagCell {
 	display: flex;
 	align-items: center;
+	min-width: 0px;
 }
 
 .tagContent {
 	padding: 0.25rem 0.125rem 0.25rem 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
 
 	.tiny & {
 		padding: 0.09375rem 0.125rem 0.09375rem 0;


### PR DESCRIPTION
## Summary
Very long text within a `Tag` overflows the container.

The `.tagCell` element was lacking the CSS necessary for the browser to derive an element width, thereby letting the element shrink its size to fit within its `inline-grid` parent. I've added a `min-width` declaration which lets the element grow/shrink as necessary to fill but not overflow its parent grid.

After that, truncating the text content overflow in the `.tagContent` element (which is rendered within `.tagCell`) can happen by adding the usual CSS.

<!-- What is changing and why? -->

## Screenshots (if appropriate):
Before:
<img width="1340" alt="Screenshot 2025-01-30 at 11 24 48 AM" src="https://github.com/user-attachments/assets/76340e2a-6ca4-4fbc-93db-d782110dcdb7" />

After:
<img width="654" alt="Screenshot 2025-01-30 at 11 31 00 AM" src="https://github.com/user-attachments/assets/86117d55-494a-4074-84e3-526b37162c26" />


<!-- Are there any visual changes that would be helpful to the reviewer to see? -->

## Testing approaches

<!-- How are these changes tested? -->
