### PR TITLE
fix(components): remove font-styling from Link

### DIFF
--- a/.changeset/silent-views-agree.md
+++ b/.changeset/silent-views-agree.md
@@ -1,0 +1,5 @@
+---
+"@launchpad-ui/components": patch
+---
+
+remove font-styling from Link

--- a/packages/components/src/styles/Link.module.css
+++ b/packages/components/src/styles/Link.module.css
@@ -3,7 +3,6 @@
 
 .link {
 	composes: interactive from './base.module.css';
-	font: var(--lp-text-body-2-regular);
 	outline: none;
 	border-radius: var(--lp-border-radius-regular);
 	text-decoration: none;


### PR DESCRIPTION
To the best of my knowledge, there's no good reason to define font-size, font-family, font-weight, etc on the `Link` component. It should generally inherit values for those properties so that the link is consistent with its surroundings.