### PR TITLE
fix: consistent popover padding for filtered collections

### DIFF
--- a/.changeset/lemon-seals-visit.md
+++ b/.changeset/lemon-seals-visit.md
@@ -1,0 +1,5 @@
+---
+"@launchpad-ui/components": patch
+---
+
+align popover padding for filtered collections

--- a/packages/components/src/styles/Popover.module.css
+++ b/packages/components/src/styles/Popover.module.css
@@ -51,6 +51,10 @@
 		padding: var(--lp-spacing-200);
 	}
 
+	&[data-trigger='SubmenuTrigger']:has(div[role='application']) {
+		padding: var(--lp-spacing-200);
+	}
+
 	&[data-placement='top'] {
 		--origin: translateY(4px);
 

--- a/packages/components/src/styles/Popover.module.css
+++ b/packages/components/src/styles/Popover.module.css
@@ -43,7 +43,7 @@
 		padding: var(--lp-spacing-200);
 	}
 
-	&:has(input[type='search']):is(
+	&:has(input[type='search']):where(
 			[data-trigger='Select'],
 			[data-trigger='MenuTrigger'],
 			[data-trigger='SubmenuTrigger']

--- a/packages/components/src/styles/Popover.module.css
+++ b/packages/components/src/styles/Popover.module.css
@@ -37,13 +37,16 @@
 	}
 
 	&[data-trigger='DialogTrigger'],
-	&[data-trigger='ComboBoxDialog'],
-	&[data-trigger='SubmenuTrigger'] {
-		padding: var(--lp-spacing-300);
+	&[data-trigger='ComboBoxDialog'] {
+		padding: var(--lp-spacing-200);
 	}
 
-	&:is([data-trigger='DatePicker'], [data-trigger='DateRangePicker']) {
-		padding: var(--lp-spacing-300);
+	&:has(input[type='search']):is(
+			[data-trigger='MenuTrigger'],
+			[data-trigger='SubmenuTrigger'],
+			[data-trigger='Select']
+		) {
+		padding: var(--lp-spacing-200);
 	}
 
 	&[data-placement='top'] {

--- a/packages/components/src/styles/Popover.module.css
+++ b/packages/components/src/styles/Popover.module.css
@@ -37,14 +37,16 @@
 	}
 
 	&[data-trigger='DialogTrigger'],
-	&[data-trigger='ComboBoxDialog'] {
+	&[data-trigger='ComboBoxDialog'],
+	&[data-trigger='DatePicker'],
+	&[data-trigger='DateRangePicker'] {
 		padding: var(--lp-spacing-200);
 	}
 
 	&:has(input[type='search']):is(
+			[data-trigger='Select'],
 			[data-trigger='MenuTrigger'],
-			[data-trigger='SubmenuTrigger'],
-			[data-trigger='Select']
+			[data-trigger='SubmenuTrigger']
 		) {
 		padding: var(--lp-spacing-200);
 	}

--- a/packages/components/src/styles/Popover.module.css
+++ b/packages/components/src/styles/Popover.module.css
@@ -43,7 +43,7 @@
 		padding: var(--lp-spacing-200);
 	}
 
-	&:has(input[type='search']):where(
+	&:has(input[type='search']):is(
 			[data-trigger='Select'],
 			[data-trigger='MenuTrigger'],
 			[data-trigger='SubmenuTrigger']

--- a/packages/components/stories/Menu.stories.tsx
+++ b/packages/components/stories/Menu.stories.tsx
@@ -4,14 +4,20 @@ import type { Selection as AriaSelection } from 'react-aria-components';
 
 import { Icon } from '@launchpad-ui/icons';
 import { useState } from 'react';
+import { useFilter } from 'react-aria-components';
 import { expect, fireEvent, userEvent, waitFor, within } from 'storybook/test';
 
+import { Autocomplete as AutocompleteComponent } from '../src/Autocomplete';
 import { Button } from '../src/Button';
+import { Group } from '../src/Group';
 import { Header } from '../src/Header';
+import { IconButton } from '../src/IconButton';
+import { Input } from '../src/Input';
 import { Keyboard } from '../src/Keyboard';
 import { Menu, MenuItem, MenuTrigger, SubmenuTrigger } from '../src/Menu';
 import { Popover } from '../src/Popover';
 import { Pressable } from '../src/Pressable';
+import { SearchField } from '../src/SearchField';
 import { MenuSection } from '../src/Section';
 import { Separator } from '../src/Separator';
 import { Text } from '../src/Text';
@@ -335,4 +341,60 @@ export const CustomTrigger: Story = {
 		);
 	},
 	...open,
+};
+
+export const Autocomplete: Story = {
+	render: (args) => {
+		const { contains } = useFilter({ sensitivity: 'base' });
+
+		return (
+			<MenuTrigger>
+				<Button>Trigger</Button>
+				<Popover>
+					<AutocompleteComponent filter={contains}>
+						<SearchField aria-label="search" autoFocus>
+							<Group>
+								<Icon name="search" size="small" />
+								<Input placeholder="Search" />
+								<IconButton
+									icon="cancel-circle-outline"
+									aria-label="clear"
+									size="small"
+									variant="minimal"
+								/>
+							</Group>
+						</SearchField>
+						<Menu {...args}>
+							<MenuItem>Item one</MenuItem>
+							<MenuItem>Item two</MenuItem>
+							<MenuItem>Item three</MenuItem>
+							<SubmenuTrigger>
+								<MenuItem>Item four</MenuItem>
+								<Popover>
+									<AutocompleteComponent filter={contains}>
+										<SearchField aria-label="search" autoFocus>
+											<Group>
+												<Icon name="search" size="small" />
+												<Input placeholder="Search" />
+												<IconButton
+													icon="cancel-circle-outline"
+													aria-label="clear"
+													size="small"
+													variant="minimal"
+												/>
+											</Group>
+										</SearchField>
+										<Menu {...args}>
+											<MenuItem>Item five</MenuItem>
+											<MenuItem>Item six</MenuItem>
+										</Menu>
+									</AutocompleteComponent>
+								</Popover>
+							</SubmenuTrigger>
+						</Menu>
+					</AutocompleteComponent>
+				</Popover>
+			</MenuTrigger>
+		);
+	},
 };

--- a/packages/components/stories/Select.stories.tsx
+++ b/packages/components/stories/Select.stories.tsx
@@ -3,12 +3,18 @@ import type { ComponentType } from 'react';
 
 import { Icon } from '@launchpad-ui/icons';
 import { vars } from '@launchpad-ui/vars';
+import { useFilter } from 'react-aria-components';
 import { expect, userEvent, within } from 'storybook/test';
 
+import { Autocomplete as AutocompleteComponent } from '../src/Autocomplete';
 import { Button } from '../src/Button';
+import { Group } from '../src/Group';
+import { IconButton } from '../src/IconButton';
+import { Input } from '../src/Input';
 import { Label } from '../src/Label';
 import { ListBox, ListBoxItem } from '../src/ListBox';
 import { Popover } from '../src/Popover';
+import { SearchField } from '../src/SearchField';
 import { Select, SelectValue } from '../src/Select';
 import { Text } from '../src/Text';
 
@@ -156,5 +162,43 @@ export const States: Story = {
 		const body = canvasElement.ownerDocument.body;
 		body.click();
 		await userEvent.tab();
+	},
+};
+
+export const Autocomplete: Story = {
+	render: (args) => {
+		const { contains } = useFilter({ sensitivity: 'base' });
+
+		return (
+			<Select {...args}>
+				<Label>Label</Label>
+				<Button>
+					<SelectValue />
+					<Icon name="chevron-down" size="small" />
+				</Button>
+				<Text slot="description">Description</Text>
+				<Popover>
+					<AutocompleteComponent filter={contains}>
+						<SearchField aria-label="search" autoFocus>
+							<Group>
+								<Icon name="search" size="small" />
+								<Input placeholder="Search" />
+								<IconButton
+									icon="cancel-circle-outline"
+									aria-label="clear"
+									size="small"
+									variant="minimal"
+								/>
+							</Group>
+						</SearchField>
+						<ListBox>
+							<ListBoxItem>Item one</ListBoxItem>
+							<ListBoxItem>Item two</ListBoxItem>
+							<ListBoxItem>Item three</ListBoxItem>
+						</ListBox>
+					</AutocompleteComponent>
+				</Popover>
+			</Select>
+		);
 	},
 };


### PR DESCRIPTION
## Summary

<img width="445" height="262" alt="CleanShot 2025-11-17 at 14 16 22" src="https://github.com/user-attachments/assets/0b6669e7-0ebf-4540-9a2c-08959a0e01a1" />
<img width="533" height="312" alt="CleanShot 2025-11-17 at 14 16 40" src="https://github.com/user-attachments/assets/0d3b2d50-d757-46a6-94ca-b1b96e834b96" />
<img width="294" height="365" alt="CleanShot 2025-11-17 at 14 17 06" src="https://github.com/user-attachments/assets/53c588d7-36a7-427c-9fb6-79a45ce4e0ed" />
<img width="478" height="325" alt="CleanShot 2025-11-17 at 14 17 18" src="https://github.com/user-attachments/assets/5a196e99-7567-4298-8b3d-3a4a70b150c0" />
<img width="287" height="181" alt="CleanShot 2025-11-17 at 14 17 53" src="https://github.com/user-attachments/assets/3557efcb-fe97-43c1-951a-65fd1aa3d678" />
<img width="256" height="221" alt="CleanShot 2025-11-17 at 14 18 04" src="https://github.com/user-attachments/assets/da0a5971-bf7f-4765-8cdd-0db409f73fc3" />


## Screenshots (if appropriate):

<!-- Are there any visual changes that would be helpful to the reviewer to see? -->

## Testing approaches

<!-- How are these changes tested? -->
