### PR TITLE
chore: pin third-party GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -88,7 +88,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Biome
-        uses: biomejs/setup-biome@4c91541eaada48f67d7dbd7833600ce162b68f51 # v2 
+        uses: biomejs/setup-biome@4c91541eaada48f67d7dbd7833600ce162b68f51 # v2
 
       - name: Run Biome
         run: biome ci .

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -88,7 +88,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Biome
-        uses: biomejs/setup-biome@a05c02a1304287da45f13648675a70d5841acdbc # v2
+        uses: biomejs/setup-biome@4c91541eaada48f67d7dbd7833600ce162b68f51 # v2
 
       - name: Run Biome
         run: biome ci .

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -88,7 +88,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Biome
-        uses: biomejs/setup-biome@4c91541eaada48f67d7dbd7833600ce162b68f51 # v2
+        uses: biomejs/setup-biome@4c91541eaada48f67d7dbd7833600ce162b68f51 # v2 
 
       - name: Run Biome
         run: biome ci .


### PR DESCRIPTION
## Summary

Pin all third-party GitHub Actions to full-length commit SHAs to prevent supply chain attacks.

Addresses findings from the [`third-party-action-not-pinned-to-commit-sha`](https://github.com/launchdarkly/semgrep-rules/blob/main/github-actions/third-party-action-not-pinned-to-commit-sha.yml) Semgrep rule.

## Test plan

- [ ] Verify CI passes with pinned action SHAs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk change limited to CI configuration; main impact is if the new `biomejs/setup-biome` commit introduces behavior changes that affect formatting/lint checks.
> 
> **Overview**
> Updates the Verify workflow to use a different pinned commit SHA for `biomejs/setup-biome` in the `quality` job, keeping the Biome CI step on v2 while adjusting the exact pinned revision.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 827f4b1af2afa8f907611728c5c68e7215bfa2df. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
<!-- ld-jira-link -->
---
Related Jira issue: [SEC-7924: Unpinned GitHub Actions remediation](https://launchdarkly.atlassian.net/browse/SEC-7924)
<!-- end-ld-jira-link -->