### PR TITLE
feat: implementing an overflow tooltip for the Text component

### DIFF
--- a/.changeset/fifty-bats-smash.md
+++ b/.changeset/fifty-bats-smash.md
@@ -1,0 +1,5 @@
+---
+"@launchpad-ui/components": minor
+---
+
+Updated the Text component to include an optional tooltip on overflow

--- a/packages/components/__tests__/Text.spec.tsx
+++ b/packages/components/__tests__/Text.spec.tsx
@@ -48,4 +48,3 @@ describe('Text', () => {
 		expect(screen.getByText('Truncated text')).toBeVisible();
 	});
 });
-

--- a/packages/components/__tests__/Text.spec.tsx
+++ b/packages/components/__tests__/Text.spec.tsx
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+
+import { render, screen } from '../../../test/utils';
+import { Text } from '../src';
+
+describe('Text', () => {
+	it('renders', () => {
+		render(<Text>Hello world</Text>);
+		expect(screen.getByText('Hello world')).toBeVisible();
+	});
+
+	it('renders with different sizes', () => {
+		const { rerender } = render(<Text size="small">Small text</Text>);
+		expect(screen.getByText('Small text')).toBeVisible();
+
+		rerender(<Text size="medium">Medium text</Text>);
+		expect(screen.getByText('Medium text')).toBeVisible();
+
+		rerender(<Text size="large">Large text</Text>);
+		expect(screen.getByText('Large text')).toBeVisible();
+	});
+
+	it('renders with bold prop', () => {
+		render(<Text bold>Bold text</Text>);
+		expect(screen.getByText('Bold text')).toBeVisible();
+	});
+
+	it('renders with maxLines', () => {
+		render(<Text maxLines={2}>Long text that should be truncated</Text>);
+		expect(screen.getByText('Long text that should be truncated')).toBeVisible();
+	});
+
+	it('renders with overflow tooltip when enabled', () => {
+		render(
+			<Text maxLines={1} showTooltipOnOverflow>
+				Text with overflow tooltip
+			</Text>,
+		);
+		expect(screen.getByText('Text with overflow tooltip')).toBeVisible();
+	});
+
+	it('renders with custom tooltip content', () => {
+		render(
+			<Text maxLines={1} showTooltipOnOverflow tooltipContent="Custom tooltip">
+				Truncated text
+			</Text>,
+		);
+		expect(screen.getByText('Truncated text')).toBeVisible();
+	});
+});
+

--- a/packages/components/src/Text.tsx
+++ b/packages/components/src/Text.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode, Ref } from 'react';
 import type { TextProps as AriaTextProps, ContextValue } from 'react-aria-components';
+import type { TooltipProps } from './Tooltip';
 
 import { cva, cx } from 'class-variance-authority';
 import { createContext, useCallback, useEffect, useRef, useState } from 'react';
@@ -8,7 +9,6 @@ import { Text as AriaText } from 'react-aria-components';
 
 import { Focusable } from './Focusable';
 import styles from './styles/Text.module.css';
-import type { TooltipProps } from './Tooltip';
 import { Tooltip, TooltipTrigger } from './Tooltip';
 import { useLPContextProps } from './utils';
 

