### PR TITLE
feat: add 'fit' width variant to Popover component

### DIFF
--- a/.changeset/popover-fit-width.md
+++ b/.changeset/popover-fit-width.md
@@ -1,0 +1,5 @@
+---
+'@launchpad-ui/components': minor
+---
+
+Add `fit` width variant to Popover component that sets `width: fit-content` with no min-width constraint

--- a/packages/components/src/Popover.tsx
+++ b/packages/components/src/Popover.tsx
@@ -30,6 +30,7 @@ const popoverStyles = cva(styles.popover, {
 	variants: {
 		width: {
 			default: styles.default,
+			fit: styles.fit,
 			trigger: styles.trigger,
 		},
 	},

--- a/packages/components/src/styles/Popover.module.css
+++ b/packages/components/src/styles/Popover.module.css
@@ -132,6 +132,10 @@
 	}
 }
 
+.fit {
+	width: fit-content;
+}
+
 .trigger {
 	&[data-trigger] {
 		width: var(--trigger-width);

--- a/packages/components/stories/Popover.stories.tsx
+++ b/packages/components/stories/Popover.stories.tsx
@@ -91,6 +91,20 @@ export const WithHeading: Story = {
 	play,
 };
 
+export const FitWidth: Story = {
+	render: (args) => {
+		return (
+			<DialogTrigger>
+				<Button>Trigger</Button>
+				<Popover width="fit" {...args}>
+					<Dialog>Message</Dialog>
+				</Popover>
+			</DialogTrigger>
+		);
+	},
+	play,
+};
+
 export const CustomTrigger: Story = {
 	render: (args) => {
 		return (


### PR DESCRIPTION
## Summary

Adds a new `width="fit"` variant to the `Popover` component. This allows consumers to opt into `width: fit-content` sizing — the popover will size to its content with no `min-width` constraint.

**Motivation:** The existing `default` variant enforces `min-width: 192px` on `DialogTrigger`/`MenuTrigger`/`SubmenuTrigger` popovers, which can cause excess whitespace when the popover content is narrow. The new `fit` variant provides an escape hatch without changing the default behavior for existing consumers.

Existing variants for reference:
- `default` (unchanged): applies `min-width: 192px` for menus/dialogs, `min-width: trigger-width` for selects/comboboxes
- `trigger` (unchanged): sets `width` to match the trigger element
- **`fit` (new)**: sets `width: fit-content`, no min/max constraints

## Human review checklist
- [ ] Confirm `fit` is the right name for this variant (alternatives: `content`, `auto`)
- [ ] The `.fit` CSS class applies unconditionally (not scoped by `data-trigger` like `.default`). Is this intentional/desired?
- [ ] No unit test was added for the new variant — the existing Popover render test passes and a Storybook story provides visual coverage

## Testing approaches

- Existing Popover unit test verified passing
- Added `FitWidth` Storybook story demonstrating the new variant
- Biome lint checks pass

Link to Devin session: https://app.devin.ai/sessions/3f677a53702048ab8528fa8051781a8b
Requested by: @cpurps22

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: additive styling change gated behind an explicit `width="fit"` prop, with no default behavior changes. Main risk is unintended layout/overflow behavior for consumers opting into the new variant.
> 
> **Overview**
> Adds a new `Popover` width variant, `fit`, which applies `width: fit-content` and avoids the default min-width constraints.
> 
> Includes a new Storybook example (`FitWidth`) to visually validate the new sizing behavior, and a changeset marking a minor release for `@launchpad-ui/components`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7c7f9d596719c4311fab26b7f28c866d40a1e3a6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/launchdarkly/launchpad-ui/pull/1864" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
