### PR TITLE
chore: [SEC-7924] pin third-party GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4
 
       - name: Setup Node
         uses: actions/setup-node@v6

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4
 
       - name: Setup Node
         uses: actions/setup-node@v6
@@ -37,7 +37,7 @@ jobs:
 
       - name: Publish to Chromatic
         id: chromatic
-        uses: chromaui/action@v13
+        uses: chromaui/action@30047ab459164cf99ae8f097f6aa5c7ef4fcc869 # v13
         with:
           projectToken: ${{ env.CHROMATIC_TOKEN }}
           buildScriptName: 'storybook:build'

--- a/.github/workflows/code-connect.yml
+++ b/.github/workflows/code-connect.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4
 
       - name: Setup Node
         uses: actions/setup-node@v6

--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -12,7 +12,7 @@ jobs:
     name: Validate PR title
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
+      - uses: amannn/action-semantic-pull-request@e32d7e603df1aa1ba07e981f2a23455dee596825 # v5
         with:
           validateSingleCommit: true
         env:

--- a/.github/workflows/package-size.yml
+++ b/.github/workflows/package-size.yml
@@ -11,7 +11,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4
 
       - name: Setup Node
         uses: actions/setup-node@v6
@@ -19,6 +19,6 @@ jobs:
           node-version: 22
           cache: pnpm
 
-      - uses: preactjs/compressed-size-action@v2
+      - uses: preactjs/compressed-size-action@8518045ed95e94e971b83333085e1cb99aa18aa8 # v2
         with:
           pattern: '**/dist/**/*.{css,js}'

--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4
 
       - name: Setup Node
         uses: actions/setup-node@v6

--- a/.github/workflows/release-vscode.yml
+++ b/.github/workflows/release-vscode.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4
 
       - name: Setup Node
         uses: actions/setup-node@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,10 +30,10 @@ jobs:
           fetch-depth: 0
           token: ${{ env.CUSTOM_GITHUB_TOKEN }}
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4
 
       - name: Derive appropriate SHAs for base and head for `nx affected` commands
-        uses: nrwl/nx-set-shas@v4
+        uses: nrwl/nx-set-shas@3e9ad7370203c1e93d109be57f3b72eb0eb511b1 # v4
 
       - name: Setup Node
         uses: actions/setup-node@v6
@@ -45,7 +45,7 @@ jobs:
         run: pnpm install
 
       - name: Create Release Pull Request or Publish to npm
-        uses: changesets/action@v1
+        uses: changesets/action@6a0a831ff30acef54f2c6aa1cbbc1096b066edaf # v1
         with:
           commit: 'chore: version packages'
           title: 'chore: version packages'

--- a/.github/workflows/sync-figma.yml
+++ b/.github/workflows/sync-figma.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4
 
       - name: Setup Node
         uses: actions/setup-node@v6

--- a/.github/workflows/sync-icons.yml
+++ b/.github/workflows/sync-icons.yml
@@ -33,7 +33,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup PNPM
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4
 
       - name: Setup Node
         uses: actions/setup-node@v6
@@ -74,7 +74,7 @@ jobs:
 
       - name: Create Pull Request
         if: steps.changes.outputs.changed == 'true'
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6
         with:
           branch: ci/feat/sync-icons
           delete-branch: true

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -32,10 +32,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4
 
       - name: Derive appropriate SHAs for base and head for `nx affected` commands
-        uses: nrwl/nx-set-shas@v4
+        uses: nrwl/nx-set-shas@3e9ad7370203c1e93d109be57f3b72eb0eb511b1 # v4
         with:
           main-branch-name: ${{needs.branch-info.outputs.base-branch}}
 
@@ -60,10 +60,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4
 
       - name: Derive appropriate SHAs for base and head for `nx affected` commands
-        uses: nrwl/nx-set-shas@v4
+        uses: nrwl/nx-set-shas@3e9ad7370203c1e93d109be57f3b72eb0eb511b1 # v4
         with:
           main-branch-name: ${{needs.branch-info.outputs.base-branch}}
 
@@ -88,7 +88,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Biome
-        uses: biomejs/setup-biome@v2
+        uses: biomejs/setup-biome@a05c02a1304287da45f13648675a70d5841acdbc # v2
 
       - name: Run Biome
         run: biome ci .


### PR DESCRIPTION
## Summary

Pin all third-party GitHub Actions to full-length commit SHAs to prevent supply chain attacks.

Addresses findings from the [`third-party-action-not-pinned-to-commit-sha`](https://github.com/launchdarkly/semgrep-rules/blob/main/github-actions/third-party-action-not-pinned-to-commit-sha.yml) Semgrep rule.

## Test plan

- [ ] Verify CI passes with pinned action SHAs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk security-hardening change that only updates workflow action references; main risk is CI failures if any pinned SHA is incorrect or deprecated.
> 
> **Overview**
> Pins multiple third-party GitHub Actions in CI workflows from version tags to full commit SHAs (e.g., `pnpm/action-setup`, `chromaui/action`, `nrwl/nx-set-shas`, `changesets/action`, `peter-evans/create-pull-request`, `biomejs/setup-biome`, `preactjs/compressed-size-action`, and `amannn/action-semantic-pull-request`) to reduce supply-chain risk without changing workflow logic.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6d4343d2673adb3a875b52f0b78fdaf0c97e7ed2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
<!-- ld-jira-link -->
---
Related Jira issue: [SEC-7924: Unpinned GitHub Actions remediation](https://launchdarkly.atlassian.net/browse/SEC-7924)
<!-- end-ld-jira-link -->