### PR TITLE
chore(deps): fix broken sync icons gh action

### DIFF
--- a/.github/workflows/sync-icons.yml
+++ b/.github/workflows/sync-icons.yml
@@ -25,6 +25,7 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ env.CUSTOM_GITHUB_TOKEN }}
+          persist-credentials: false
 
       - name: Setup PNPM
         uses: pnpm/action-setup@v4

--- a/.github/workflows/sync-icons.yml
+++ b/.github/workflows/sync-icons.yml
@@ -24,6 +24,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          token: ${{ env.CUSTOM_GITHUB_TOKEN }}
 
       - name: Setup PNPM
         uses: pnpm/action-setup@v4


### PR DESCRIPTION
## Summary

Sync icons github action was broken
<img width="1011" height="598" alt="CleanShot 2026-02-03 at 18 31 31" src="https://github.com/user-attachments/assets/ccc684f9-92ca-47d4-a576-57717d6263da" />

 Added persist-credentials: false to the checkout step to prevent duplicate Authorization headers when the create-pull-request action configures its own git credentials.
## Screenshots (if appropriate):

<!-- Are there any visual changes that would be helpful to the reviewer to see? -->

## Testing approaches

<!-- How are these changes tested? -->
