### PR TITLE
ci: migrate from using npm tokens to oicd

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,8 +39,11 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 22.14.0
           cache: pnpm
+
+      - name: Upgrade npm
+        run: npm install -g npm@11.5.1
 
       - name: Install Dependencies
         run: pnpm install

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,15 +14,16 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
-      contents: read
+      contents: write
+      pull-requests: write
+      issues: write
     steps:
       - name: Get Tokens
         uses: launchdarkly/gh-actions/actions/release-secrets@release-secrets-v1.2.0
         with:
           aws_assume_role: ${{ vars.AWS_ROLE_ARN }}
           ssm_parameter_pairs: |
-            /production/common/launchpad-ui/gh-pat-token = CUSTOM_GITHUB_TOKEN,
-            /production/common/releasing/npm/token = NODE_AUTH_TOKEN
+            /production/common/launchpad-ui/gh-pat-token = CUSTOM_GITHUB_TOKEN
 
       - uses: actions/checkout@v6
         with:
@@ -53,5 +54,4 @@ jobs:
           cwd: ${{ github.workspace }}
         env:
           GITHUB_TOKEN: ${{ env.CUSTOM_GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ env.NODE_AUTH_TOKEN }}
           NPM_CONFIG_PROVENANCE: true

--- a/package.json
+++ b/package.json
@@ -82,6 +82,10 @@
 		"not dead",
 		"not IE 11"
 	],
+	"engines": {
+		"node": ">=22.14.0",
+		"npm": ">=11.5.1"
+	},
 	"packageManager": "pnpm@10.12.4",
 	"pnpm": {
 		"onlyBuiltDependencies": [


### PR DESCRIPTION
## Summary

releases are failing because the npm tokens expired, but the recommended way is to use trusted publishers anyways

## Screenshots (if appropriate):

<!-- Are there any visual changes that would be helpful to the reviewer to see? -->

## Testing approaches

<!-- How are these changes tested? -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/launchdarkly/launchpad-ui/pull/1874" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the release workflow’s permissions and npm publish auth mechanism; failures would block publishing but won’t affect runtime behavior of the library itself.
> 
> **Overview**
> Updates the GitHub Actions release workflow to stop using an `NPM_TOKEN` secret and instead rely on npm trusted publishing via OIDC (`id-token` + `NPM_CONFIG_PROVENANCE`).
> 
> Pins the CI runtime to `node` `22.14.0`, upgrades npm to `11.5.1` during the job, and expands workflow permissions (`contents`/`pull-requests`/`issues`) to support Changesets release PR creation/publishing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f263dde607c2662bb6abcda2e56d3118c41185bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->