### PR TITLE
fix(components): remove max-width on `Heading`

### DIFF
--- a/.changeset/thirty-bags-rule.md
+++ b/.changeset/thirty-bags-rule.md
@@ -1,0 +1,5 @@
+---
+"@launchpad-ui/components": patch
+---
+
+Remove max-width on `Heading`

--- a/packages/components/src/styles/Heading.module.css
+++ b/packages/components/src/styles/Heading.module.css
@@ -1,7 +1,5 @@
 .heading {
 	white-space: nowrap;
-	max-width: calc(100% - var(--lp-size-32));
 	overflow: hidden;
 	text-overflow: ellipsis;
-	position: relative;
 }

--- a/packages/components/src/styles/Modal.module.css
+++ b/packages/components/src/styles/Modal.module.css
@@ -50,7 +50,7 @@
 
 	& [slot='title'] {
 		font: var(--lp-text-heading-1-semibold);
-		flex-grow: 1;
+		grid-column: 1;
 	}
 
 	& [role='dialog']:has([slot='body']) {
@@ -61,10 +61,14 @@
 	}
 
 	& [slot='header'] {
-		display: flex;
+		display: grid;
+		grid-template-columns: 1fr;
 		align-items: center;
 		gap: var(--lp-spacing-300);
-		flex-wrap: wrap;
+
+		& button[data-rac] {
+			grid-column: 2;
+		}
 	}
 
 	& [slot='body'] {
@@ -82,7 +86,8 @@
 	& [slot='subtitle'] {
 		font: var(--lp-text-body-1-regular);
 		color: var(--lp-color-text-ui-secondary);
-		flex-basis: 100%;
+		grid-row: 2;
+		grid-column: 1 / span 2;
 	}
 }
 


### PR DESCRIPTION
## Summary

Remove max-width on `Heading` and adjust `Modal` to handle title overflow via grid.

## Testing approaches

- Titles in modals still show ellipses on overflow
- Removing subtitle and close button in modal stories results in layout remaining intact.