### PR TITLE
fix(modal): increase modal close button style specificity

### DIFF
--- a/.changeset/open-plants-cheer.md
+++ b/.changeset/open-plants-cheer.md
@@ -1,0 +1,5 @@
+---
+"@launchpad-ui/modal": patch
+---
+
+Increase modal close button style specificity

--- a/packages/modal/src/styles/Modal.module.css
+++ b/packages/modal/src/styles/Modal.module.css
@@ -50,6 +50,17 @@
 	flex-direction: column;
 	gap: 0.25rem;
 	padding: 1rem;
+
+	& > .headerMain {
+		display: flex;
+		gap: 0.5rem;
+		align-items: flex-start;
+
+		& > .closeButton {
+			margin-left: auto;
+			transform: translateY(-1px);
+		}
+	}
 }
 
 .title {
@@ -66,12 +77,6 @@
 	fill: var(--lp-color-brand-yellow-dark);
 }
 
-.headerMain {
-	display: flex;
-	gap: 0.5rem;
-	align-items: flex-start;
-}
-
 .headerDescription {
 	font-size: 0.875rem;
 	color: var(--lp-color-text-ui-secondary);
@@ -86,11 +91,6 @@
 
 .requiredAsterisk {
 	color: var(--lp-color-text-feedback-error);
-}
-
-.closeButton {
-	margin-left: auto;
-	transform: translateY(-1px);
 }
 
 .body {


### PR DESCRIPTION
## Summary
If a bundled CSS file were to be loaded after the Modal CSS file, and that bundled file also includes the base styles for `Button`, it will cause the `.closeButton` of the `Modal` to lose its `margin-left` style declaration, which is what pushes the modal close button to the right of the header.

Given that neither `.headerMain` or `.closeButton` are user-configurable, this nests those classes under `.header` to increase the specificity of the `.closeButton`'s `margin-left` declaration to be higher than that of the base `.Button` styles.

<!-- What is changing and why? -->

## Screenshots (if appropriate):

<!-- Are there any visual changes that would be helpful to the reviewer to see? -->

## Testing approaches

<!-- How are these changes tested? -->
