### PR TITLE
chore: Update icon changeset note to be human readable

### DIFF
--- a/.changeset/icon-updates.md
+++ b/.changeset/icon-updates.md
@@ -4,6 +4,12 @@
 
 feat(icons): sync and connect icons with figma library
 
+Updated icons
+ - sidebar-left-collapse
+ - sidebar-left-expand
+ - sidebar-right-collapse
+ - sidebar-right-expand
+
 Removed icons:
   - size-large-40x40
   - size-medium-20x20


### PR DESCRIPTION
## Summary

<!-- What is changing and why? -->

## Screenshots (if appropriate):

<!-- Are there any visual changes that would be helpful to the reviewer to see? -->

## Testing approaches

<!-- How are these changes tested? -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Edits only a changeset markdown entry; no runtime code or icon assets are modified, so impact is limited to release notes.
> 
> **Overview**
> Makes the `@launchpad-ui/icons` changeset note more human-readable by explicitly listing the **updated** sidebar collapse/expand icons and keeping the list of **removed** size icons.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 77dc52ab186e6d23c1a9f8e438da5ebd44e3ef7a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->