### PR TITLE
chore: convert shared dependencies to peer dependencies

### DIFF
--- a/.changeset/weak-jobs-turn.md
+++ b/.changeset/weak-jobs-turn.md
@@ -1,0 +1,12 @@
+---
+"@launchpad-ui/components": minor
+"@launchpad-ui/focus-trap": minor
+"@launchpad-ui/navigation": minor
+"@launchpad-ui/dropdown": minor
+"@launchpad-ui/drawer": minor
+"@launchpad-ui/filter": minor
+"@launchpad-ui/modal": minor
+"@launchpad-ui/form": minor
+---
+
+@react-aria and react-router are now peer dependencies

--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -36,4 +36,4 @@ jobs:
       - name: Build
         run: pnpm nx run @launchpad-ui/components:build
 
-      - run: pnpm dlx pkg-pr-new publish --compact --pnpm --no-template './packages/components' './packages/icons' './packages/tokens'
+      - run: pnpm dlx pkg-pr-new publish --compact --pnpm --no-template --packageManager="yarn" './packages/components' './packages/icons' './packages/tokens'

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -40,24 +40,32 @@
 		"@internationalized/date": "3.8.1",
 		"@launchpad-ui/icons": "workspace:~",
 		"@launchpad-ui/tokens": "workspace:~",
+		"class-variance-authority": "0.7.0"
+	},
+	"peerDependencies": {
+		"react": "^19.0.0",
+		"react-dom": "^19.0.0",
 		"@react-aria/focus": "3.20.3",
 		"@react-aria/interactions": "3.25.1",
 		"@react-aria/utils": "3.29.0",
 		"@react-stately/utils": "3.10.6",
 		"@react-types/shared": "3.29.1",
-		"class-variance-authority": "0.7.0",
 		"react-aria": "3.40.0",
 		"react-aria-components": "1.9.0",
 		"react-router": "7.5.2"
-	},
-	"peerDependencies": {
-		"react": "^19.0.0",
-		"react-dom": "^19.0.0"
 	},
 	"devDependencies": {
 		"react": "19.1.0",
 		"react-dom": "19.1.0",
 		"react-hook-form": "7.57.0",
-		"react-stately": "3.38.0"
+		"react-stately": "3.38.0",
+		"@react-aria/focus": "3.20.3",
+		"@react-aria/interactions": "3.25.1",
+		"@react-aria/utils": "3.29.0",
+		"@react-stately/utils": "3.10.6",
+		"@react-types/shared": "3.29.1",
+		"react-aria": "3.40.0",
+		"react-aria-components": "1.9.0",
+		"react-router": "7.5.2"
 	}
 }

--- a/packages/drawer/package.json
+++ b/packages/drawer/package.json
@@ -42,17 +42,19 @@
 		"@launchpad-ui/portal": "workspace:~",
 		"@launchpad-ui/progress": "0.5.57",
 		"@launchpad-ui/tokens": "workspace:~",
-		"@react-aria/interactions": "3.25.1",
-		"@react-aria/overlays": "3.27.1",
 		"classix": "2.2.0",
 		"framer-motion": "12.15.0"
 	},
 	"peerDependencies": {
 		"react": "^18.0.0 || ^19.0.0",
-		"react-dom": "^18.0.0 || ^19.0.0"
+		"react-dom": "^18.0.0 || ^19.0.0",
+		"@react-aria/interactions": "3.25.1",
+		"@react-aria/overlays": "3.27.1"
 	},
 	"devDependencies": {
 		"react": "19.1.0",
-		"react-dom": "19.1.0"
+		"react-dom": "19.1.0",
+		"@react-aria/interactions": "3.25.1",
+		"@react-aria/overlays": "3.27.1"
 	}
 }

--- a/packages/dropdown/package.json
+++ b/packages/dropdown/package.json
@@ -40,16 +40,17 @@
 		"@launchpad-ui/icons": "workspace:~",
 		"@launchpad-ui/popover": "workspace:~",
 		"@launchpad-ui/tokens": "workspace:~",
