### PR TITLE
fix(components): set min-width on Alert content to let content shrink to fit container

### DIFF
--- a/.changeset/chatty-insects-clean.md
+++ b/.changeset/chatty-insects-clean.md
@@ -1,0 +1,5 @@
+---
+"@launchpad-ui/components": patch
+---
+
+Set min-width on Alert content wrapper to let it shrink to fit flex container

--- a/packages/components/src/styles/Alert.module.css
+++ b/packages/components/src/styles/Alert.module.css
@@ -87,6 +87,7 @@
 }
 
 .content {
+	min-width: 0;
 	flex: 1;
 	display: flex;
 	flex-direction: column;


### PR DESCRIPTION
## Summary
Sets a `min-width: 0` on the `.content` wrapper inside `Alert`, which lets the content wrapper shrink to fit inside the root flex container. This typically only becomes an issue if the Alert itself has a constrained width and if some content within the Alert forces the `.content` wrapper to grow, such as if the content contains a `<div>` and that `<div>` contains a `<span>` with a very large word in it.

Before:
<img width="1075" height="154" alt="Screenshot 2025-08-25 at 3 47 34 PM" src="https://github.com/user-attachments/assets/24411b82-dbc9-45d2-92a7-37097b808c65" />

After:
<img width="736" height="170" alt="Screenshot 2025-08-25 at 3 53 12 PM" src="https://github.com/user-attachments/assets/98eef522-ce00-439c-99ea-8d3b80eedcac" />

With this change, there's still the problem of the overflowing content, but because the `.content` wrapper has a calculable width and shrinks to respect its flex container, consumers can properly style the slotted children as they see fit, such as setting a `max-width: 100%` and having that width be calculated property based on the width of the parent.


<!-- What is changing and why? -->

## Screenshots (if appropriate):

<!-- Are there any visual changes that would be helpful to the reviewer to see? -->

## Testing approaches

<!-- How are these changes tested? -->
