### PR TITLE
fix(components): fix how single buttons render in button group

### DIFF
--- a/.changeset/rude-icons-sink.md
+++ b/.changeset/rude-icons-sink.md
@@ -1,0 +1,5 @@
+---
+"@launchpad-ui/components": patch
+---
+
+Ensure single button in button group renders correctly

--- a/packages/components/src/styles/base.module.css
+++ b/packages/components/src/styles/base.module.css
@@ -10,12 +10,12 @@
 
 .buttonGroup {
 	&[data-orientation='horizontal'] {
-		& :first-child {
+		& :first-child:not(:only-child) {
 			border-top-right-radius: 0;
 			border-bottom-right-radius: 0;
 		}
 
-		& :last-child {
+		& :last-child:not(:only-child) {
 			border-top-left-radius: 0;
 			border-bottom-left-radius: 0;
 		}


### PR DESCRIPTION
## Summary

If a button group has a single button — because one of the buttons renders conditionally — it will be square.

There's an argument that can be made that if there's only one button we should put it inside of a group, but that feels too rigid, and less convenient for consumers.

## Screenshots (if appropriate):

| Before | After |
| ------- | ------- |
| ![CleanShot 2025-04-10 at 10 19 54](https://github.com/user-attachments/assets/594a1b28-f872-4320-a64e-a5eda9936255) | ![CleanShot 2025-04-10 at 10 19 24](https://github.com/user-attachments/assets/ca7e7038-e8f7-4a37-8282-90c656d12829) |
  
## Testing approaches

<!-- How are these changes tested? -->
