### PR TITLE
fix: add missing a11y snapshot

### DIFF
--- a/playwright/__snapshots__/aria-components-navigation-disclosuregroup--example.yml
+++ b/playwright/__snapshots__/aria-components-navigation-disclosuregroup--example.yml
@@ -1,0 +1,8 @@
+- heading "Disclosure one" [level=3]:
+  - button "Disclosure one"
+- heading "Disclosure two" [level=3]:
+  - button "Disclosure two" [expanded]
+- group "Disclosure two":
+  - paragraph: Panel with content.
+- heading "Disclosure three" [level=3]:
+  - button "Disclosure three"


### PR DESCRIPTION
## Summary

`DisclosureGroup` PR was opened before aria snapshots were implemented.