### PR TITLE
feat(components): update checkbox and radio styles and svgs

### DIFF
--- a/.changeset/two-shoes-marry.md
+++ b/.changeset/two-shoes-marry.md
@@ -2,4 +2,4 @@
 "@launchpad-ui/components": patch
 ---
 
-chore: update checkbox svgs
+feat: update checkbox and radio styles and svgs

--- a/.changeset/two-shoes-marry.md
+++ b/.changeset/two-shoes-marry.md
@@ -1,0 +1,5 @@
+---
+"@launchpad-ui/components": patch
+---
+
+chore: update checkbox svgs

--- a/packages/components/src/Checkbox.tsx
+++ b/packages/components/src/Checkbox.tsx
@@ -4,7 +4,6 @@ import type {
 	CheckboxRenderProps,
 } from 'react-aria-components';
 
-import { Icon } from '@launchpad-ui/icons';
 import { cva } from 'class-variance-authority';
 import { Checkbox as AriaCheckbox, composeRenderProps } from 'react-aria-components';
 
@@ -16,9 +15,21 @@ const box = cva(styles.box);
 const CheckboxInner = ({ isSelected, isIndeterminate }: Partial<CheckboxRenderProps>) => (
 	<div className={box()}>
 		{isIndeterminate ? (
-			<Icon name="minus" size="small" className={styles.icon} />
+			<svg aria-hidden="true" className={styles.icon} viewBox="0 0 16 16">
+				<path
+					fillRule="evenodd"
+					clipPath="evenodd"
+					d="M3.5 8a1 1 0 0 1 1-1h7a1 1 0 1 1 0 2h-7a1 1 0 0 1-1-1Z"
+				/>
+			</svg>
 		) : isSelected ? (
-			<Icon name="check" size="small" className={styles.icon} />
+			<svg aria-hidden="true" className={styles.icon} viewBox="0 0 16 16">
+				<path
+					fillRule="evenodd"
+					clipPath="evenodd"
+					d="M12.581 3.686a1 1 0 0 1 .233 1.395l-5 7a1 1 0 0 1-1.521.126l-2.5-2.5a1 1 0 0 1 1.414-1.414l1.665 1.665 4.314-6.04a1 1 0 0 1 1.395-.232Z"
+				/>
+			</svg>
 		) : null}
 	</div>
 );

--- a/packages/components/src/Menu.tsx
+++ b/packages/components/src/Menu.tsx
@@ -76,7 +76,11 @@ const MenuItem = <T extends object>({ variant = 'default', ref, ...props }: Menu
 							</div>
 						)}
 						{selectionMode === 'single' && (
-							<div className={radio()} data-disabled={isDisabled || undefined}>
+							<div
+								className={radio()}
+								data-selected={isSelected || undefined}
+								data-disabled={isDisabled || undefined}
+							>
 								<RadioInner isSelected={isSelected} />
 							</div>
 						)}

--- a/packages/components/src/Radio.tsx
+++ b/packages/components/src/Radio.tsx
@@ -1,7 +1,6 @@
 import type { Ref } from 'react';
 import type { RadioProps as AriaRadioProps, RadioRenderProps } from 'react-aria-components';
 
-import { Icon } from '@launchpad-ui/icons';
 import { cva } from 'class-variance-authority';
 import { Radio as AriaRadio, composeRenderProps } from 'react-aria-components';
 
@@ -16,7 +15,15 @@ interface RadioProps extends AriaRadioProps {
 
 const RadioInner = ({ isSelected }: Partial<RadioRenderProps>) => (
 	<div className={circle()}>
-		{isSelected ? <Icon name="circle" className={styles.icon} /> : null}
+		{isSelected ? (
+			<svg aria-hidden="true" className={styles.icon} viewBox="0 0 16 16">
+				<path
+					fillRule="evenodd"
+					clipPath="evenodd"
+					d="M6.852 5.228a3 3 0 1 1 2.296 5.544 3 3 0 0 1-2.296-5.544Z"
+				/>
+			</svg>
+		) : null}
 	</div>
 );
 

--- a/packages/components/src/styles/Checkbox.module.css
+++ b/packages/components/src/styles/Checkbox.module.css
@@ -50,7 +50,8 @@
 			border-color: var(--lp-color-bg-field-disabled);
 
 			& .icon {
-				fill: var(--lp-color-text-field-disabled);
+				fill: var(--lp-color-fill-ui-primary);
+				opacity: 0.6;
 			}
 		}
 	}

--- a/packages/components/src/styles/Checkbox.module.css
+++ b/packages/components/src/styles/Checkbox.module.css
@@ -11,7 +11,7 @@
 	transition: all var(--lp-duration-100) ease-in-out, outline, outline-offset, box-shadow 0ms;
 
 	& .icon {
-		fill: var(--lp-color-text-interactive-primary-base);
+		fill: var(--lp-color-fill-interactive-primary);
 		width: var(--lp-size-16);
 		height: var(--lp-size-16);
 	}

