### PR TITLE
fix(components): remove extra popover padding for DialogTrigger with menu/listbox

### DIFF
--- a/.changeset/fix-menu-popover-padding.md
+++ b/.changeset/fix-menu-popover-padding.md
@@ -1,0 +1,5 @@
+---
+'@launchpad-ui/components': patch
+---
+
+Remove extra popover padding when a DialogTrigger popover contains a Menu or ListBox

--- a/packages/components/src/styles/Popover.module.css
+++ b/packages/components/src/styles/Popover.module.css
@@ -37,6 +37,7 @@
 	}
 
 	&[data-trigger='DialogTrigger']:not(:has([role='menu'], [role='listbox'])),
+	&[data-trigger='DialogTrigger']:has(input[type='search']),
 	&[data-trigger='ComboBoxDialog'],
 	&[data-trigger='DatePicker'],
 	&[data-trigger='DateRangePicker'] {

--- a/packages/components/src/styles/Popover.module.css
+++ b/packages/components/src/styles/Popover.module.css
@@ -36,7 +36,7 @@
 		stroke-width: 1px;
 	}
 
-	&[data-trigger='DialogTrigger'],
+	&[data-trigger='DialogTrigger']:not(:has([role='menu'], [role='listbox'])),
 	&[data-trigger='ComboBoxDialog'],
 	&[data-trigger='DatePicker'],
 	&[data-trigger='DateRangePicker'] {


### PR DESCRIPTION
## Summary

When a `Menu` or `ListBox` is rendered inside a `DialogTrigger` popover, the popover's 8px padding (`--lp-spacing-300`) stacks on top of the menu's own 4px container padding (`--lp-spacing-200`), resulting in 12px of container padding instead of the expected 4px. This creates visually inconsistent menus compared to those rendered via `MenuTrigger` (which has no popover padding).

This change splits the `DialogTrigger` padding rule into two selectors:
1. `&[data-trigger='DialogTrigger']:not(:has([role='menu'], [role='listbox']))` — preserves padding for non-menu dialog content
2. `&[data-trigger='DialogTrigger']:has(input[type='search'])` — re-adds padding when a search input is present (e.g. autocomplete/combobox patterns inside a DialogTrigger)

Plain menus/listboxes inside a `DialogTrigger` popover no longer receive the extra popover padding, while search-containing popovers retain it.

### Human review checklist
- [ ] Verify selector precedence: when both selectors could apply (a DialogTrigger popover with a listbox AND a search input), confirm the search selector wins and padding is applied. Since both are comma-separated in the same rule, either matching should apply the padding — but worth verifying in a real component.
- [ ] Confirm no existing `DialogTrigger` popovers with mixed content (dialog elements alongside a menu, no search) are negatively impacted
- [ ] Review Chromatic visual diffs to validate the padding change looks correct across all affected stories
- [ ] A follow-up change in consumer repos (e.g. gonfalon) to use `MenuTrigger` instead of `DialogTrigger` for pure menu popovers would be the more architecturally correct long-term fix

## Testing approaches

- Visual regression via Chromatic CI
- Manual verification: open any `DialogTrigger` popover containing a `Menu` and confirm padding matches a standard `MenuTrigger` menu (4px container padding, no extra outer padding from the popover)
- Manual verification: open a `DialogTrigger` popover containing a search input + listbox and confirm padding is still present around the search field

Link to Devin session: https://app.devin.ai/sessions/e83a67884e96414b8f6b288b8c045e6d
Requested by: @cpurps22