### PR TITLE
fix(components): ensure `Text` gets className from context

### DIFF
--- a/.changeset/thick-humans-strive.md
+++ b/.changeset/thick-humans-strive.md
@@ -1,0 +1,5 @@
+---
+"@launchpad-ui/components": patch
+---
+
+Ensure `Text` gets className from context

--- a/packages/components/src/Text.tsx
+++ b/packages/components/src/Text.tsx
@@ -16,8 +16,10 @@ interface TextProps extends AriaTextProps {
 
 const TextContext = createContext<ContextValue<TextProps, HTMLElement>>(null);
 
-const Text = ({ className, ref, ...props }: TextProps) => {
+const Text = ({ ref, ...props }: TextProps) => {
 	[props, ref] = useLPContextProps(props, ref, TextContext);
+	const { className } = props;
+
 	return <AriaText {...props} ref={ref} className={textStyles({ className })} />;
 };
 


### PR DESCRIPTION
## Summary

Ensure `Text` gets className from context.