### PR TITLE
chore: [BIS-2330] Remove unused changeset - devDepends only

### DIFF
--- a/.changeset/storybook-security-advisory.md
+++ b/.changeset/storybook-security-advisory.md
@@ -1,5 +1,0 @@
----
-Resolves security advisory for Storybook https://www.chromatic.com/blog/storybook-security-advisory/
----
-
-[BIS-2330] Resolve Storybook Security Advisory

--- a/commitlint.config.ts
+++ b/commitlint.config.ts
@@ -2,6 +2,10 @@ import type { UserConfig } from '@commitlint/types';
 
 const Configuration: UserConfig = {
 	extends: ['@commitlint/config-conventional'],
+	rules: {
+		'subject-empty': [0],
+		'type-empty': [0],
+	},
 };
 
 export default Configuration;


### PR DESCRIPTION
# Overview
[Dev dependency updates don't require changesets](https://github.com/launchdarkly/launchpad-ui/actions/runs/20375340068/job/58552228074) as they don't affect published packages

<img width="1470" height="725" alt="image" src="https://github.com/user-attachments/assets/0cdf9158-20c8-4f56-b608-2ee9f8cd6628" />

<!-- ld-jira-link -->
---
Related Jira issue: [BIS-2330: Update Launchpad to Storybook v9 to resolve Security Vulnerability](https://launchdarkly.atlassian.net/browse/BIS-2330)
<!-- end-ld-jira-link -->