### PR TITLE
fix(components): use render props for `Breadcrumb` separator

### DIFF
--- a/.changeset/forty-clocks-search.md
+++ b/.changeset/forty-clocks-search.md
@@ -1,0 +1,5 @@
+---
+"@launchpad-ui/components": patch
+---
+
+Use render props for `Breadcrumb` separator

--- a/packages/components/src/Breadcrumbs.tsx
+++ b/packages/components/src/Breadcrumbs.tsx
@@ -4,6 +4,7 @@ import type {
 	BreadcrumbsProps as AriaBreadcrumbsProps,
 } from 'react-aria-components';
 
+import { Icon } from '@launchpad-ui/icons';
 import { cva } from 'class-variance-authority';
 import {
 	Breadcrumb as AriaBreadcrumb,
@@ -49,8 +50,11 @@ const Breadcrumb = ({ ref, ...props }: BreadcrumbProps) => {
 				crumb({ ...renderProps, className }),
 			)}
 		>
-			{composeRenderProps(props.children, (children) => (
-				<Provider values={[[LinkContext, { variant: 'subtle' }]]}>{children}</Provider>
+			{composeRenderProps(props.children, (children, { isCurrent }) => (
+				<Provider values={[[LinkContext, { variant: 'subtle' }]]}>
+					{children}
+					{!isCurrent && <Icon name="slash" className={styles.separator} size={null} />}
+				</Provider>
 			))}
 		</AriaBreadcrumb>
 	);

--- a/packages/components/src/Link.tsx
+++ b/packages/components/src/Link.tsx
@@ -3,7 +3,6 @@ import type { VariantProps } from 'class-variance-authority';
 import type { Ref } from 'react';
 import type { LinkProps as AriaLinkProps } from 'react-aria-components';
 
-import { Icon } from '@launchpad-ui/icons';
 import { cva } from 'class-variance-authority';
 import { createContext, useContext } from 'react';
 import { Link as AriaLink, composeRenderProps } from 'react-aria-components';
@@ -37,18 +36,15 @@ const Link = ({ variant = 'default', href, ref, ...props }: LinkProps) => {
 	const linkProps = useContext(LinkContext);
 
 	return (
-		<>
-			<AriaLink
-				{...props}
-				{...linkProps}
-				ref={ref}
-				className={composeRenderProps(props.className, (className, renderProps) =>
-					link({ ...renderProps, variant: linkProps?.variant ?? variant, className }),
-				)}
-				href={href}
-			/>
-			{href && linkProps && <Icon name="slash" className={styles.separator} size={null} />}
-		</>
+		<AriaLink
+			{...props}
+			{...linkProps}
+			ref={ref}
+			className={composeRenderProps(props.className, (className, renderProps) =>
+				link({ ...renderProps, variant: linkProps?.variant ?? variant, className }),
+			)}
+			href={href}
+		/>
 	);
 };
 

--- a/packages/components/src/styles/Breadcrumbs.module.css
+++ b/packages/components/src/styles/Breadcrumbs.module.css
@@ -18,3 +18,9 @@
 		font: var(--lp-text-heading-1-semibold);
 	}
 }
+
+.separator {
+	fill: var(--lp-color-fill-ui-secondary);
+	height: var(--lp-size-24);
+	width: var(--lp-size-24);
+}

--- a/packages/components/src/styles/Link.module.css
+++ b/packages/components/src/styles/Link.module.css
@@ -42,9 +42,3 @@
 	composes: link;
 	color: var(--lp-color-text-ui-secondary);
 }
-
-.separator {
-	fill: var(--lp-color-fill-ui-secondary);
-	height: var(--lp-size-24);
-	width: var(--lp-size-24);
-}


### PR DESCRIPTION
## Summary

Use render props for `Breadcrumb` separator.