### PR TITLE
fix(components): fix `ListBox` width

### DIFF
--- a/.changeset/thirty-gorillas-peel.md
+++ b/.changeset/thirty-gorillas-peel.md
@@ -1,0 +1,5 @@
+---
+"@launchpad-ui/components": patch
+---
+
+Fix `ListBox` width

--- a/packages/components/src/styles/ListBox.module.css
+++ b/packages/components/src/styles/ListBox.module.css
@@ -1,6 +1,6 @@
 .box {
+	--lp-menu-max-width: none;
 	composes: menu from './Menu.module.css';
-	max-width: unset;
 }
 
 .item {

--- a/packages/components/stories/ListBox.stories.tsx
+++ b/packages/components/stories/ListBox.stories.tsx
@@ -3,7 +3,6 @@ import type { ComponentType } from 'react';
 import type { Selection as AriaSelection } from 'react-aria-components';
 
 import { Icon } from '@launchpad-ui/icons';
-import { vars } from '@launchpad-ui/vars';
 import { fireEvent, userEvent, within } from '@storybook/test';
 import { useState } from 'react';
 
@@ -13,13 +12,6 @@ const meta: Meta<typeof ListBox> = {
 	component: ListBox,
 	subcomponents: { ListBoxItem, ListBoxSection, Header } as Record<string, ComponentType<unknown>>,
 	title: 'Components/Collections/ListBox',
-	decorators: [
-		(Story) => (
-			<div style={{ width: vars.size[400] }}>
-				<Story />
-			</div>
-		),
-	],
 };
 
 export default meta;

--- a/packages/components/stories/ListBox.stories.tsx
+++ b/packages/components/stories/ListBox.stories.tsx
@@ -3,6 +3,7 @@ import type { ComponentType } from 'react';
 import type { Selection as AriaSelection } from 'react-aria-components';
 
 import { Icon } from '@launchpad-ui/icons';
+import { vars } from '@launchpad-ui/vars';
 import { fireEvent, userEvent, within } from '@storybook/test';
 import { useState } from 'react';
 
@@ -12,6 +13,13 @@ const meta: Meta<typeof ListBox> = {
 	component: ListBox,
 	subcomponents: { ListBoxItem, ListBoxSection, Header } as Record<string, ComponentType<unknown>>,
 	title: 'Components/Collections/ListBox',
+	decorators: [
+		(Story) => (
+			<div style={{ width: vars.size[400] }}>
+				<Story />
+			</div>
+		),
+	],
 };
 
 export default meta;


### PR DESCRIPTION
## Summary

To avoid `max-width` unset losing to CSS ordering we can just set `--lp-menu-max-width` to none for the listbox class.