### PR TITLE
fix: re-increase popover padding slightly

### DIFF
--- a/.changeset/fast-worlds-shout.md
+++ b/.changeset/fast-worlds-shout.md
@@ -1,0 +1,5 @@
+---
+"@launchpad-ui/components": patch
+---
+
+bump popover padding back to where it used to be

--- a/packages/components/src/styles/Popover.module.css
+++ b/packages/components/src/styles/Popover.module.css
@@ -40,7 +40,7 @@
 	&[data-trigger='ComboBoxDialog'],
 	&[data-trigger='DatePicker'],
 	&[data-trigger='DateRangePicker'] {
-		padding: var(--lp-spacing-200);
+		padding: var(--lp-spacing-300);
 	}
 
 	&:has(input[type='search']):is(
@@ -48,11 +48,11 @@
 			[data-trigger='MenuTrigger'],
 			[data-trigger='SubmenuTrigger']
 		) {
-		padding: var(--lp-spacing-200);
+		padding: var(--lp-spacing-300);
 	}
 
 	&[data-trigger='SubmenuTrigger']:has(div[role='application']) {
-		padding: var(--lp-spacing-200);
+		padding: var(--lp-spacing-300);
 	}
 
 	&[data-placement='top'] {


### PR DESCRIPTION
## Summary

Meticulous is kind of a great way to see the impact of Launchpad changes.

Here's [the run for the version bump in gonfalon](https://app.meticulous.ai/projects/LaunchDarkly/gonfalon/test-runs/bFGzhjWkFd7Jn8qFpgqcgWnfGr#diff-288-before-html).

While it's what I expected, seeing it in the app makes me feel like the previous padding amount looked better, so this PR reverts that (while also keeping the consistent padding that was missing before).