-		"@react-aria/utils": "3.29.0",
 		"classix": "2.2.0"
 	},
 	"peerDependencies": {
 		"react": "^18.0.0 || ^19.0.0",
-		"react-dom": "^18.0.0 || ^19.0.0"
+		"react-dom": "^18.0.0 || ^19.0.0",
+		"@react-aria/utils": "3.29.0"
 	},
 	"devDependencies": {
 		"@react-types/shared": "3.29.1",
 		"react": "19.1.0",
-		"react-dom": "19.1.0"
+		"react-dom": "19.1.0",
+		"@react-aria/utils": "3.29.0"
 	}
 }

--- a/packages/filter/package.json
+++ b/packages/filter/package.json
@@ -42,15 +42,16 @@
 		"@launchpad-ui/menu": "workspace:~",
 		"@launchpad-ui/tokens": "workspace:~",
 		"@launchpad-ui/tooltip": "workspace:~",
-		"@react-aria/visually-hidden": "3.8.23",
 		"classix": "2.2.0"
 	},
 	"peerDependencies": {
 		"react": "^18.0.0 || ^19.0.0",
-		"react-dom": "^18.0.0 || ^19.0.0"
+		"react-dom": "^18.0.0 || ^19.0.0",
+		"@react-aria/visually-hidden": "3.8.23"
 	},
 	"devDependencies": {
 		"react": "19.1.0",
-		"react-dom": "19.1.0"
+		"react-dom": "19.1.0",
+		"@react-aria/visually-hidden": "3.8.23"
 	}
 }

--- a/packages/focus-trap/package.json
+++ b/packages/focus-trap/package.json
@@ -33,15 +33,14 @@
 		"lint": "exit 0",
 		"test": "vitest run --coverage"
 	},
-	"dependencies": {
-		"@react-aria/focus": "3.20.3"
-	},
 	"peerDependencies": {
 		"react": "^18.0.0 || ^19.0.0",
-		"react-dom": "^18.0.0 || ^19.0.0"
+		"react-dom": "^18.0.0 || ^19.0.0",
+		"@react-aria/focus": "3.20.3"
 	},
 	"devDependencies": {
 		"react": "19.1.0",
-		"react-dom": "19.1.0"
+		"react-dom": "19.1.0",
+		"@react-aria/focus": "3.20.3"
 	}
 }

--- a/packages/form/package.json
+++ b/packages/form/package.json
@@ -40,19 +40,23 @@
 		"@launchpad-ui/icons": "workspace:~",
 		"@launchpad-ui/tokens": "workspace:~",
 		"@launchpad-ui/tooltip": "workspace:~",
-		"@react-aria/button": "3.13.1",
-		"@react-aria/i18n": "3.12.9",
-		"@react-aria/numberfield": "3.11.14",
-		"@react-aria/visually-hidden": "3.8.23",
 		"@react-stately/numberfield": "3.9.12",
 		"classix": "2.2.0"
 	},
 	"peerDependencies": {
 		"react": "^18.0.0 || ^19.0.0",
-		"react-dom": "^18.0.0 || ^19.0.0"
+		"react-dom": "^18.0.0 || ^19.0.0",
+		"@react-aria/button": "3.13.1",
+		"@react-aria/i18n": "3.12.9",
+		"@react-aria/numberfield": "3.11.14",
+		"@react-aria/visually-hidden": "3.8.23"
 	},
 	"devDependencies": {
 		"react": "19.1.0",
-		"react-dom": "19.1.0"
+		"react-dom": "19.1.0",
+		"@react-aria/button": "3.13.1",
+		"@react-aria/i18n": "3.12.9",
+		"@react-aria/numberfield": "3.11.14",
+		"@react-aria/visually-hidden": "3.8.23"
 	}
 }

--- a/packages/modal/package.json
+++ b/packages/modal/package.json
@@ -41,17 +41,19 @@
 		"@launchpad-ui/icons": "workspace:~",
 		"@launchpad-ui/portal": "workspace:~",
 		"@launchpad-ui/tokens": "workspace:~",
