### PR TITLE
feat(components): move the snippet code from gonfalon to lp

### DIFF
--- a/.changeset/angry-words-hope.md
+++ b/.changeset/angry-words-hope.md
@@ -1,0 +1,5 @@
+---
+"@launchpad-ui/components": minor
+---
+
+add the Snippet component

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -34,7 +34,8 @@
 		"@launchpad-ui/icons": "workspace:~",
 		"@launchpad-ui/tokens": "workspace:~",
 		"@react-aria/live-announcer": "3.4.4",
-		"class-variance-authority": "0.7.0"
+		"class-variance-authority": "0.7.0",
+		"prism-themes": "1.9.0"
 	},
 	"devDependencies": {
 		"@react-aria/focus": "3.21.2",
@@ -42,7 +43,10 @@
 		"@react-aria/utils": "3.31.0",
 		"@react-stately/utils": "3.10.8",
 		"@react-types/shared": "3.32.1",
+		"@types/prismjs": "1.26.5",
+		"classix": "2.2.0",
 		"copyfiles": "2.4.1",
+		"prismjs": "1.30.0",
 		"react": "19.2.0",
 		"react-aria": "3.44.0",
 		"react-aria-components": "1.13.0",

--- a/packages/components/src/Snippet.tsx
+++ b/packages/components/src/Snippet.tsx
@@ -1,7 +1,9 @@
-import { CopyToClipboard, IconButton } from '@launchpad-ui/components';
 import { cx } from 'classix';
 import Prism from 'prismjs';
 import { type JSX, useLayoutEffect, useRef } from 'react';
+
+import { CopyToClipboard } from './CopyToClipboard';
+import { IconButton } from './IconButton';
 
 // Import languages based on what you need
 import 'prismjs/components/prism-apex';

--- a/packages/components/src/Snippet.tsx
+++ b/packages/components/src/Snippet.tsx
@@ -1,0 +1,198 @@
+import { CopyToClipboard, IconButton } from '@launchpad-ui/components';
+import { cx } from 'classix';
+import Prism from 'prismjs';
+import { type JSX, useLayoutEffect, useRef } from 'react';
+
+// Import languages based on what you need
+import 'prismjs/components/prism-apex';
+import 'prismjs/components/prism-bash';
+import 'prismjs/components/prism-brightscript';
+import 'prismjs/components/prism-c';
+import 'prismjs/components/prism-clike';
+import 'prismjs/components/prism-cpp';
+import 'prismjs/components/prism-csharp';
+import 'prismjs/components/prism-dart';
+import 'prismjs/components/prism-erlang';
+import 'prismjs/components/prism-go';
+import 'prismjs/components/prism-gradle';
+import 'prismjs/components/prism-haskell';
+import 'prismjs/components/prism-java';
+import 'prismjs/components/prism-javascript';
+import 'prismjs/components/prism-json';
+import 'prismjs/components/prism-jsx';
+import 'prismjs/components/prism-kotlin';
+import 'prismjs/components/prism-lua';
+import 'prismjs/components/prism-makefile';
+import 'prismjs/components/prism-markup';
+import 'prismjs/components/prism-markup-templating';
+import 'prismjs/components/prism-objectivec';
+import 'prismjs/components/prism-php';
+import 'prismjs/components/prism-powershell';
+import 'prismjs/components/prism-python';
+import 'prismjs/components/prism-ruby';
+import 'prismjs/components/prism-rust';
+import 'prismjs/components/prism-sql';
+import 'prismjs/components/prism-swift';
+import 'prismjs/components/prism-tsx';
+import 'prismjs/components/prism-typescript';
+import 'prismjs/components/prism-yaml';
+// Import plugins
+import 'prismjs/plugins/keep-markup/prism-keep-markup';
+import 'prismjs/plugins/line-highlight/prism-line-highlight';
+import 'prismjs/plugins/line-numbers/prism-line-numbers';
+import 'prismjs/plugins/custom-class/prism-custom-class';
+
+import 'prism-themes/themes/prism-ghcolors.css';
+import 'prismjs/plugins/line-numbers/prism-line-numbers.css';
+
+import styles from './styles/Snippet.module.css';
+
+export const languages = [
+	'bash',
+	'shell',
+	'json',
+	'html',
+	'xml',
+	'js',
+	'javascript',
+	'lua',
+	'ts',
+	'typescript',
+	'php',
+	'java',
+	'ruby',
+	'python',
+	'go',
+	'csharp',
+	'c',
+	'cpp',
+	'objectivec',
+	'swift',
+	'makefile',
+	'haskell',
+	'brightscript',
+	'dart',
+	'rust',
+	'tsx',
+	'gradle',
+	'powershell',
+	'kotlin',
+	'erlang',
+	'yaml',
+	'apex',
+	// text and empty string are not a recognized languages by prism, we use it here as a default option for when you don't want styling.
+	'text',
+	'',
+] as const;
+
+export type SnippetLang = (typeof languages)[number];
+
+// Map Prism token classes to CSS module classes
+Prism.plugins.customClass.map({
+	operator: styles.operator,
+	punctuation: styles.punctuation,
+	function: styles.function,
+	tag: styles.tag,
+	'attr-value': styles.attrValue,
+	string: styles.string,
+	property: styles.property,
+	keyword: styles.keyword,
+});
+
+type SnippetProps = {
+	children: string | JSX.Element;
+	className?: string;
+	highlightRange?: string;
+	highlightOffset?: number;
+	lang: SnippetLang;
+	label?: string;
+	withHeader?: boolean;
+	withLineNumbers?: boolean;
+	useDefaultHighlighting?: boolean;
+	withCopyButton?: boolean;
+	trackAnalyticsOnClick?: () => void;
+};
+
+// Example usage:
+//
+// const json = JSON.stringify({
+//    'key': 'test@test.com',
+//    'ip': '192.168.0.1',
+//    'custom': {
+//      'customer_ranking': 10004
+//    }
+// }, null, 2);
+//
+// <Snippet withCopyButton={true} lang="json">{json}</Snippet>
+export function Snippet({
+	children,
+	className,
+	highlightRange,
+	highlightOffset,
+	lang,
+	label,
+	withHeader,
+	withLineNumbers,
+	useDefaultHighlighting = false,
+	withCopyButton,
+	trackAnalyticsOnClick,
+}: SnippetProps) {
+	const codeEl = useRef<HTMLElement>(null);
+
+	useLayoutEffect(() => {
+		const element = codeEl.current;
+		if (!element) {
+			return;
+		}
+
+		// Use requestAnimationFrame to ensure that the element is mounted
+		// before highlighting it.
+		const frame = requestAnimationFrame(() => {
+			Prism.highlightElement(element);
+		});
+
+		// Cancel the animation frame when the component unmounts.
+		return () => cancelAnimationFrame(frame);
+	}, []);
+
+	return (
+		<>
+			{withHeader && (
+				<div className={styles.header}>
+					{label && <span>{label}</span>}
+					{lang && <span>{lang}</span>}
+				</div>
+			)}
+			<div
+				className={cx(
+					styles.snippet,
+					className,
+					withCopyButton && styles.copyable,
+					useDefaultHighlighting && styles.useDefaultHighlighting,
+				)}
+			>
+				<pre
+					className={withLineNumbers ? 'line-numbers' : ''}
+					data-start={1}
+					data-line-offset={highlightOffset ? highlightOffset.toString() : ''}
+					data-line={highlightRange}
+				>
+					<code className={`language-${lang}`} ref={codeEl}>
+						{children}
+					</code>
+					{withCopyButton && (
+						<CopyToClipboard text={children as string} showTooltip={false}>
+							<IconButton
+								className={styles.copyCodeSnippet}
+								aria-label="Copy code snippet"
+								variant="minimal"
+								icon="copy-code"
+								onPress={trackAnalyticsOnClick}
+							/>
+						</CopyToClipboard>
+					)}
+				</pre>
+			</div>
+		</>
+	);
+}

--- a/packages/components/src/styles/Snippet.module.css
+++ b/packages/components/src/styles/Snippet.module.css
@@ -1,0 +1,140 @@
+.snippet {
+	border: 1px solid var(--lp-color-border-ui-secondary);
+	border-radius: 3px;
+	overflow-x: auto;
+	overflow-y: auto;
+}
+
+.snippet > pre {
+	position: relative;
+	white-space: pre-wrap;
+	word-break: break-word;
+	width: 100%;
+}
+
+.copyable {
+	display: flex;
+	align-items: flex-start;
+	justify-content: space-between;
+	position: relative;
+}
+
+.header {
+	display: flex;
+	justify-content: space-between;
+	color: var(--lp-color-text-ui-secondary);
+	font-size: var(--lp-font-size-200);
+	line-height: var(--lp-line-height-200);
+	width: 100%;
+}
+
+.copyable [class*='_CopyToClipboard'] {
+	position: absolute;
+	top: var(--lp-spacing-400);
+	right: var(--lp-spacing-400);
+	visibility: hidden;
+}
+
+.copyable:hover [class*='_CopyToClipboard'] {
+	visibility: visible;
+}
+
+.Snippet--inline {
+	border: none;
+}
+
+.snippet pre[class*='language-'] {
+	margin: 0;
+	border: none;
+	background-color: var(--lp-color-bg-ui-secondary);
+	padding-right: 2rem;
+}
+
+.snippet pre[class*='language-'] [data-theme='dark'] {
+	background-color: var(--lp-color-bg-ui-tertiary);
+	color: var(--lp-color-gray-200);
+}
+
+.snippet pre[class*='language-'],
+.snippet code[class*='language-'] {
+	font-family: var(--lp-font-family-monospace);
+	line-height: 140%;
+	color: var(--lp-color-text-code-base);
+}
+
+.snippet code {
+	padding-left: 0;
+	background-color: transparent;
+	z-index: var(--stacking-above-new-context);
+	white-space: pre-wrap;
+	word-break: break-word;
+	border: none;
+}
+
+.snippet:not(.useDefaultHighlighting) .line-highlight {
+	margin-top: 0;
+	background: var(--lp-color-brand-yellow-light);
+	z-index: var(--stacking-new-context);
+}
+
+.snippet:not(.useDefaultHighlighting) .line-highlight [data-theme='dark'] {
+	background: #3c4200;
+}
+
+/* Line numbers styles - scoped to snippet container */
+.snippet pre[class*='language-'][class~='line-numbers'] {
+	line-height: 0.625rem;
+	padding-bottom: var(--lp-spacing-400);
+	padding-top: var(--lp-spacing-400);
+	overflow-y: hidden;
+	white-space: pre-wrap;
+	z-index: var(--stacking-above-new-context);
+}
+
+.snippet [class~='line-numbers'] [class~='line-numbers-rows'] {
+	border: none;
+	left: -3em;
+	width: 2em;
+}
+
+/* Prism token classes - mapped by custom-class plugin */
+.operator {
+	color: var(--lp-color-text-ui-primary-base);
+}
+
+.punctuation {
+	color: var(--lp-color-text-ui-primary-base);
+}
+
+.function {
+	color: var(--lp-color-text-code-function);
+	font-weight: var(--lp-font-weight-regular);
+}
+
+.tag {
+	color: var(--lp-color-text-code-tag);
+}
+
+.attrValue {
+	color: var(--lp-color-text-code-string);
+}
+
+.string {
+	color: var(--lp-color-text-code-string);
+}
+
+.property {
+	color: var(--lp-color-text-code-keyword);
+}
+
+.keyword {
+	color: var(--lp-color-text-code-keyword);
+}
+
+.copyCodeSnippet {
+	position: absolute !important;
+	right: 0;
+	top: 0;
+	width: var(--lp-size-32) !important;
+	height: var(--lp-size-32);
+}

--- a/packages/components/stories/Snippet.stories.tsx
+++ b/packages/components/stories/Snippet.stories.tsx
@@ -1,0 +1,38 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { Snippet } from '../src/Snippet';
+
+const meta: Meta<typeof Snippet> = {
+	component: Snippet,
+	title: 'Components/Forms/Snippet',
+	parameters: {
+		figma: {
+			design:
+				'https://www.figma.com/design/98HKKXL2dTle29ikJ3tzk7/%F0%9F%9A%80-LaunchPad?node-id=14383-120499&m=dev',
+		},
+	},
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Snippet>;
+
+const json = JSON.stringify(
+	{
+		key: 'test@test.com',
+		ip: '192.168.0.1',
+		custom: {
+			customerRanking: 10004,
+		},
+	},
+	null,
+	2,
+);
+
+export const Example: Story = {
+	args: {
+		children: json,
+		lang: 'json',
+		withCopyButton: true,
+	},
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -254,6 +254,9 @@ importers:
       class-variance-authority:
         specifier: 0.7.0
         version: 0.7.0
+      prism-themes:
+        specifier: 1.9.0
+        version: 1.9.0
       react-hook-form:
         specifier: 7.59.0
         version: 7.59.0(react@19.2.0)
@@ -273,9 +276,18 @@ importers:
       '@react-types/shared':
         specifier: 3.32.1
         version: 3.32.1(react@19.2.0)
+      '@types/prismjs':
+        specifier: 1.26.5
+        version: 1.26.5
+      classix:
+        specifier: 2.2.0
+        version: 2.2.0
       copyfiles:
         specifier: 2.4.1
         version: 2.4.1
+      prismjs:
+        specifier: 1.30.0
+        version: 1.30.0
       react:
         specifier: 19.2.0
         version: 19.2.0
@@ -2586,6 +2598,9 @@ packages:
   '@types/postcss-modules-scope@3.0.4':
     resolution: {integrity: sha512-//ygSisVq9kVI0sqx3UPLzWIMCmtSVrzdljtuaAEJtGoGnpjBikZ2sXO5MpH9SnWX9HRfXxHifDAXcQjupWnIQ==}
 
+  '@types/prismjs@1.26.5':
+    resolution: {integrity: sha512-AUZTa7hQ2KY5L7AmtSiqxlhWxb4ina0yd8hNbl4TWuqnv/pFP0nDMb3YrfSBf4hJVGLh2YEIBfKaBW/9UEl6IQ==}
+
   '@types/react-dom@19.2.1':
     resolution: {integrity: sha512-/EEvYBdT3BflCWvTMO7YkYBHVE9Ci6XdqZciZANQgKpaiDRGOLIlRo91jbTNRQjgPFWVaRxcYc0luVNFitz57A==}
     peerDependencies:
@@ -4641,6 +4656,13 @@ packages:
   pretty-format@29.7.0:
     resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  prism-themes@1.9.0:
+    resolution: {integrity: sha512-tX2AYsehKDw1EORwBps+WhBFKc2kxfoFpQAjxBndbZKr4fRmMkv47XN0BghC/K1qwodB1otbe4oF23vUTFDokw==}
+
+  prismjs@1.30.0:
+    resolution: {integrity: sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==}
+    engines: {node: '>=6'}
 
   process-nextick-args@2.0.1:
     resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
@@ -7987,6 +8009,8 @@ snapshots:
     dependencies:
       postcss: 8.5.4
 
+  '@types/prismjs@1.26.5': {}
+
   '@types/react-dom@19.2.1(@types/react@19.2.2)':
     dependencies:
       '@types/react': 19.2.2
@@ -10230,6 +10254,10 @@ snapshots:
       '@jest/schemas': 29.6.3
       ansi-styles: 5.2.0
       react-is: 18.3.1
+
+  prism-themes@1.9.0: {}
+
+  prismjs@1.30.0: {}
 
   process-nextick-args@2.0.1: {}
 


### PR DESCRIPTION
## Summary

Retry of https://github.com/launchdarkly/launchpad-ui/pull/1795

We got it working without globals!

## Screenshots (if appropriate):

<img width="919" height="359" alt="Screenshot 2025-11-05 at 10 33 46 AM" src="https://github.com/user-attachments/assets/2987391f-45c1-4010-89f0-41549efbf623" />

<!-- Are there any visual changes that would be helpful to the reviewer to see? -->

## Testing approaches

<!-- How are these changes tested? -->