--- a/packages/components/src/styles/Checkbox.module.css
+++ b/packages/components/src/styles/Checkbox.module.css
@@ -12,6 +12,8 @@
 
 	& .icon {
 		fill: var(--lp-color-text-interactive-primary-base);
+		width: var(--lp-size-16);
+		height: var(--lp-size-16);
 	}
 }
 
@@ -19,7 +21,7 @@
 	composes: interactive from './base.module.css';
 	display: inline-flex;
 	flex-direction: row;
-	gap: var(--lp-spacing-200);
+	gap: var(--lp-size-8);
 	font: var(--lp-text-label-1-regular);
 	align-items: flex-start;
 	position: relative;

--- a/packages/components/src/styles/Radio.module.css
+++ b/packages/components/src/styles/Radio.module.css
@@ -10,7 +10,7 @@
 	transition: all var(--lp-duration-100) ease-in-out, outline, outline-offset 0ms;
 
 	& .icon {
-		fill: var(--lp-color-text-interactive-primary-base);
+		fill: var(--lp-color-fill-interactive-primary);
 		width: var(--lp-size-16);
 		height: var(--lp-size-16);
 	}

--- a/packages/components/src/styles/Radio.module.css
+++ b/packages/components/src/styles/Radio.module.css
@@ -10,9 +10,9 @@
 	transition: all var(--lp-duration-100) ease-in-out, outline, outline-offset 0ms;
 
 	& .icon {
-		height: var(--lp-size-10);
-		width: var(--lp-size-10);
-		fill: var(--lp-color-bg-interactive-primary-base);
+		fill: var(--lp-color-text-interactive-primary-base);
+		width: var(--lp-size-16);
+		height: var(--lp-size-16);
 	}
 }
 
@@ -21,14 +21,21 @@
 	display: flex;
 	flex-direction: row;
 	align-items: center;
-	gap: var(--lp-spacing-200);
+	gap: var(--lp-size-8);
 	font: var(--lp-text-label-1-regular);
 
 	&[data-focus-visible] {
 		& .circle {
-			outline: 2px solid var(--lp-color-shadow-interactive-focus);
-			outline-offset: -2px;
+			outline: 1px solid var(--lp-color-shadow-interactive-focus);
+			outline-offset: -1px;
 			z-index: 1;
+		}
+	}
+
+	&[data-selected] {
+		& .circle {
+			background-color: var(--lp-color-bg-interactive-primary-base);
+			border-color: var(--lp-color-border-interactive-primary-base);
 		}
 	}
 
@@ -40,7 +47,8 @@
 			border-color: var(--lp-color-bg-field-disabled);
 
 			& .icon {
-				fill: var(--lp-color-text-field-disabled);
+				fill: var(--lp-color-fill-ui-primary);
+				opacity: 0.6;
 			}
 		}
 	}
@@ -48,6 +56,12 @@
 	&[data-invalid] {
 		& .circle {
 			border-color: var(--lp-color-border-field-error);
+		}
+	}
+
+	&[data-focus-visible]:is([data-selected]) {
+		& .circle {
+			box-shadow: inset 0 0 0 1px var(--lp-color-shadow-interactive-primary);
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- Updates the `Checkbox` and indeterminate svgs to use custom paths instead of icons in `<Icon/>`. Why? Checkboxes require a slightly different optical alignment and stroke width than our standard icons.
- Updates `Radio` to match `Checkbox` styles (blue bg on selection) and adjusts svg
- Increases the spacing of the gap from 4 to 8

[Figma branch](https://www.figma.com/design/98HKKXL2dTle29ikJ3tzk7/branch/luWoIpzQagd0b7DG3g0V18/%F0%9F%9A%80-LaunchPad?node-id=1-32733&p=f&t=d3WoCu1AMzKd4ty6-0)

| Before | After |
| - | - |
| <img width="122" alt="current checkbox" src="https://github.com/user-attachments/assets/726cd9ee-70af-41d1-847d-337143323be7" /> <img width="74" alt="current indeterminate state" src="https://github.com/user-attachments/assets/7228ca30-d188-4977-ab9c-7795478bad8b" /> <img width="137" alt="current radio" src="https://github.com/user-attachments/assets/00bb7612-1eae-404d-8c89-ac94da75049c" /> | <img width="160" alt="updated checkbox" src="https://github.com/user-attachments/assets/b6558882-7976-49c5-9992-62c3b1d2ab81" /> <img width="85" alt="updated indeterminate state" src="https://github.com/user-attachments/assets/eaba3f6e-7884-4ede-93c9-57fc1ab25206" /> <img width="147" alt="updated radio" src="https://github.com/user-attachments/assets/fa318a15-64c1-41a5-8f07-e002a0966507" /> |