-		"@react-aria/interactions": "3.25.1",
-		"@react-aria/overlays": "3.27.1",
 		"classix": "2.2.0",
 		"framer-motion": "12.15.0"
 	},
 	"peerDependencies": {
 		"react": "^18.0.0 || ^19.0.0",
-		"react-dom": "^18.0.0 || ^19.0.0"
+		"react-dom": "^18.0.0 || ^19.0.0",
+		"@react-aria/interactions": "3.25.1",
+		"@react-aria/overlays": "3.27.1"
 	},
 	"devDependencies": {
 		"react": "19.1.0",
-		"react-dom": "19.1.0"
+		"react-dom": "19.1.0",
+		"@react-aria/interactions": "3.25.1",
+		"@react-aria/overlays": "3.27.1"
 	}
 }

--- a/packages/navigation/package.json
+++ b/packages/navigation/package.json
@@ -43,18 +43,21 @@
 		"@launchpad-ui/popover": "workspace:~",
 		"@launchpad-ui/tokens": "workspace:~",
 		"@launchpad-ui/tooltip": "workspace:~",
-		"@react-aria/utils": "3.29.0",
-		"@react-stately/list": "3.12.2",
-		"@react-types/shared": "3.29.1",
-		"classix": "2.2.0",
-		"react-router": "7.5.2"
+		"classix": "2.2.0"
 	},
 	"peerDependencies": {
 		"react": "^18.0.0 || ^19.0.0",
-		"react-dom": "^18.0.0 || ^19.0.0"
+		"react-dom": "^18.0.0 || ^19.0.0",
+		"react-router": "7.5.2",
+		"@react-aria/utils": "3.29.0",
+		"@react-stately/list": "3.12.2"
 	},
 	"devDependencies": {
 		"react": "19.1.0",
-		"react-dom": "19.1.0"
+		"react-dom": "19.1.0",
+		"react-router": "7.5.2",
+		"@react-types/shared": "3.29.1",
+		"@react-aria/utils": "3.29.0",
+		"@react-stately/list": "3.12.2"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -358,12 +358,6 @@ importers:
       '@launchpad-ui/tokens':
         specifier: workspace:~
         version: link:../tokens
-      '@react-aria/interactions':
-        specifier: 3.25.1
-        version: 3.25.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@react-aria/overlays':
-        specifier: 3.27.1
-        version: 3.27.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       classix:
         specifier: 2.2.0
         version: 2.2.0
@@ -371,6 +365,12 @@ importers:
         specifier: 12.15.0
         version: 12.15.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
     devDependencies:
+      '@react-aria/interactions':
+        specifier: 3.25.1
+        version: 3.25.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@react-aria/overlays':
+        specifier: 3.27.1
+        version: 3.27.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react:
         specifier: 19.1.0
         version: 19.1.0
@@ -392,13 +392,13 @@ importers:
       '@launchpad-ui/tokens':
         specifier: workspace:~
         version: link:../tokens
-      '@react-aria/utils':
-        specifier: 3.29.0
-        version: 3.29.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       classix:
         specifier: 2.2.0
         version: 2.2.0
     devDependencies:
+      '@react-aria/utils':
+        specifier: 3.29.0
+        version: 3.29.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@react-types/shared':
         specifier: 3.29.1
         version: 3.29.1(react@19.1.0)
@@ -429,13 +429,13 @@ importers:
       '@launchpad-ui/tooltip':
         specifier: workspace:~
         version: link:../tooltip
-      '@react-aria/visually-hidden':
-        specifier: 3.8.23
-        version: 3.8.23(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       classix:
         specifier: 2.2.0
         version: 2.2.0
     devDependencies:
+      '@react-aria/visually-hidden':
+        specifier: 3.8.23
+        version: 3.8.23(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react:
         specifier: 19.1.0
         version: 19.1.0
@@ -444,11 +444,10 @@ importers:
         version: 19.1.0(react@19.1.0)
 
   packages/focus-trap:
-    dependencies:
+    devDependencies:
       '@react-aria/focus':
         specifier: 3.20.3
         version: 3.20.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-    devDependencies:
       react:
         specifier: 19.1.0
         version: 19.1.0
@@ -470,6 +469,13 @@ importers:
       '@launchpad-ui/tooltip':
         specifier: workspace:~
         version: link:../tooltip
+      '@react-stately/numberfield':
+        specifier: 3.9.12
+        version: 3.9.12(react@19.1.0)
+      classix:
+        specifier: 2.2.0
+        version: 2.2.0
+    devDependencies:
       '@react-aria/button':
         specifier: 3.13.1
         version: 3.13.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -482,13 +488,6 @@ importers:
       '@react-aria/visually-hidden':
         specifier: 3.8.23
         version: 3.8.23(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@react-stately/numberfield':
-        specifier: 3.9.12
-        version: 3.9.12(react@19.1.0)
-      classix:
-        specifier: 2.2.0
-        version: 2.2.0
-    devDependencies:
       react:
         specifier: 19.1.0
         version: 19.1.0
@@ -569,12 +568,6 @@ importers:
       '@launchpad-ui/tokens':
         specifier: workspace:~
         version: link:../tokens
-      '@react-aria/interactions':
-        specifier: 3.25.1
-        version: 3.25.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@react-aria/overlays':
-        specifier: 3.27.1
-        version: 3.27.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       classix:
         specifier: 2.2.0
         version: 2.2.0
@@ -582,6 +575,12 @@ importers:
         specifier: 12.15.0
         version: 12.15.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
     devDependencies:
+      '@react-aria/interactions':
+        specifier: 3.25.1
+        version: 3.25.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@react-aria/overlays':
+        specifier: 3.27.1
+        version: 3.27.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react:
         specifier: 19.1.0
         version: 19.1.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -245,6 +245,10 @@ importers:
       '@launchpad-ui/tokens':
         specifier: workspace:~
         version: link:../tokens
+      class-variance-authority:
+        specifier: 0.7.0
+        version: 0.7.0
+    devDependencies:
       '@react-aria/focus':
         specifier: 3.20.3
         version: 3.20.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -260,28 +264,24 @@ importers:
       '@react-types/shared':
         specifier: 3.29.1
         version: 3.29.1(react@19.1.0)
-      class-variance-authority:
-        specifier: 0.7.0
-        version: 0.7.0
+      react:
+        specifier: 19.1.0
+        version: 19.1.0
       react-aria:
         specifier: 3.40.0
         version: 3.40.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react-aria-components:
         specifier: 1.9.0
         version: 1.9.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      react-router:
-        specifier: 7.5.2
-        version: 7.5.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-    devDependencies:
-      react:
-        specifier: 19.1.0
-        version: 19.1.0
       react-dom:
         specifier: 19.1.0
         version: 19.1.0(react@19.1.0)
       react-hook-form:
         specifier: 7.57.0
         version: 7.57.0(react@19.1.0)
+      react-router:
+        specifier: 7.5.2
+        version: 7.5.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react-stately:
         specifier: 3.38.0
         version: 3.38.0(react@19.1.0)
@@ -612,6 +612,10 @@ importers:
       '@launchpad-ui/tooltip':
         specifier: workspace:~
         version: link:../tooltip
+      classix:
+        specifier: 2.2.0
+        version: 2.2.0
+    devDependencies:
       '@react-aria/utils':
         specifier: 3.29.0
         version: 3.29.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -621,19 +625,15 @@ importers:
       '@react-types/shared':
         specifier: 3.29.1
         version: 3.29.1(react@19.1.0)
-      classix:
-        specifier: 2.2.0
-        version: 2.2.0
-      react-router:
-        specifier: 7.5.2
-        version: 7.5.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-    devDependencies:
       react:
         specifier: 19.1.0
         version: 19.1.0
       react-dom:
         specifier: 19.1.0
         version: 19.1.0(react@19.1.0)
+      react-router:
+        specifier: 7.5.2
+        version: 7.5.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
 
   packages/overlay:
     dependencies:


### PR DESCRIPTION
## Summary

I talked about this Robb in hypotheticals. We both thought it would be neat if we didn't need to write versions if we automatically picked up react-aria upgrades from launchpad without the need to make sure that all the versions align.

With peer deps, launchpad owns the versioning entirely.

We might need to pair it with: https://classic.yarnpkg.com/en/package/install-peers

## Screenshots (if appropriate):

<!-- Are there any visual changes that would be helpful to the reviewer to see? -->

## Testing approaches

<!-- How are these changes tested? -->
