### PR TITLE
fix(components): revert popover width change

### DIFF
--- a/.changeset/lucky-mammals-sing.md
+++ b/.changeset/lucky-mammals-sing.md
@@ -1,0 +1,5 @@
+---
+"@launchpad-ui/components": patch
+---
+
+Revert change to popover widths

--- a/packages/components/src/styles/Popover.module.css
+++ b/packages/components/src/styles/Popover.module.css
@@ -49,11 +49,11 @@
 	}
 
 	&[data-trigger='Select'] {
-		width: var(--trigger-width);
+		min-width: var(--trigger-width);
 	}
 
 	&[data-trigger='ComboBox'] {
-		width: var(--trigger-width);
+		min-width: var(--trigger-width);
 	}
 
 	&[data-trigger='ComboBoxDialog'] {


### PR DESCRIPTION
## Summary

This change introduced some unwanted behavior across the app, so reverting until we find a better solution.