### PR TITLE
feat: forward width prop from Tooltip to Popover when variant="popover"

### DIFF
--- a/.changeset/popover-fit-width.md
+++ b/.changeset/popover-fit-width.md
@@ -1,0 +1,5 @@
+---
+'@launchpad-ui/components': minor
+---
+
+Add `fit` width variant to Popover component that sets `width: fit-content` with no min-width constraint

--- a/.changeset/tooltip-forward-width.md
+++ b/.changeset/tooltip-forward-width.md
@@ -1,0 +1,5 @@
+---
+'@launchpad-ui/components': minor
+---
+
+Forward `width` prop from Tooltip to Popover styles when `variant="popover"`

--- a/packages/components/src/Popover.tsx
+++ b/packages/components/src/Popover.tsx
@@ -30,6 +30,7 @@ const popoverStyles = cva(styles.popover, {
 	variants: {
 		width: {
 			default: styles.default,
+			fit: styles.fit,
 			trigger: styles.trigger,
 		},
 	},

--- a/packages/components/src/Tooltip.tsx
+++ b/packages/components/src/Tooltip.tsx
@@ -5,6 +5,7 @@ import type {
 	ContextValue,
 	TooltipTriggerComponentProps,
 } from 'react-aria-components';
+import type { PopoverProps } from './Popover';
 
 import { cva } from 'class-variance-authority';
 import { createContext } from 'react';
@@ -20,6 +21,7 @@ import { useLPContextProps } from './utils';
 
 interface TooltipProps extends AriaTooltipProps, VariantProps<typeof tooltipStyles> {
 	ref?: Ref<HTMLDivElement>;
+	width?: PopoverProps['width'];
 }
 interface TooltipTriggerProps extends TooltipTriggerComponentProps {}
 
@@ -44,7 +46,7 @@ const tooltipStyles = cva(styles.base, {
  */
 const Tooltip = ({ ref, ...props }: TooltipProps) => {
 	[props, ref] = useLPContextProps(props, ref, TooltipContext);
-	const { variant = 'default' } = props;
+	const { variant = 'default', width = 'default' } = props;
 
 	return (
 		<AriaTooltip
@@ -54,7 +56,13 @@ const Tooltip = ({ ref, ...props }: TooltipProps) => {
 			{...props}
 			ref={ref}
 			className={composeRenderProps(props.className, (className, renderProps) =>
-				tooltipStyles({ ...renderProps, variant, className }),
+				variant === 'popover'
+					? tooltipStyles({
+							...renderProps,
+							variant: null,
+							className: popoverStyles({ width, className }),
+						})
+					: tooltipStyles({ ...renderProps, variant, className }),
 			)}
 			data-trigger={variant === 'popover' ? 'DialogTrigger' : undefined}
 		/>

--- a/packages/components/src/styles/Popover.module.css
+++ b/packages/components/src/styles/Popover.module.css
@@ -132,6 +132,10 @@
 	}
 }
 
+.fit {
+	width: fit-content;
+}
+
 .trigger {
 	&[data-trigger] {
 		width: var(--trigger-width);

--- a/packages/components/stories/Popover.stories.tsx
+++ b/packages/components/stories/Popover.stories.tsx
@@ -91,6 +91,20 @@ export const WithHeading: Story = {
 	play,
 };
 
+export const FitWidth: Story = {
+	render: (args) => {
+		return (
+			<DialogTrigger>
+				<Button>Trigger</Button>
+				<Popover width="fit" {...args}>
+					<Dialog>Message</Dialog>
+				</Popover>
+			</DialogTrigger>
+		);
+	},
+	play,
+};
+
 export const CustomTrigger: Story = {
 	render: (args) => {
 		return (

--- a/packages/components/stories/Tooltip.stories.tsx
+++ b/packages/components/stories/Tooltip.stories.tsx
@@ -84,3 +84,17 @@ export const Popover: Story = {
 	},
 	play,
 };
+
+export const PopoverFitWidth: Story = {
+	render: (args) => {
+		return (
+			<TooltipTrigger>
+				<Button>Trigger</Button>
+				<Tooltip variant="popover" width="fit" {...args}>
+					Message
+				</Tooltip>
+			</TooltipTrigger>
+		);
+	},
+	play,
+};


### PR DESCRIPTION
## Summary

Adds a new `width="fit"` variant to the Popover component and updates the Tooltip component to accept and forward the `width` prop when `variant="popover"`.

**Motivation:** Popovers currently enforce a `min-width: 192px` via the `default` width variant, which causes excess whitespace for popovers with short content. The new `fit` variant applies `width: fit-content` with no min-width constraint, allowing the popover to size to its content.

**Changes:**
- **Popover CSS**: New `.fit` class with `width: fit-content`
- **Popover TSX**: Register `fit` in the CVA width variants
- **Tooltip TSX**: Accept a `width` prop (typed from `PopoverProps['width']`) and dynamically pass it to `popoverStyles()` when `variant="popover"` instead of using the hardcoded `popoverStyles({ width: 'default' })`
- **Stories**: Added `FitWidth` story for Popover and `PopoverFitWidth` story for Tooltip

## Human review checklist

- [ ] **Tooltip className logic change** — when `variant="popover"`, the code now passes `variant: null` to `tooltipStyles` and composes popover classes via `popoverStyles({ width, className })`. Verify that `styles.base` from `tooltipStyles` is still applied and no styling is lost vs. the previous behavior.
- [ ] **`width` prop is ignored when `variant !== "popover"`** — is this acceptable or should it warn / be typed more narrowly?
- [ ] **`.fit` CSS class** intentionally has no `min-width` — confirm this is the desired behavior for the use case.

## Testing approaches

- Existing unit tests (44 files, 74 tests) all pass
- TypeScript type check passes
- Biome lint passes
- Storybook stories added for both Popover `FitWidth` and Tooltip `PopoverFitWidth` variants
- Chromatic visual tests will capture baseline snapshots for the new stories

Link to Devin session: https://app.devin.ai/sessions/3f677a53702048ab8528fa8051781a8b
Requested by: @cpurps22
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/launchdarkly/launchpad-ui/pull/1868" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly styling/API-surface changes, but it alters `Tooltip` className composition for `variant="popover"`, which could subtly change applied classes and layout in existing usages.
> 
> **Overview**
> Adds a new `Popover` `width="fit"` variant that applies `width: fit-content` (removing the default min-width behavior).
> 
> Updates `Tooltip` to accept a `width` prop and, when `variant="popover"`, compute styles via `popoverStyles({ width })` instead of hardcoding the default width; Storybook stories and changesets are added to document and release the new behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0754bd490e210f16314bb26542edb565f714cc7a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->