### PR TITLE
fix(components): fix layout of collection items descriptions when selection is enabled

### DIFF
--- a/.changeset/dark-lights-invent.md
+++ b/.changeset/dark-lights-invent.md
@@ -1,0 +1,5 @@
+---
+"@launchpad-ui/components": patch
+---
+
+Fix collection item layout for descriptions when selection is active

--- a/packages/components/src/styles/Menu.module.css
+++ b/packages/components/src/styles/Menu.module.css
@@ -84,7 +84,7 @@
 		word-break: break-all;
 	}
 
-	&:has([data-icon]) [slot='description'] {
+	&:has([slot='label']:has([data-icon])) [slot='description'] {
 		padding-inline-start: calc(var(--lp-size-16) + var(--lp-spacing-300));
 	}
 

--- a/packages/components/src/styles/Menu.module.css
+++ b/packages/components/src/styles/Menu.module.css
@@ -84,7 +84,7 @@
 		word-break: break-all;
 	}
 
-	&:has([slot='label']:has([data-icon])) ~ [slot='description'] {
+	& [slot='label']:has([data-icon]) ~ [slot='description'] {
 		padding-inline-start: calc(var(--lp-size-16) + var(--lp-spacing-300));
 	}
 

--- a/packages/components/src/styles/Menu.module.css
+++ b/packages/components/src/styles/Menu.module.css
@@ -84,7 +84,7 @@
 		word-break: break-all;
 	}
 
-	&:has([slot='label']:has([data-icon])) [slot='description'] {
+	&:has([slot='label']:has([data-icon])) ~ [slot='description'] {
 		padding-inline-start: calc(var(--lp-size-16) + var(--lp-spacing-300));
 	}
 

--- a/packages/components/stories/Menu.stories.tsx
+++ b/packages/components/stories/Menu.stories.tsx
@@ -47,7 +47,9 @@ const renderMenu = (args: Story['args']) => (
 		<Popover>
 			<Menu {...args}>
 				<MenuItem>
-					<Text slot="label"><Icon name="add" size="small" /> Item one</Text>
+					<Text slot="label">
+						<Icon name="add" size="small" /> Item one
+					</Text>
 					<Text slot="description">Item one description</Text>
 				</MenuItem>
 				<MenuItem>

--- a/packages/components/stories/Menu.stories.tsx
+++ b/packages/components/stories/Menu.stories.tsx
@@ -46,7 +46,10 @@ const renderMenu = (args: Story['args']) => (
 		<Button>Trigger</Button>
 		<Popover>
 			<Menu {...args}>
-				<MenuItem>Item one</MenuItem>
+				<MenuItem>
+					<Text slot="label">Item one</Text>
+					<Text slot="description">Item one description</Text>
+				</MenuItem>
 				<MenuItem>
 					<Text slot="label">Item two</Text>
 				</MenuItem>

--- a/packages/components/stories/Menu.stories.tsx
+++ b/packages/components/stories/Menu.stories.tsx
@@ -47,7 +47,7 @@ const renderMenu = (args: Story['args']) => (
 		<Popover>
 			<Menu {...args}>
 				<MenuItem>
-					<Text slot="label">Item one</Text>
+					<Text slot="label"><Icon name="add" size="small" /> Item one</Text>
 					<Text slot="description">Item one description</Text>
 				</MenuItem>
 				<MenuItem>

--- a/packages/components/stories/Menu.stories.tsx
+++ b/packages/components/stories/Menu.stories.tsx
@@ -206,11 +206,15 @@ export const IconsAndDescriptions: Story = {
 							<Text slot="description">Add a new item</Text>
 						</MenuItem>
 						<MenuItem>
-							<Icon name="edit" size="small" /> Edit
+							<Text slot="label">
+								<Icon name="edit" size="small" /> Edit
+							</Text>
 							<Text slot="description">Edit the selected item</Text>
 						</MenuItem>
 						<MenuItem variant="destructive">
-							<Icon name="delete" size="small" /> Delete
+							<Text slot="label">
+								<Icon name="delete" size="small" /> Delete
+							</Text>
 							<Text slot="description">Delete the selected item</Text>
 						</MenuItem>
 					</Menu>

--- a/packages/components/stories/Menu.stories.tsx
+++ b/packages/components/stories/Menu.stories.tsx
@@ -187,6 +187,35 @@ export const Icons: Story = {
 	...open,
 };
 
+export const IconsAndDescriptions: Story = {
+	render: (args) => {
+		return (
+			<MenuTrigger>
+				<Button>Trigger</Button>
+				<Popover>
+					<Menu {...args}>
+						<MenuItem>
+							<Text slot="label">
+								<Icon name="add" size="small" /> Add
+							</Text>
+							<Text slot="description">Add a new item</Text>
+						</MenuItem>
+						<MenuItem>
+							<Icon name="edit" size="small" /> Edit
+							<Text slot="description">Edit the selected item</Text>
+						</MenuItem>
+						<MenuItem variant="destructive">
+							<Icon name="delete" size="small" /> Delete
+							<Text slot="description">Delete the selected item</Text>
+						</MenuItem>
+					</Menu>
+				</Popover>
+			</MenuTrigger>
+		);
+	},
+	...open,
+};
+
 export const States: Story = {
 	render: (args) => {
 		return (


### PR DESCRIPTION
## Summary

This change fixes  this bug I introduced yesterday with an overly-broad selector:
<img width="526" height="455" alt="CleanShot 2025-09-04 at 06 55 18" src="https://github.com/user-attachments/assets/037fa235-cd97-4c36-b6e0-6266913198b9" />


## Screenshots (if appropriate):

Tweaked the `<Menu>` stories to have more combinations of icons/descriptions/selection.
https://626696a2018c1f004a1cde86-dcvtbyahmy.chromatic.com/?path=/docs/components-collections-menu--docs

The layout works better now:

<img width="458" height="350" alt="CleanShot 2025-09-04 at 06 54 21@2x" src="https://github.com/user-attachments/assets/8d6ea2f3-f6e5-4643-9bd2-f8245c942ca5" />
<img width="458" height="350" alt="CleanShot 2025-09-04 at 06 54 46@2x" src="https://github.com/user-attachments/assets/6da9bb9e-8eee-484c-b4c7-c29a3fd0d423" />
<img width="458" height="350" alt="CleanShot 2025-09-04 at 06 54 53@2x" src="https://github.com/user-attachments/assets/93beb717-ecfd-4200-a63d-4e041091aef1" />