--- a/packages/components/stories/Text.stories.tsx
+++ b/packages/components/stories/Text.stories.tsx
@@ -200,9 +200,7 @@ export const CustomTooltip: Story = {
 			</div>
 
 			<div>
-				<p style={{ marginBottom: '0.5rem', fontSize: '14px', color: '#666' }}>
-					Bottom placement:
-				</p>
+				<p style={{ marginBottom: '0.5rem', fontSize: '14px', color: '#666' }}>Bottom placement:</p>
 				<Text maxLines={1} showTooltipOnOverflow tooltipPlacement="bottom">
 					Hover to see tooltip below this text. This text is long enough to be truncated.
 				</Text>

--- a/packages/components/stories/Text.stories.tsx
+++ b/packages/components/stories/Text.stories.tsx
@@ -37,6 +37,23 @@ For headings, use [Heading](/docs/components-content-heading--docs). For labels,
 		maxLines: {
 			control: { type: 'number' },
 		},
+		showTooltipOnOverflow: {
+			control: { type: 'boolean' },
+			description: 'Show tooltip when text overflows',
+		},
+		tooltipContent: {
+			control: { type: 'text' },
+			description: 'Custom tooltip content (defaults to text children)',
+		},
+		tooltipPlacement: {
+			control: { type: 'select' },
+			options: ['top', 'bottom', 'left', 'right', 'start', 'end'],
+			description: 'Tooltip placement',
+		},
+		tooltipClassName: {
+			control: { type: 'text' },
+			description: 'Additional CSS class for tooltip',
+		},
 		elementType: {
 			table: {
 				disable: true,
@@ -121,6 +138,92 @@ export const Truncation: Story = {
 				prop is set to 3. It continues for many more lines to demonstrate how the truncation works
 				with the ellipsis at the end.
 			</Text>
+		</div>
+	),
+};
+
+/**
+ * Show a tooltip when text overflows by enabling the `showTooltipOnOverflow` prop.
+ * The tooltip only appears when the text is actually truncated.
+ */
+export const OverflowTooltip: Story = {
+	render: () => (
+		<div style={{ display: 'flex', flexDirection: 'column', gap: '2rem', width: '250px' }}>
+			<div>
+				<p style={{ marginBottom: '0.5rem', fontSize: '14px', color: '#666' }}>
+					Single line with overflow tooltip:
+				</p>
+				<Text maxLines={1} showTooltipOnOverflow>
+					This is a very long text that will be truncated and show a tooltip on hover or focus
+				</Text>
+			</div>
+
+			<div>
+				<p style={{ marginBottom: '0.5rem', fontSize: '14px', color: '#666' }}>
+					Multi-line (2 lines) with overflow tooltip:
+				</p>
+				<Text maxLines={2} showTooltipOnOverflow>
+					This is a longer text that will be truncated after two lines and show a tooltip when you
+					hover over it. The tooltip contains the full text content.
+				</Text>
+			</div>
+
+			<div>
+				<p style={{ marginBottom: '0.5rem', fontSize: '14px', color: '#666' }}>
+					No overflow (tooltip won't show):
+				</p>
+				<Text maxLines={2} showTooltipOnOverflow>
+					Short text
+				</Text>
+			</div>
+		</div>
+	),
+};
+
+/**
+ * Customize the tooltip content and placement.
+ */
+export const CustomTooltip: Story = {
+	render: () => (
+		<div style={{ display: 'flex', flexDirection: 'column', gap: '2rem', width: '250px' }}>
+			<div>
+				<p style={{ marginBottom: '0.5rem', fontSize: '14px', color: '#666' }}>
+					Custom tooltip content:
+				</p>
+				<Text
+					maxLines={1}
+					showTooltipOnOverflow
+					tooltipContent="This is custom tooltip text that's different from the truncated content"
+				>
+					This is the truncated text that appears in the component
+				</Text>
+			</div>
+
+			<div>
+				<p style={{ marginBottom: '0.5rem', fontSize: '14px', color: '#666' }}>
+					Bottom placement:
+				</p>
+				<Text maxLines={1} showTooltipOnOverflow tooltipPlacement="bottom">
+					Hover to see tooltip below this text. This text is long enough to be truncated.
+				</Text>
+			</div>
+
+			<div>
+				<p style={{ marginBottom: '0.5rem', fontSize: '14px', color: '#666' }}>
+					Different sizes with tooltips:
+				</p>
+				<div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+					<Text size="small" maxLines={1} showTooltipOnOverflow>
+						Small text with overflow tooltip - this text will be truncated
+					</Text>
+					<Text size="medium" maxLines={1} showTooltipOnOverflow>
+						Medium text with overflow tooltip - this text will be truncated
+					</Text>
+					<Text size="large" maxLines={1} showTooltipOnOverflow>
+						Large text with overflow tooltip - this text will be truncated
+					</Text>
+				</div>
+			</div>
 		</div>
 	),
 };


### PR DESCRIPTION
## Summary

We were facing some overflow issues that were happening with the details section of the Metric Selection Menu tooltip by creating a new component in launchpad experimental - and while writing that PR I found some this new simpler approach.

Per feedback on this PR (https://github.com/launchdarkly/gonfalon/pull/55722) I've moved it to this launchpad component for simplicity and greater ease of use.

## Screenshots (if appropriate):


(more details and screenshots in the storybook)

## Testing approaches

New test file with relevant tests, added story files.