### PR TITLE
ci: add preview releases

### DIFF
--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -1,0 +1,39 @@
+name: Preview release
+
+on:
+  pull_request:
+    paths:
+      - 'packages/components/**'
+      - 'packages/icons/**'
+      - 'packages/tokens/**'
+  push:
+    paths:
+      - 'packages/components/**'
+      - 'packages/icons/**'
+      - 'packages/tokens/**'
+    branches:
+      - main
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build
+        run: pnpm nx run @launchpad-ui/components:build
+
+      - run: pnpm dlx pkg-pr-new publish --compact --pnpm --no-template './packages/components' './packages/icons' './packages/tokens'

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -7,7 +7,7 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/launchdarkly/launchpad-ui",
+		"url": "git+https://github.com/launchdarkly/launchpad-ui.git",
 		"directory": "packages/components"
 	},
 	"description": "An implementation of LaunchDarkly's LaunchPad Design System using React Aria Components.",

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -7,7 +7,7 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/launchdarkly/launchpad-ui",
+		"url": "git+https://github.com/launchdarkly/launchpad-ui.git",
 		"directory": "packages/icons"
 	},
 	"description": "An element that supplements content and represents an action or feature within LaunchDarkly.",

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -7,7 +7,7 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/launchdarkly/launchpad-ui",
+		"url": "git+https://github.com/launchdarkly/launchpad-ui.git",
 		"directory": "packages/tokens"
 	},
 	"description": "LaunchPad design tokens delivered as CSS custom properties, CommonJS modules, and ES modules.",


### PR DESCRIPTION
## Summary

Publish preview releases for `components`, `icons`, and `tokens` using [pkg.pr.new](https://github.com/stackblitz-labs/pkg.pr.new).

https://github.com/launchdarkly/launchpad-ui/pull/1565#issuecomment-2690992404