### PR TITLE
feat(components): consistent selection display for menus and listbox

### DIFF
--- a/.changeset/lovely-hotels-switch.md
+++ b/.changeset/lovely-hotels-switch.md
@@ -1,5 +1,5 @@
 ---
-"@launchpad-ui/components": minor
+"@launchpad-ui/components": patch
 ---
 
 Consistent selection handling for menu and listbox

--- a/.changeset/lovely-hotels-switch.md
+++ b/.changeset/lovely-hotels-switch.md
@@ -1,0 +1,5 @@
+---
+"@launchpad-ui/components": minor
+---
+
+Consistent selection handling for menu and listbox

--- a/packages/components/src/ListBox.tsx
+++ b/packages/components/src/ListBox.tsx
@@ -11,10 +11,9 @@ import {
 	composeRenderProps,
 } from 'react-aria-components';
 
+import { Icon } from '@launchpad-ui/icons';
 import { CheckboxInner } from './Checkbox';
 import { checkbox } from './Checkbox';
-import { RadioInner } from './Radio';
-import { radio } from './Radio';
 import styles from './styles/ListBox.module.css';
 const box = cva(styles.box);
 const item = cva(styles.item);
@@ -71,16 +70,8 @@ const ListBoxItem = <T extends object>({ ref, ...props }: ListBoxItemProps<T>) =
 							<CheckboxInner isSelected={isSelected} />
 						</div>
 					)}
-					{selectionMode === 'single' && (
-						<div
-							className={radio()}
-							data-selected={isSelected || undefined}
-							data-disabled={isDisabled || undefined}
-						>
-							<RadioInner isSelected={isSelected} />
-						</div>
-					)}
 					<span className={styles.content}>{children}</span>
+					{selectionMode === 'single' && isSelected && <Icon name="check-circle" size="small" />}
 				</>
 			))}
 		</AriaListBoxItem>

--- a/packages/components/src/ListBox.tsx
+++ b/packages/components/src/ListBox.tsx
@@ -4,7 +4,6 @@ import type {
 	ListBoxProps as AriaListBoxProps,
 } from 'react-aria-components';
 
-import { Icon } from '@launchpad-ui/icons';
 import { cva } from 'class-variance-authority';
 import {
 	ListBox as AriaListBox,
@@ -12,8 +11,11 @@ import {
 	composeRenderProps,
 } from 'react-aria-components';
 
+import { CheckboxInner } from './Checkbox';
+import { checkbox } from './Checkbox';
+import { RadioInner } from './Radio';
+import { radio } from './Radio';
 import styles from './styles/ListBox.module.css';
-
 const box = cva(styles.box);
 const item = cva(styles.item);
 
@@ -58,10 +60,27 @@ const ListBoxItem = <T extends object>({ ref, ...props }: ListBoxItemProps<T>) =
 				item({ ...renderProps, className }),
 			)}
 		>
-			{composeRenderProps(props.children, (children, { isSelected }) => (
+			{composeRenderProps(props.children, (children, { selectionMode, isDisabled, isSelected }) => (
 				<>
+					{selectionMode === 'multiple' && (
+						<div
+							className={checkbox()}
+							data-selected={isSelected || undefined}
+							data-disabled={isDisabled || undefined}
+						>
+							<CheckboxInner isSelected={isSelected} />
+						</div>
+					)}
+					{selectionMode === 'single' && (
+						<div
+							className={radio()}
+							data-selected={isSelected || undefined}
+							data-disabled={isDisabled || undefined}
+						>
+							<RadioInner isSelected={isSelected} />
+						</div>
+					)}
 					<span className={styles.content}>{children}</span>
-					{isSelected && <Icon name="check" size="medium" />}
 				</>
 			))}
 		</AriaListBoxItem>

--- a/packages/components/src/Menu.tsx
+++ b/packages/components/src/Menu.tsx
@@ -18,7 +18,6 @@ import {
 } from 'react-aria-components';
 
 import { CheckboxInner, checkbox } from './Checkbox';
-import { RadioInner, radio } from './Radio';
 import styles from './styles/Menu.module.css';
 
 const menu = cva(styles.menu);
@@ -75,16 +74,8 @@ const MenuItem = <T extends object>({ variant = 'default', ref, ...props }: Menu
 								<CheckboxInner isSelected={isSelected} />
 							</div>
 						)}
-						{selectionMode === 'single' && (
-							<div
-								className={radio()}
-								data-selected={isSelected || undefined}
-								data-disabled={isDisabled || undefined}
-							>
-								<RadioInner isSelected={isSelected} />
-							</div>
-						)}
 						<span className={styles.content}>{children}</span>
+						{selectionMode === 'single' && isSelected && <Icon name="check-circle" size="small" />}
 						{hasSubmenu && <Icon name="chevron-right" size="small" />}
 					</>
 				),


### PR DESCRIPTION
## Summary

<!-- What is changing and why? -->

## Screenshots (if appropriate):

| Component | Single selection | Multiple selection |
| ------- | ------- | ------- |
| Menu | ![image](https://github.com/user-attachments/assets/962196b3-7d68-48b6-b2d2-f69cef397780) | ![image](https://github.com/user-attachments/assets/cd7d6d46-fdb3-4dba-ac03-b6723272cee0) |
| Listbox | ![image](https://github.com/user-attachments/assets/fbd735cd-57c6-4328-8a81-44a6e7b405cb) | ![CleanShot 2025-03-27 at 18 41 03](https://github.com/user-attachments/assets/114306f1-8207-439a-b7b9-25f85d234dce) |


