### PR TITLE
chore(deps): update react-router to 7.13.0

### DIFF
--- a/.changeset/update-react-router.md
+++ b/.changeset/update-react-router.md
@@ -1,0 +1,6 @@
+---
+"@launchpad-ui/components": patch
+"@launchpad-ui/navigation": patch
+---
+
+Update react-router to 7.13.0

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
 		"nx": "21.2.1",
 		"react": "19.2.0",
 		"react-dom": "19.2.0",
-		"react-router": "7.9.6",
+		"react-router": "7.13.0",
 		"rollup-plugin-pure": "^0.4.0",
 		"storybook": "^9.1.17",
 		"storybook-addon-pseudo-states": "^9.1.17",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -47,7 +47,7 @@
 		"react-aria": "3.44.0",
 		"react-aria-components": "1.13.0",
 		"react-dom": "19.2.0",
-		"react-router": "7.9.6",
+		"react-router": "7.13.0",
 		"react-stately": "3.42.0"
 	},
 	"peerDependencies": {
@@ -61,7 +61,7 @@
 		"react-aria-components": "1.13.0",
 		"react-dom": "19.2.0",
 		"react-hook-form": "7.59.0",
-		"react-router": "7.9.6",
+		"react-router": "7.13.0",
 		"react-stately": "3.42.0"
 	},
 	"exports": {

--- a/packages/navigation/package.json
+++ b/packages/navigation/package.json
@@ -39,14 +39,14 @@
 		"@react-types/shared": "3.32.1",
 		"react": "19.2.0",
 		"react-dom": "19.2.0",
-		"react-router": "7.9.6"
+		"react-router": "7.13.0"
 	},
 	"peerDependencies": {
 		"@react-aria/utils": "3.31.0",
 		"@react-stately/list": "3.13.1",
 		"react": "19.2.0",
 		"react-dom": "19.2.0",
-		"react-router": "7.9.6"
+		"react-router": "7.13.0"
 	},
 	"exports": {
 		".": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -123,8 +123,8 @@ importers:
         specifier: 19.2.0
         version: 19.2.0(react@19.2.0)
       react-router:
-        specifier: 7.9.6
-        version: 7.9.6(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        specifier: 7.13.0
+        version: 7.13.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       rollup-plugin-pure:
         specifier: ^0.4.0
         version: 0.4.0(rollup@4.41.1)
@@ -289,8 +289,8 @@ importers:
         specifier: 19.2.0
         version: 19.2.0(react@19.2.0)
       react-router:
-        specifier: 7.9.6
-        version: 7.9.6(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        specifier: 7.13.0
+        version: 7.13.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react-stately:
         specifier: 3.42.0
         version: 3.42.0(react@19.2.0)
@@ -643,8 +643,8 @@ importers:
         specifier: 19.2.0
         version: 19.2.0(react@19.2.0)
       react-router:
-        specifier: 7.9.6
-        version: 7.9.6(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        specifier: 7.13.0
+        version: 7.13.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
 
   packages/overlay:
     dependencies:
@@ -4746,8 +4746,8 @@ packages:
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
 
-  react-router@7.9.6:
-    resolution: {integrity: sha512-Y1tUp8clYRXpfPITyuifmSoE2vncSME18uVLgaqyxh9H35JWpIfzHo+9y3Fzh5odk/jxPW29IgLgzcdwxGqyNA==}
+  react-router@7.13.0:
+    resolution: {integrity: sha512-PZgus8ETambRT17BUm/LL8lX3Of+oiLaPuVTRH3l1eLvSPpKO3AvhAEb5N7ihAFZQrYDqkvvWfFh9p0z9VsjLw==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: '>=18'
@@ -10412,7 +10412,7 @@ snapshots:
 
   react-is@18.3.1: {}
 
-  react-router@7.9.6(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
+  react-router@7.13.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
     dependencies:
       cookie: 1.0.2
       react: 19.2.0


### PR DESCRIPTION
## Summary

Updates `react-router` from 7.9.6 to 7.13.0 across the root workspace, `@launchpad-ui/components`, and `@launchpad-ui/navigation` packages (devDependencies and peerDependencies).

## Testing approaches

- Existing test suite covers react-router usage in components and navigation packages
- Reviewer should verify the [react-router changelog](https://github.com/remix-run/react-router/releases) between 7.9.6 and 7.13.0 for any notable changes

---

[Link to Devin run](https://app.devin.ai/sessions/40947d9f7f074ceeb06e2963e52a862d) | Requested by: @zmdavis