### PR TITLE
fix(components): fix button styles when popover is open

### DIFF
--- a/.changeset/rotten-plants-kiss.md
+++ b/.changeset/rotten-plants-kiss.md
@@ -1,0 +1,5 @@
+---
+"@launchpad-ui/components": patch
+---
+
+Add styles for button when a popover is opened

--- a/packages/components/src/styles/Button.module.css
+++ b/packages/components/src/styles/Button.module.css
@@ -1,5 +1,5 @@
 .base {
-	composes: interactive from "./base.module.css";
+	composes: interactive from './base.module.css';
 }
 
 .button {
@@ -161,9 +161,9 @@
 }
 
 .picker {
-	composes: base from "./Input.module.css";
-	composes: _default from "./Input.module.css";
-	composes: group from "./Group.module.css";
+	composes: base from './Input.module.css';
+	composes: _default from './Input.module.css';
+	composes: group from './Group.module.css';
 
 	& [data-icon]:last-child {
 		fill: var(--lp-color-fill-ui-secondary);

--- a/packages/components/src/styles/Button.module.css
+++ b/packages/components/src/styles/Button.module.css
@@ -139,6 +139,10 @@
 	z-index: 1;
 }
 
+.button[data-pressed][aria-expanded] {
+	border-color: var(--lp-color-border-interactive-selected);
+}
+
 .button[data-pending] {
 	cursor: wait;
 

--- a/packages/components/src/styles/Button.module.css
+++ b/packages/components/src/styles/Button.module.css
@@ -1,5 +1,5 @@
 .base {
-	composes: interactive from './base.module.css';
+	composes: interactive from "./base.module.css";
 }
 
 .button {
@@ -141,6 +141,7 @@
 
 .button[data-pressed][aria-expanded] {
 	border-color: var(--lp-color-border-interactive-selected);
+	background-color: var(--lp-color-bg-interactive-selected);
 }
 
 .button[data-pending] {
@@ -160,9 +161,9 @@
 }
 
 .picker {
-	composes: base from './Input.module.css';
-	composes: _default from './Input.module.css';
-	composes: group from './Group.module.css';
+	composes: base from "./Input.module.css";
+	composes: _default from "./Input.module.css";
+	composes: group from "./Group.module.css";
 
 	& [data-icon]:last-child {
 		fill: var(--lp-color-fill-ui-secondary);

--- a/packages/components/stories/Popover.stories.tsx
+++ b/packages/components/stories/Popover.stories.tsx
@@ -7,6 +7,7 @@ import { expect, userEvent, within } from 'storybook/test';
 import { Button } from '../src/Button';
 import { Dialog, DialogTrigger } from '../src/Dialog';
 import { Heading } from '../src/Heading';
+import { IconButton } from '../src/IconButton';
 import { OverlayArrow, Popover } from '../src/Popover';
 import { Pressable } from '../src/Pressable';
 
@@ -44,6 +45,20 @@ export const Example: Story = {
 		return (
 			<DialogTrigger>
 				<Button>Trigger</Button>
+				<Popover {...args}>
+					<Dialog>Message</Dialog>
+				</Popover>
+			</DialogTrigger>
+		);
+	},
+	play,
+};
+
+export const ExampleWithIconButton: Story = {
+	render: (args) => {
+		return (
+			<DialogTrigger>
+				<IconButton icon="info" aria-label="Trigger" />
 				<Popover {...args}>
 					<Dialog>Message</Dialog>
 				</Popover>


### PR DESCRIPTION
## Summary

Add button style for popover open state using aria-expanded and data-pressed


<!-- What is changing and why? -->

## Screenshots (if appropriate):

Popover on `Button`
![Screenshot 2025-05-12 at 9 10 23 AM](https://github.com/user-attachments/assets/bf8ace37-a1d0-4a95-8b0c-bc7444b8f8b2)

Popover on `IconButton`
![Screenshot 2025-05-12 at 9 10 34 AM](https://github.com/user-attachments/assets/6b7d93da-abf3-4bdc-a631-a34a02a1d026)


## Testing approaches

Manual 

<!-- How are these changes tested? -->
<!-- ld-jira-link -->
---
Related Jira issue: [EXPT-2213: Popovers UI ](https://launchdarkly.atlassian.net/browse/EXPT-2213)
<!-- end-ld-jira-link -->