### PR TITLE
fix(components): removal buttons overflow small Tags

### DIFF
--- a/.changeset/ripe-squids-walk.md
+++ b/.changeset/ripe-squids-walk.md
@@ -1,0 +1,5 @@
+---
+"@launchpad-ui/components": patch
+---
+
+Removal buttons within Tags of size "small" no longer overflow the Tag when hovered or focused

--- a/packages/components/src/styles/TagGroup.module.css
+++ b/packages/components/src/styles/TagGroup.module.css
@@ -49,6 +49,16 @@
 .small {
 	font: var(--lp-text-label-2-medium);
 	height: var(--lp-size-20);
+
+	& [slot='remove'] {
+		height: var(--lp-size-20);
+		width: var(--lp-size-20);
+		background-color: transparent;
+
+		&[data-hovered] {
+			background-color: transparent;
+		}
+	}
 }
 
 .medium {

--- a/packages/components/stories/TagGroup.stories.tsx
+++ b/packages/components/stories/TagGroup.stories.tsx
@@ -65,6 +65,24 @@ export const Removable: Story = {
 	},
 };
 
+export const SmallRemovable: Story = {
+	render: (args) => {
+		const list = useListData({
+			initialItems: [
+				{ id: 1, name: 'One' },
+				{ id: 2, name: 'Two' },
+				{ id: 3, name: 'Three' },
+			],
+		});
+		return (
+			<TagGroup onRemove={(keys) => list.remove(...keys)} {...args}>
+				<Label>Label</Label>
+				<TagList items={list.items}>{(item) => <Tag size="small">{item.name}</Tag>}</TagList>
+			</TagGroup>
+		);
+	},
+};
+
 export const States: Story = {
 	args: {
 		children: (


### PR DESCRIPTION
## Summary
Tags of size `"small"` that were also removable had icon buttons that were still 24 x 24, so they would overflow the tag container on hover or focus.

Before:

https://github.com/user-attachments/assets/55a74b51-f723-4831-aefd-1fb60269f609

After:

https://github.com/user-attachments/assets/41b0042c-accb-49da-8ac7-177ce3aaf891



<!-- What is changing and why? -->

## Screenshots (if appropriate):

<!-- Are there any visual changes that would be helpful to the reviewer to see? -->

## Testing approaches

<!-- How are these changes tested? -->
