### PR TITLE
fix(components): addresses the modal closing when toasts appear bug

### DIFF
--- a/.changeset/fruity-points-agree.md
+++ b/.changeset/fruity-points-agree.md
@@ -1,0 +1,5 @@
+---
+"@launchpad-ui/components": patch
+---
+
+fix a bug around autoclose behavior in modals when a toast is present

--- a/packages/components/src/Modal.tsx
+++ b/packages/components/src/Modal.tsx
@@ -94,6 +94,19 @@ const ModalOverlay = ({ isDismissable = true, ref, ...props }: ModalOverlayProps
 	return (
 		<AriaModalOverlay
 			isDismissable={isDismissable}
+			shouldCloseOnInteractOutside={(element) => {
+				// Don't close when the element being checked is HTML or BODY.
+				// This indicates a portal interaction (e.g., spawning a toast from a button).
+				//
+				// Why this is safe:
+				// - When users click the modal backdrop, the element is the overlay <div>, NOT HTML/BODY
+				// - HTML/BODY only appear here during React portal rendering edge cases
+				// - This prevents the modal from incorrectly closing when triggering toasts from modal buttons
+				// - Legitimate outside clicks (backdrop, other UI) still close the modal as expected
+				const isRootElement = element.tagName === 'HTML' || element.tagName === 'BODY';
+
+				return !isRootElement;
+			}}
 			{...props}
 			ref={ref}
 			className={composeRenderProps(props.className, (className, renderProps) =>

--- a/packages/components/stories/Modal.stories.tsx
+++ b/packages/components/stories/Modal.stories.tsx
@@ -11,6 +11,7 @@ import { Heading } from '../src/Heading';
 import { IconButton } from '../src/IconButton';
 import { Modal, ModalOverlay } from '../src/Modal';
 import { Text } from '../src/Text';
+import { ToastRegion, toastQueue } from '../src/Toast';
 
 const meta: Meta<typeof Modal> = {
 	component: Modal,
@@ -108,5 +109,75 @@ export const Drawer: Story = {
 				mobile: allModes.mobile,
 			},
 		},
+	},
+};
+
+/**
+ * Bug reproduction: Dialog closes when clicking a button inside it while Toast is active.
+ *
+ * Steps to reproduce:
+ * 1. Click "Show Toast" to display a toast notification
+ * 2. Click "Open Dialog" to open the modal
+ * 3. Click "Click Me" button inside the dialog
+ *
+ * Expected: Button click should work normally, dialog stays open
+ * Actual: Dialog closes unexpectedly
+ */
+export const DialogWithActiveToast: Story = {
+	render: (args) => {
+		return (
+			<>
+				<ToastRegion />
+				<div style={{ display: 'flex', gap: '1rem', marginBottom: '1rem' }}>
+					<DialogTrigger>
+						<Button variant="primary">Open Dialog</Button>
+						<ModalOverlay>
+							<Modal {...args}>
+								<Dialog>
+									{({ close }) => (
+										<>
+											<div slot="header">
+												<Heading slot="title">Dialog with Toast Active</Heading>
+												<IconButton
+													aria-label="close"
+													icon="cancel"
+													size="small"
+													variant="minimal"
+													onPress={close}
+												/>
+												<Text slot="subtitle">Try clicking the button below with toast active</Text>
+											</div>
+											<div slot="body">
+												<p>
+													When a toast is visible, clicking the button below should NOT close the
+													dialog.
+												</p>
+												<div style={{ marginTop: '1rem' }}>
+													<Button
+														onPress={() => {
+															toastQueue.add({
+																title: 'Toast is active',
+																description: 'Now try clicking the button inside the dialog',
+																status: 'info',
+															});
+														}}
+													>
+														Show Toast
+													</Button>{' '}
+												</div>
+											</div>
+											<div slot="footer">
+												<Button slot="close">Cancel</Button>
+												<Button variant="primary">Confirm</Button>
+											</div>
+										</>
+									)}
+								</Dialog>
+							</Modal>
+						</ModalOverlay>
+					</DialogTrigger>
+				</div>
+			</>
+		);
 	},
 };


### PR DESCRIPTION
## Summary

- Adds a test case to validate against how dialogs behave with toasts. 
- Updates the Modal component to prevent spamming buttons that trigger a toast from closing the dialog. 

### Problem

The crux of the problem here is that react-aria uses a portal mechanism to set toasts onto when they are appended onto the DOM. When someone triggers a toast, a HTML tag is appended to the DOM via the portal, so spamming the same button results in the second click (after the toast is initialized) from being set onto the HTML tag, which is "outside" the dialog and causes it to collapse. This solution works by listening to the element that's being clicked on and preventing the collapse when that's a BODY or HTML tag.

## CURRENT BUG:

https://www.loom.com/share/98745d81ab324abeb91cdf522b5c47c5

## SOLUTION:

https://www.loom.com/share/6a0880c893184250a6a0b671eb4d5a66

## Screenshots (if appropriate):

<!-- Are there any visual changes that would be helpful to the reviewer to see? -->

## Testing approaches

<!-- How are these changes tested? -->
<!-- ld-jira-link -->
---
Related Jira issue: [REL-11286: BUG: Clicking a dialog when a toast is up closes the dialog](https://launchdarkly.atlassian.net/browse/REL-11286)
<!-- end-ld-jira-link -->