### PR TITLE
fix(components): remove duplicate Tag name from Tag removal IconButton accessible name

### DIFF
--- a/.changeset/proud-peas-invent.md
+++ b/.changeset/proud-peas-invent.md
@@ -1,0 +1,5 @@
+---
+"@launchpad-ui/components": patch
+---
+
+Remove Tag textValue from Tag removal IconButton aria-label, as it results in the Tag textValue getting included twice in the accessible name of the removal button, such as "Remove tag-name tag-name" instead of "Remove tag-name"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,5 +7,8 @@
 		"quickfix.biome": "explicit",
 		"source.organizeImports.biome": "explicit"
 	},
-	"editor.tabSize": 2
+	"editor.tabSize": 2,
+	"[typescriptreact]": {
+		"editor.defaultFormatter": "biomejs.biome"
+	}
 }

--- a/packages/components/__tests__/TagGroup.spec.tsx
+++ b/packages/components/__tests__/TagGroup.spec.tsx
@@ -18,7 +18,7 @@ describe('TagGroup', () => {
 		expect(screen.getByRole('grid')).toBeVisible();
 	});
 
-	it('renders remove buttons', () => {
+	it('renders remove buttons with correct accessible names', () => {
 		render(
 			<TagGroup onRemove={() => undefined}>
 				<Label>Label</Label>
@@ -29,10 +29,20 @@ describe('TagGroup', () => {
 				</TagList>
 			</TagGroup>,
 		);
+
+		// Verify all buttons are visible
 		const buttons = screen.getAllByRole('button');
+		expect(buttons).toHaveLength(3);
 		for (const button of buttons) {
 			expect(button).toBeVisible();
 		}
-		expect(buttons[0].getAttribute('aria-label')).toBe('Remove One');
+
+		// Verify accessible names are correct for each tag
+		expect(screen.getByRole('button', { name: 'Remove One' })).toBeVisible();
+		expect(screen.getByRole('button', { name: 'Remove Two' })).toBeVisible();
+		expect(screen.getByRole('button', { name: 'Remove Three' })).toBeVisible();
+
+		// Verify the aria-label attribute is just "Remove"
+		expect(buttons[0].getAttribute('aria-label')).toBe('Remove');
 	});
 });

--- a/packages/components/src/TagGroup.tsx
+++ b/packages/components/src/TagGroup.tsx
@@ -110,7 +110,7 @@ const Tag = ({ size = 'medium', variant = 'default', ref, ...props }: TagProps) 
 					{children}
 					{allowsRemoving && (
 						<IconButton
-							aria-label={`Remove ${textValue ?? ''}`.trim()}
+							aria-label="Remove"
 							size="small"
 							variant="minimal"
 							icon="cancel-circle-outline"


### PR DESCRIPTION
## Summary
In testing the usage of a `Tag`'s removal button when a `TagGroup` has a `onRemove` callback, I realized that by including the `Tag`'s `textValue` as part of the removal `IconButton`'s `aria-label`, this results in a final calculated accessible name for that button of `Remove tag-name tag-name` instead of just `Remove tag-name`, so querying for the button in unit tests a la `screen.getByRole('button', { name: 'Remove tag-1' })` wouldn't work unless you repeated the tag name like: `screen.getByRole('button', { name: 'Remove tag-1 tag-1' })`.

<!-- What is changing and why? -->

## Screenshots (if appropriate):

<!-- Are there any visual changes that would be helpful to the reviewer to see? -->

## Testing approaches
Updated tests so that we're asserting that the accessible name is what we expect, rather than just what the `aria-label` of the removal button is.

<!-- How are these changes tested? -->
