### PR TITLE
fix(components): tweak layout of collection items with icons and descriptions

### DIFF
--- a/.changeset/metal-turtles-own.md
+++ b/.changeset/metal-turtles-own.md
@@ -1,0 +1,5 @@
+---
+"@launchpad-ui/components": patch
+---
+
+tweak layout of collection items with icons and descriptions

--- a/package.json
+++ b/package.json
@@ -87,11 +87,12 @@
 		"onlyBuiltDependencies": [
 			"@biomejs/biome",
 			"@bundled-es-modules/glob",
+			"@parcel/watcher",
 			"@swc/core",
 			"esbuild",
 			"nx",
-			"style-dictionary",
-			"rolldown"
+			"rolldown",
+			"style-dictionary"
 		],
 		"peerDependencyRules": {
 			"allowedVersions": {

--- a/packages/components/src/styles/Menu.module.css
+++ b/packages/components/src/styles/Menu.module.css
@@ -66,7 +66,7 @@
 			& .content {
 				grid-template-areas:
 					'label kbd'
-					'desc kbd';
+					'desc -';
 				grid-template-columns: 1fr min-content;
 			}
 		}
@@ -81,6 +81,11 @@
 
 	& [slot='description'] {
 		grid-area: desc;
+		word-break: break-all;
+	}
+
+	&:has([data-icon]) [slot='description'] {
+		padding-inline-start: calc(var(--lp-size-16) + var(--lp-spacing-300));
 	}
 
 	& kbd {


### PR DESCRIPTION
## Summary

This detail does not match what's in Figma. And this looks better.

## Screenshots (if appropriate):

| Before | After |
| ------- | ------- |
| <img width="231" height="140" alt="CleanShot 2025-09-03 at 13 36 28" src="https://github.com/user-attachments/assets/df4e1d17-1915-4e73-8440-9d40d9c05b66" /> | <img width="231" height="140" alt="CleanShot 2025-09-03 at 13 38 10" src="https://github.com/user-attachments/assets/06f9a157-8109-4864-9e8a-db983a002c8d" /> |
  

## Testing approaches

<!-- How are these changes tested? -->
