### PR TITLE
fix: fix release script

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 		"graph": "nx graph --affected",
 		"postinstall": "syncpack lint",
 		"prepare": "husky",
-		"release": "nx affected --target=build --base=HEAD~1 --head=HEAD --exclude=launchpad-design-system && changeset publish",
+		"release": "nx run-many --target=build --all --exclude=launchpad-design-system && changeset publish",
 		"storybook": "pnpm build:transform && storybook dev -p 3000",
 		"storybook:build": "pnpm build:transform && storybook build --quiet",
 		"test": "pnpm build:transform && vitest run --coverage",


### PR DESCRIPTION
## Summary

<!-- What is changing and why? -->

## Screenshots (if appropriate):

<!-- Are there any visual changes that would be helpful to the reviewer to see? -->

## Testing approaches

<!-- How are these changes tested? -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/launchdarkly/launchpad-ui/pull/1878" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the build scope used during publishing, which can affect what artifacts get built and released (and may increase CI time), but it’s confined to a `package.json` script change.
> 
> **Overview**
> **Release pipeline change:** updates the `release` script in `package.json` to run `nx run-many --target=build --all` (excluding `launchpad-design-system`) instead of using `nx affected` with `--base/--head`, then publishes via `changeset publish`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3493d304e8e8ca6d9ff59e4997cfc70ed4ee38e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->