### PR TITLE
fix(components): menu descriptions should not wrap mid-word

### DIFF
--- a/.changeset/major-nights-run.md
+++ b/.changeset/major-nights-run.md
@@ -1,0 +1,5 @@
+---
+"@launchpad-ui/components": patch
+---
+
+menu descriptions should not wrap mid-word

--- a/packages/components/src/styles/Menu.module.css
+++ b/packages/components/src/styles/Menu.module.css
@@ -81,7 +81,7 @@
 
 	& [slot='description'] {
 		grid-area: desc;
-		word-break: break-all;
+		word-break: break-word;
 	}
 
 	& [slot='label']:has([data-icon]) ~ [slot='description'] {


### PR DESCRIPTION
It's currently set to `break-all` but that means it will aggressively wrap mid-word. `break-word` will still wrap long words if necessary, but will try to wrap at whitespace whenever possible