### PR TITLE
fix: type declaration not loading

### DIFF
--- a/.changeset/puny-pants-stick.md
+++ b/.changeset/puny-pants-stick.md
@@ -1,0 +1,5 @@
+---
+"@launchpad-ui/components": patch
+---
+
+fix: expose router types

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -65,7 +65,7 @@
 	},
 	"exports": {
 		".": {
-			"types": "./dist/index.d.ts",
+			"types": "./dist/typesIndex.d.ts",
 			"import": "./dist/index.es.js",
 			"require": "./dist/index.js"
 		},


### PR DESCRIPTION
## Summary

My `types` was conflicting with `exports.["."].types`, which prevent my global override for the router from loading. This fixes it.

## Screenshots (if appropriate):

<!-- Are there any visual changes that would be helpful to the reviewer to see? -->

## Testing approaches

<!-- How are these changes tested? -->
