### PR TITLE
fix(components): Code inline style bugfix

### DIFF
--- a/.changeset/cruel-hounds-win.md
+++ b/.changeset/cruel-hounds-win.md
@@ -1,0 +1,5 @@
+---
+"@launchpad-ui/components": patch
+---
+
+Code component inline style bug fix

--- a/packages/components/src/styles/Code.module.css
+++ b/packages/components/src/styles/Code.module.css
@@ -6,7 +6,6 @@
 	width: fit-content;
 	background-color: var(--lp-color-bg-ui-tertiary);
 	padding: var(--lp-spacing-100) var(--lp-spacing-200);
-	display: flex;
 	border: none;
 	outline: none;
 }

--- a/packages/components/src/styles/Code.module.css
+++ b/packages/components/src/styles/Code.module.css
@@ -6,6 +6,7 @@
 	width: fit-content;
 	background-color: var(--lp-color-bg-ui-tertiary);
 	padding: var(--lp-spacing-100) var(--lp-spacing-200);
+	display: inline-flex;
 	border: none;
 	outline: none;
 }

--- a/packages/components/stories/Code.stories.tsx
+++ b/packages/components/stories/Code.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 import { Code } from '../src/Code';
+import { Text } from '../src/Text';
 
 const meta: Meta<typeof Code> = {
 	title: 'Components/Content/Code',
@@ -59,5 +60,15 @@ export const Size: Story = {
 			<Code size="small">const size = "small";</Code>
 			<Code size="medium">const size = "medium";</Code>
 		</div>
+	),
+};
+
+export const Inline: Story = {
+	render: () => (
+		<Text>
+			This paragraph contains inline code like <Code>const variable = "value";</Code> which should
+			flow naturally within the text. The code component should behave as an inline element, not
+			breaking the text flow.
+		</Text>
 	),
 };


### PR DESCRIPTION
## Summary

- Before: Code components were breaking into 2 lines.
- After: Code components are now Inline like they used to

## Testing approaches

Added new story to be able to capture this in Chromatic snapshots in future

<img width="889" height="228" alt="image" src="https://github.com/user-attachments/assets/518b1017-1778-4317-a230-c414da5d6cbe" />
