### PR TITLE
fix(components): wrap `Button` string children with `Text`

### DIFF
--- a/.changeset/petite-teeth-itch.md
+++ b/.changeset/petite-teeth-itch.md
@@ -1,0 +1,5 @@
+---
+"@launchpad-ui/components": patch
+---
+
+Wrap `Button` string children with `Text`

--- a/packages/components/src/Button.tsx
+++ b/packages/components/src/Button.tsx
@@ -14,6 +14,7 @@ import {
 import { PerceivableContext } from './Perceivable';
 import { ProgressBar } from './ProgressBar';
 import styles from './styles/Button.module.css';
+import { Text } from './Text';
 import { useLPContextProps } from './utils';
 
 const buttonStyles = cva(styles.base, {
@@ -71,7 +72,7 @@ const Button = ({ ref, ...props }: ButtonProps) => {
 					{isPending && (
 						<ProgressBar isIndeterminate aria-label="loading" className={styles.progress} />
 					)}
-					{children}
+					{typeof children === 'string' ? <Text>{children}</Text> : children}
 				</Provider>
 			))}
 		</AriaButton>

--- a/packages/components/stories/Button.stories.tsx
+++ b/packages/components/stories/Button.stories.tsx
@@ -147,7 +147,7 @@ export const Pending: Story = {
 		return <Button isPending={isPending} onPress={handlePress} {...args} />;
 	},
 	args: {
-		children: <Text>Pending</Text>,
+		children: 'Pending',
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);


### PR DESCRIPTION
## Summary

Wrap `Button` string children with `Text` to avoid Google translate errors when a button is in `isPending` state.

## Testing approaches

Toggle between languages via Google translate in Chrome for a button in pending state with plain string content.