### PR TITLE
fix(components): add min-width to menu item so consumers can truncate properly

### DIFF
--- a/.changeset/real-cows-fail.md
+++ b/.changeset/real-cows-fail.md
@@ -1,0 +1,5 @@
+---
+"@launchpad-ui/components": patch
+---
+
+Add min-width to menu item so consumers can truncate properly

--- a/packages/components/src/styles/Menu.module.css
+++ b/packages/components/src/styles/Menu.module.css
@@ -50,6 +50,7 @@
 		align-items: center;
 		column-gap: var(--lp-spacing-300);
 		flex: 1;
+		min-width: 0;
 	}
 
 	&:has([slot='label']) {


### PR DESCRIPTION
## Summary

`min-width: 0` on flex containers gives consumers the ability to truncate long content with an ellipsis.