### PR TITLE
fix(components): fix date picker layout in submenu

### DIFF
--- a/.changeset/giant-spies-fry.md
+++ b/.changeset/giant-spies-fry.md
@@ -1,0 +1,5 @@
+---
+"@launchpad-ui/components": patch
+---
+
+fix date picker layout in submenus

--- a/packages/components/src/styles/Popover.module.css
+++ b/packages/components/src/styles/Popover.module.css
@@ -43,7 +43,7 @@
 	}
 
 	&:is([data-trigger='DatePicker'], [data-trigger='DateRangePicker']) {
-		padding: var(--lp-spacing-600);
+		padding: var(--lp-spacing-300);
 	}
 
 	&[data-placement='top'] {

--- a/packages/components/src/styles/Popover.module.css
+++ b/packages/components/src/styles/Popover.module.css
@@ -36,16 +36,14 @@
 		stroke-width: 1px;
 	}
 
-	&[data-trigger='DialogTrigger'] {
-		padding: var(--lp-spacing-300);
-	}
-
-	&[data-trigger='ComboBoxDialog'] {
+	&[data-trigger='DialogTrigger'],
+	&[data-trigger='ComboBoxDialog'],
+	&[data-trigger='SubmenuTrigger'] {
 		padding: var(--lp-spacing-300);
 	}
 
 	&:is([data-trigger='DatePicker'], [data-trigger='DateRangePicker']) {
-		padding: var(--lp-spacing-600);
+		padding: var(--lp-spacing-300);
 	}
 
 	&[data-placement='top'] {

--- a/packages/components/src/styles/Popover.module.css
+++ b/packages/components/src/styles/Popover.module.css
@@ -43,7 +43,7 @@
 	}
 
 	&:is([data-trigger='DatePicker'], [data-trigger='DateRangePicker']) {
-		padding: var(--lp-spacing-300);
+		padding: var(--lp-spacing-600);
 	}
 
 	&[data-placement='top'] {

--- a/packages/components/stories/DatePicker.stories.tsx
+++ b/packages/components/stories/DatePicker.stories.tsx
@@ -16,6 +16,7 @@ import { Group } from '../src/Group';
 import { Heading } from '../src/Heading';
 import { IconButton } from '../src/IconButton';
 import { Label } from '../src/Label';
+import { Menu, MenuItem, MenuTrigger, SubmenuTrigger } from '../src/Menu';
 import { Popover } from '../src/Popover';
 
 const meta: Meta<typeof DatePicker> = {
@@ -137,5 +138,47 @@ export const InForms: Story = {
 		await userEvent.click(canvas.getByRole('button'));
 		const body = canvasElement.ownerDocument.body;
 		await expect(await within(body).findByRole('application'));
+	},
+};
+
+export const InSubmenu: Story = {
+	args: {
+		children: (
+			<MenuTrigger>
+				<Button>Select</Button>
+				<Popover>
+					<Menu>
+						<SubmenuTrigger>
+							<MenuItem id="calendar">Choose custom date</MenuItem>
+							<Popover>
+								<Dialog>
+									<Calendar>
+										<header>
+											<IconButton
+												slot="previous"
+												icon="chevron-left"
+												aria-label="previous"
+												size="small"
+												variant="minimal"
+											/>
+											<Heading />
+											<IconButton
+												slot="next"
+												icon="chevron-right"
+												aria-label="next"
+												size="small"
+												variant="minimal"
+											/>
+										</header>
+										<CalendarGrid>{(date) => <CalendarCell date={date} />}</CalendarGrid>
+									</Calendar>
+								</Dialog>
+							</Popover>
+						</SubmenuTrigger>
+					</Menu>
+				</Popover>
+			</MenuTrigger>
+		),
+		defaultValue: parseDate('2025-01-01'),
 	},
 };


### PR DESCRIPTION
## Summary

This change tweaks popover padding around calendars inside submenus to be consistent with the rest of our popovers.

## Screenshots (if appropriate):

| Before | After |
| ------- | ------- |
| <img width="291" height="251" alt="CleanShot 2025-10-20 at 08 34 55" src="https://github.com/user-attachments/assets/21e271b6-482a-4122-88b5-e81a06ccbc8f" /> | <img width="291" height="251" alt="CleanShot 2025-10-20 at 08 35 20" src="https://github.com/user-attachments/assets/1b3843f1-37f8-431d-bcf0-88be25a9362f" /> |
  
