### PR TITLE
Revert "feat(components): Set select and combobox popover container width to be the width of the trigger"

### DIFF
--- a/packages/components/src/styles/Popover.module.css
+++ b/packages/components/src/styles/Popover.module.css
@@ -49,11 +49,11 @@
 	}
 
 	&[data-trigger='Select'] {
-		width: var(--trigger-width);
+		min-width: var(--trigger-width);
 	}
 
 	&[data-trigger='ComboBox'] {
-		width: var(--trigger-width);
+		min-width: var(--trigger-width);
 	}
 
 	&[data-trigger='ComboBoxDialog'] {


### PR DESCRIPTION
Reverts launchdarkly/launchpad-ui#1669