### PR TITLE
fix: export global typings

### DIFF
--- a/.changeset/lucky-areas-hang.md
+++ b/.changeset/lucky-areas-hang.md
@@ -1,0 +1,5 @@
+---
+"@launchpad-ui/components": patch
+---
+
+react-aria-component type override should be picked up automatically

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -10,7 +10,7 @@
 	"license": "Apache-2.0",
 	"status": "beta",
 	"main": "dist/index.js",
-	"types": "dist/index.d.ts",
+	"types": "dist/typesIndex.d.ts",
 	"module": "dist/index.es.js",
 	"source": "src/index.ts",
 	"files": [

--- a/packages/components/src/typesIndex.d.ts
+++ b/packages/components/src/typesIndex.d.ts
@@ -1,0 +1,4 @@
+// biome-ignore lint/performance/noReExportAll: This is necessary to re-surface type definitions
+export * from './index';
+// biome-ignore lint/performance/noReExportAll: This is necessary to re-surface type definitions
+export * from './global';


### PR DESCRIPTION
## Summary

My previous work in #1739 does not automatically activate. I need some hackery to re-surface it.

## Screenshots (if appropriate):

<!-- Are there any visual changes that would be helpful to the reviewer to see? -->

## Testing approaches

<!-- How are these changes tested? -->
