### PR TITLE
fix: add `skipLibCheck: true` to `tsconfig.build.json` files that were missing it

### DIFF
--- a/.changeset/chubby-zoos-hug.md
+++ b/.changeset/chubby-zoos-hug.md
@@ -1,0 +1,13 @@
+---
+"@launchpad-ui/overlay": patch
+"@launchpad-ui/tooltip": patch
+"@launchpad-ui/button": patch
+"@launchpad-ui/portal": patch
+"@launchpad-ui/icons": patch
+"@launchpad-ui/table": patch
+"@launchpad-ui/form": patch
+"@launchpad-ui/vars": patch
+"@launchpad-ui/box": patch
+---
+
+add skipLibCheck for tsconfing.build.json

--- a/packages/box/tsconfig.build.json
+++ b/packages/box/tsconfig.build.json
@@ -2,6 +2,7 @@
 	"extends": "../../tsconfig.base.json",
 	"include": ["src/*.ts", "src/*.tsx"],
 	"compilerOptions": {
-		"outDir": "./dist"
+		"outDir": "./dist",
+		"skipLibCheck": true
 	}
 }

--- a/packages/button/tsconfig.build.json
+++ b/packages/button/tsconfig.build.json
@@ -2,6 +2,7 @@
 	"extends": "../../tsconfig.base.json",
 	"include": ["src/*.ts", "src/*.tsx"],
 	"compilerOptions": {
-		"outDir": "./dist"
+		"outDir": "./dist",
+		"skipLibCheck": true
 	}
 }

--- a/packages/form/tsconfig.build.json
+++ b/packages/form/tsconfig.build.json
@@ -2,6 +2,7 @@
 	"extends": "../../tsconfig.base.json",
 	"include": ["src/*.ts", "src/*.tsx"],
 	"compilerOptions": {
-		"outDir": "./dist"
+		"outDir": "./dist",
+		"skipLibCheck": true
 	}
 }

--- a/packages/icons/tsconfig.build.json
+++ b/packages/icons/tsconfig.build.json
@@ -2,6 +2,7 @@
 	"extends": "../../tsconfig.base.json",
 	"include": ["src/*.ts", "src/*.tsx"],
 	"compilerOptions": {
-		"outDir": "./dist"
+		"outDir": "./dist",
+		"skipLibCheck": true
 	}
 }

--- a/packages/overlay/tsconfig.build.json
+++ b/packages/overlay/tsconfig.build.json
@@ -2,6 +2,7 @@
 	"extends": "../../tsconfig.base.json",
 	"include": ["src/*.ts", "src/*.tsx"],
 	"compilerOptions": {
-		"outDir": "./dist"
+		"outDir": "./dist",
+		"skipLibCheck": true
 	}
 }

--- a/packages/portal/tsconfig.build.json
+++ b/packages/portal/tsconfig.build.json
@@ -2,6 +2,7 @@
 	"extends": "../../tsconfig.base.json",
 	"include": ["src/*.ts", "src/*.tsx"],
 	"compilerOptions": {
-		"outDir": "./dist"
+		"outDir": "./dist",
+		"skipLibCheck": true
 	}
 }

--- a/packages/table/tsconfig.build.json
+++ b/packages/table/tsconfig.build.json
@@ -2,6 +2,7 @@
 	"extends": "../../tsconfig.base.json",
 	"include": ["src/*.ts", "src/*.tsx"],
 	"compilerOptions": {
-		"outDir": "./dist"
+		"outDir": "./dist",
+		"skipLibCheck": true
 	}
 }

--- a/packages/tooltip/tsconfig.build.json
+++ b/packages/tooltip/tsconfig.build.json
@@ -2,6 +2,7 @@
 	"extends": "../../tsconfig.base.json",
 	"include": ["src/*.ts", "src/*.tsx"],
 	"compilerOptions": {
-		"outDir": "./dist"
+		"outDir": "./dist",
+		"skipLibCheck": true
 	}
 }

--- a/packages/vars/tsconfig.build.json
+++ b/packages/vars/tsconfig.build.json
@@ -2,6 +2,7 @@
 	"extends": "../../tsconfig.base.json",
 	"include": ["src/*.ts", "src/*.tsx"],
 	"compilerOptions": {
-		"outDir": "./dist"
+		"outDir": "./dist",
+		"skipLibCheck": true
 	}
 }


### PR DESCRIPTION
## Summary

Necessary due to bad MDX types: https://github.com/withastro/astro/issues/5061#issuecomment-1350184500

## Screenshots (if appropriate):

<!-- Are there any visual changes that would be helpful to the reviewer to see? -->

## Testing approaches

<!-- How are these changes tested? -->
