### PR TITLE
fix(storybook): disable focus trap to fix search box blur issue

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from 'react';
 import type { DecoratorFunction, GlobalTypes, Parameters } from 'storybook/internal/types';
 
 import { Box } from '@launchpad-ui/box';
+import { FocusTrapContext } from '@launchpad-ui/focus-trap';
 import sprite from '@launchpad-ui/icons/img/sprite.svg';
 import { withThemeByDataAttribute } from '@storybook/addon-themes';
 import { BrowserRouter, useNavigate } from 'react-router';
@@ -156,29 +157,31 @@ const decorators: DecoratorFunction<ReactRenderer>[] = [
 		return (
 			<BrowserRouter>
 				<RouterProvider>
-					{mirror ? (
-						<Box display="flex" flexDirection={sideBySide ? 'row' : 'column'} minHeight="100vh">
-							<Box
-								padding="$400"
-								width={sideBySide ? '50vw' : undefined}
-								height={stacked ? '50vh' : undefined}
-							>
+					<FocusTrapContext.Provider value={{ contain: false }}>
+						{mirror ? (
+							<Box display="flex" flexDirection={sideBySide ? 'row' : 'column'} minHeight="100vh">
+								<Box
+									padding="$400"
+									width={sideBySide ? '50vw' : undefined}
+									height={stacked ? '50vh' : undefined}
+								>
+									<StoryFn />
+								</Box>
+								<Box
+									data-theme="dark"
+									padding="$400"
+									width={sideBySide ? '50vw' : undefined}
+									height={stacked ? '50vh' : undefined}
+								>
+									<StoryFn />
+								</Box>
+							</Box>
+						) : (
+							<Box padding="$400">
 								<StoryFn />
 							</Box>
-							<Box
-								data-theme="dark"
-								padding="$400"
-								width={sideBySide ? '50vw' : undefined}
-								height={stacked ? '50vh' : undefined}
-							>
-								<StoryFn />
-							</Box>
-						</Box>
-					) : (
-						<Box padding="$400">
-							<StoryFn />
-						</Box>
-					)}
+						)}
+					</FocusTrapContext.Provider>
 				</RouterProvider>
 			</BrowserRouter>
 		);


### PR DESCRIPTION
## Summary

Fixes the Storybook search box immediately losing focus when clicking into it, particularly on stories that have modals/drawers open (like the Legacy Drawer story).

The root cause was that the `FocusTrap` component (used by Drawer, Modal, etc.) uses `FocusScope` from `@react-aria/focus` with `contain={true}`, which traps focus inside the component. When a story renders with a modal/drawer open, clicking the Storybook search box would cause focus to immediately return to the trapped element.

The fix wraps story content with `FocusTrapContext.Provider` with `contain: false`, which disables focus trapping in Storybook while preserving the behavior in production.

## Testing approaches

- Manually tested by navigating to the Legacy Drawer story (which has the drawer open by default)
- Clicked on the search box and typed "button" - search maintained focus and displayed results correctly
- Verified the drawer remained visible while using search

**Link to Devin run:** https://app.devin.ai/sessions/731006ba17a944138441298d219a7bcc
**Requested by:** Zach (@zmdavis)