### PR TITLE
chore(Alert): restore new alert styles

### DIFF
--- a/.changeset/alert-layout-and-styles.md
+++ b/.changeset/alert-layout-and-styles.md
@@ -1,0 +1,5 @@
+---
+"@launchpad-ui/components": minor
+---
+
+Update **Alert** visuals (block backgrounds, borders, spacing, and icon sizing) and add **`AlertText`** for grouping heading and body when using **`actionsLayout="inline"`**. New optional props: **`actionsLayout`** (`stacked` | `inline`, block variant only) and **`hideIcon`**. Dismiss control uses a medium icon button for alignment with the refreshed layout.

--- a/.changeset/alert-layout-and-styles.md
+++ b/.changeset/alert-layout-and-styles.md
@@ -2,4 +2,6 @@
 "@launchpad-ui/components": minor
 ---
 
-Update **Alert** visuals (block backgrounds, borders, spacing, and icon sizing) and add **`AlertText`** for grouping heading and body when using **`actionsLayout="inline"`**. New optional props: **`actionsLayout`** (`stacked` | `inline`, block variant only) and **`hideIcon`**. Dismiss control uses a medium icon button for alignment with the refreshed layout.
+- Update **Alert** visuals (block backgrounds, borders, spacing, and icon sizing) and add **`AlertText`** for grouping heading and body when using **`actionsLayout="inline"`**. 
+- New optional props: **`actionsLayout`** (`stacked` | `inline`, block variant only) and **`hideIcon`**. 
+- Dismiss control uses a medium icon button for alignment with the refreshed layout.

--- a/packages/components/src/Alert.tsx
+++ b/packages/components/src/Alert.tsx
@@ -1,5 +1,5 @@
 import type { VariantProps } from 'class-variance-authority';
-import type { HTMLAttributes, Ref } from 'react';
+import type { ComponentProps, HTMLAttributes, Ref } from 'react';
 
 import { StatusIcon } from '@launchpad-ui/icons';
 import { useControlledState } from '@react-stately/utils';
@@ -9,6 +9,18 @@ import { HeadingContext, Provider } from 'react-aria-components';
 import { ButtonGroupContext } from './ButtonGroup';
 import { IconButton } from './IconButton';
 import styles from './styles/Alert.module.css';
+
+interface AlertTextProps extends ComponentProps<'div'> {
+	ref?: Ref<HTMLDivElement>;
+}
+
+/**
+ * AlertText wraps the title and description content within an Alert.
+ * Use this to group Heading and Text elements when using actionsLayout="inline".
+ */
+const AlertText = ({ className, ref, ...props }: AlertTextProps) => {
+	return <div ref={ref} className={`${styles.text} ${className ?? ''}`.trim()} {...props} />;
+};
 
 const alertStyles = cva(styles.base, {
 	variants: {
@@ -23,6 +35,10 @@ const alertStyles = cva(styles.base, {
 			default: styles.default,
 			inline: styles.inline,
 		},
+		actionsLayout: {
+			stacked: null,
+			inline: styles.actionsInline,
+		},
 	},
 	defaultVariants: {
 		status: 'neutral',
@@ -33,8 +49,15 @@ const alertStyles = cva(styles.base, {
 interface AlertVariants extends VariantProps<typeof alertStyles> {}
 
 interface AlertProps extends HTMLAttributes<HTMLDivElement>, AlertVariants {
+	/** Controls the layout of actions within the alert (block variant only). */
+	actionsLayout?: 'stacked' | 'inline';
+	/** Hides the status icon. */
+	hideIcon?: boolean;
+	/** Whether the alert can be dismissed. */
 	isDismissable?: boolean;
+	/** Whether the alert is open (controlled). */
 	isOpen?: boolean;
+	/** Handler called when the alert is dismissed. */
 	onDismiss?: () => void;
 	ref?: Ref<HTMLDivElement>;
 }
@@ -44,28 +67,37 @@ const Alert = ({
 	children,
 	status = 'neutral',
 	variant = 'default',
+	actionsLayout = 'stacked',
 	isDismissable,
 	isOpen,
 	onDismiss,
+	hideIcon,
 	ref,
 	...props
 }: AlertProps) => {
 	const [open, setOpen] = useControlledState(isOpen, true, (val) => !val && onDismiss?.());
 
+	const showIcon = !hideIcon && status !== 'neutral';
+	const resolvedActionsLayout = variant === 'default' ? actionsLayout : undefined;
+
 	return open ? (
-		<div ref={ref} {...props} role="alert" className={alertStyles({ status, variant, className })}>
-			{variant === 'default' && <div role="presentation" className={styles.bar} />}
-			{status !== 'neutral' && <StatusIcon kind={status || 'info'} className={styles.icon} />}
+		<div
+			ref={ref}
+			{...props}
+			role="alert"
+			className={alertStyles({
+				status,
+				variant,
+				actionsLayout: resolvedActionsLayout,
+				className,
+			})}
+		>
+			{showIcon && <StatusIcon size="small" kind={status || 'info'} className={styles.icon} />}
 			<div className={styles.content}>
 				<Provider
 					values={[
 						[HeadingContext, { className: styles.heading }],
-						[
-							ButtonGroupContext,
-							{
-								className: styles.buttonGroup,
-							},
-						],
+						[ButtonGroupContext, { className: styles.buttonGroup }],
 					]}
 				>
 					{children}
@@ -76,7 +108,7 @@ const Alert = ({
 					aria-label="Close"
 					icon="cancel"
 					variant="minimal"
-					size="small"
+					size="medium"
 					className={styles.close}
 					onPress={() => setOpen(false)}
 				/>
@@ -85,5 +117,5 @@ const Alert = ({
 	) : null;
 };
 
-export { Alert, alertStyles };
-export type { AlertProps };
+export { Alert, AlertText, alertStyles };
+export type { AlertProps, AlertTextProps };

--- a/packages/components/src/Alert.tsx
+++ b/packages/components/src/Alert.tsx
@@ -25,7 +25,7 @@ const AlertText = ({ className, ref, ...props }: AlertTextProps) => {
 const alertStyles = cva(styles.base, {
 	variants: {
 		status: {
-			neutral: styles.neutral,
+			neutral: null,
 			error: styles.error,
 			info: styles.info,
 			success: styles.success,

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -1,7 +1,7 @@
 import './styles/base.css';
 import './styles/themes.css';
 
-export type { AlertProps } from './Alert';
+export type { AlertProps, AlertTextProps } from './Alert';
 export type { AutocompleteProps } from './Autocomplete';
 export type { AvatarProps, InitialsAvatarProps } from './Avatar';
 export type { BreadcrumbProps, BreadcrumbsProps } from './Breadcrumbs';
@@ -94,7 +94,7 @@ export type {
 	TreeProps,
 } from './Tree';
 
-export { Alert, alertStyles } from './Alert';
+export { Alert, AlertText, alertStyles } from './Alert';
 export { Autocomplete } from './Autocomplete';
 export { Avatar, avatarStyles, InitialsAvatar } from './Avatar';
 export {

--- a/packages/components/src/styles/Alert.module.css
+++ b/packages/components/src/styles/Alert.module.css
@@ -1,9 +1,38 @@
+/* Temporary color aliases for Alerts. This block should be removed when the new color system is implemented. */
+:root,
+[data-theme='default'] {
+	--alert-color-border-neutral: var(--lp-color-gray-200);
+	--alert-color-bg-neutral: var(--lp-color-gray-0);
+	--alert-color-border-error: var(--lp-color-red-200);
+	--alert-color-bg-error: var(--lp-color-red-0);
+	--alert-color-border-info: var(--lp-color-blue-200);
+	--alert-color-bg-info: var(--lp-color-blue-0);
+	--alert-color-border-success: var(--lp-color-green-200);
+	--alert-color-bg-success: var(--lp-color-green-0);
+	--alert-color-border-warning: #fad88f;
+	--alert-color-bg-warning: #fdfae4;
+}
+[data-theme='dark'] {
+	--alert-color-border-neutral: var(--lp-color-gray-800);
+	--alert-color-bg-neutral: var(--lp-color-gray-900);
+	--alert-color-border-error: var(--lp-color-red-700);
+	--alert-color-bg-error: #391620;
+	--alert-color-border-info: var(--lp-color-blue-700);
+	--alert-color-bg-info: #192142;
+	--alert-color-border-success: var(--lp-color-green-700);
+	--alert-color-bg-success: #14260d;
+	--alert-color-border-warning: #932c00;
+	--alert-color-bg-warning: #3c170c;
+}
+
+/* Shared styles for both the block and inline variants */
 .base {
 	display: flex;
 	border-radius: var(--lp-border-radius-medium);
-	gap: var(--lp-spacing-500);
+	gap: var(--lp-spacing-300);
 	align-items: flex-start;
 
+	/* Status icon styles */
 	&.error .icon {
 		fill: var(--lp-color-fill-feedback-error);
 	}
@@ -17,75 +46,110 @@
 	}
 
 	&.warning .icon {
-		fill: var(--lp-color-brand-orange-base);
+		fill: #e65d00;
 	}
 }
 
+/* Base styles for the block variant */
 .default {
-	padding: var(--lp-spacing-700);
-	background-color: var(--lp-color-bg-ui-primary);
-	border: 1px solid var(--lp-color-border-ui-primary);
+	/* Add a base layer of padding on the Alert itself. This is just enough to create some breathing room in case any buttons are present. */
+	padding: var(--lp-spacing-300) var(--lp-spacing-300) var(--lp-spacing-300) var(--lp-spacing-500);
+	background-color: var(--alert-color-bg-neutral);
+	border: 1px solid var(--alert-color-border-neutral);
 	position: relative;
+	min-height: var(--lp-size-48);
 
-	&.neutral {
-		--color-1: var(--lp-color-gray-500);
-		--color-2: var(--lp-color-gray-400);
-	}
-
+	/* Status borders and background colors */
 	&.error {
-		--color-1: var(--lp-color-red-500);
-		--color-2: var(--lp-color-red-400);
+		border-color: var(--alert-color-border-error);
+		background-color: var(--alert-color-bg-error);
 	}
 
 	&.info {
-		--color-1: var(--lp-color-blue-500);
-		--color-2: var(--lp-color-blue-400);
+		border-color: var(--alert-color-border-info);
+		background-color: var(--alert-color-bg-info);
 	}
 
 	&.success {
-		--color-1: var(--lp-color-green-500);
-		--color-2: var(--lp-color-green-400);
+		border-color: var(--alert-color-border-success);
+		background-color: var(--alert-color-bg-success);
 	}
 
 	&.warning {
-		--color-1: var(--lp-color-brand-orange-base);
-		--color-2: #ffb052;
+		border-color: var(--alert-color-border-warning);
+		background-color: var(--alert-color-bg-warning);
 	}
 
-	&:has(.heading) {
-		/* biome-ignore lint/style/noDescendingSpecificity: ignore */
-		& .icon {
-			transform: translateY(2px);
-		}
+	& .icon {
+		transform: translateY(var(--lp-size-10));
 	}
 
-	& .close {
+	/* Add another layer of vertical padding to the Alert content (text and actions). This will align the basline of the text with the baseline of the dismiss button. */
+	.content {
+		padding: var(--lp-spacing-300) var(--lp-spacing-300) var(--lp-spacing-300) 0;
+	}
+
+	/* Add a little space at the top of the button group to separate it from the text */
+	.buttonGroup {
+		margin-top: var(--lp-spacing-400);
+	}
+
+	/* We need to position the close button absolutely so we can adjust its position without affecting the layout of the Alert content. */
+	.close {
 		position: absolute;
+		top: var(--lp-spacing-300);
 		right: var(--lp-spacing-300);
-		top: var(--lp-spacing-500);
+	}
+
+	/* Add extra right padding when there's a close button to prevent text from overlapping the button */
+	&:has(.close) .content {
+		padding-right: var(--lp-size-48);
 	}
 }
 
-.inline {
-	align-items: center;
-	gap: var(--lp-spacing-300);
+/* Inline actions variant */
+.actionsInline {
+	/* Switch the direction of the content to row and make sure it fills its container. */
+	& .content {
+		flex-direction: row;
+		align-items: flex-start;
+		flex: 1;
+		gap: var(--lp-spacing-500);
 
+		/* Unset padding on content to prevent it looking too big if there are actions present. */
+		padding: unset;
+	}
+
+	/* Move vertical padding from the content container to the text container. This ensures the text baseline is aligned with the trailing actions and dismiss buttons. We need to do some fancy calc stuff to make it look right. */
+	& .text {
+		padding: calc(var(--lp-spacing-300) - var(--lp-size-2)) 0;
+	}
+
+	/* Need a specific selector to override the padding on the content container when there is a close button. */
+	&:has(.close) .content {
+		padding-right: unset;
+	}
+
+	/* Adjust icon position to compensate for the different padding */
+	& .icon {
+		transform: translateY(var(--lp-spacing-300));
+	}
+
+	/* Move the button group into position. We don't need a top margin here, and we want to flush it to the right */
+	& .buttonGroup {
+		margin-top: unset;
+		margin-left: auto;
+	}
+
+	/* Remove the absolute positioning from the close button so that it can participate in the flex layout. */
 	& .close {
-		margin-left: var(--lp-spacing-300);
+		position: unset;
+		top: unset;
+		right: unset;
 	}
 }
 
-.bar {
-	position: absolute;
-	background: linear-gradient(91deg, var(--color-1) 0%, var(--color-2) 100%);
-	border-radius: calc(var(--lp-border-radius-medium) - 1px)
-		calc(var(--lp-border-radius-medium) - 1px) 0 0;
-	width: 100%;
-	height: var(--lp-size-8);
-	top: 0;
-	left: 0;
-}
-
+/* Base styles for the content container */
 .content {
 	min-width: 0;
 	flex: 1;
@@ -93,13 +157,37 @@
 	flex-direction: column;
 	font: var(--lp-text-body-2-regular);
 	align-items: flex-start;
+
+	/* Ensure all direct children stack vertically by default (handles inline elements like <span>) */
+	& > * {
+		display: block;
+	}
 }
 
+/* Base styles for the text container */
+.text {
+	display: flex;
+	flex-direction: column;
+	flex: 1;
+	min-width: 0;
+}
+
+/* Make sure the heading is the right size and weight regardless of which element is used */
 .heading {
-	font: var(--lp-text-heading-2-semibold);
-	margin-bottom: var(--lp-spacing-200);
+	font: var(--lp-text-body-2-semibold) !important;
 }
 
-.buttonGroup {
-	margin-top: var(--lp-spacing-700);
+/* Sometimes we want to make text bold, but we need to make sure this maps to semibold, not bold. */
+.content strong,
+.content b {
+	font-weight: var(--lp-font-weight-semibold);
+}
+
+/* Inline variant styles */
+.inline {
+	align-items: center;
+
+	& .close {
+		margin-left: var(--lp-spacing-300);
+	}
 }

--- a/packages/components/src/styles/Alert.module.css
+++ b/packages/components/src/styles/Alert.module.css
@@ -157,11 +157,6 @@
 	flex-direction: column;
 	font: var(--lp-text-body-2-regular);
 	align-items: flex-start;
-
-	/* Ensure all direct children stack vertically by default (handles inline elements like <span>) */
-	& > * {
-		display: block;
-	}
 }
 
 /* Base styles for the text container */

--- a/packages/components/src/styles/Alert.module.css
+++ b/packages/components/src/styles/Alert.module.css
@@ -157,6 +157,16 @@
 	flex-direction: column;
 	font: var(--lp-text-body-2-regular);
 	align-items: flex-start;
+
+	/* Ensure all direct children stack vertically by default (handles inline elements like <span>) */
+	& > * {
+		display: block;
+	}
+
+	/* Preserve the button group as a flex container */
+	& > .buttonGroup {
+		display: flex;
+	}
 }
 
 /* Base styles for the text container */

--- a/packages/components/stories/Alert.stories.tsx
+++ b/packages/components/stories/Alert.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
-import { Alert } from '../src/Alert';
+import { Alert, AlertText } from '../src/Alert';
 import { Button } from '../src/Button';
 import { ButtonGroup } from '../src/ButtonGroup';
 import { Heading } from '../src/Heading';
@@ -15,93 +15,224 @@ const meta: Meta<typeof Alert> = {
 				'https://www.figma.com/design/98HKKXL2dTle29ikJ3tzk7/%F0%9F%9A%80-LaunchPad?node-id=8225-704&m=dev',
 		},
 	},
+	argTypes: {
+		actionsLayout: {
+			control: 'inline-radio',
+			options: ['stacked', 'inline'],
+			description: 'Controls the layout of actions (block variant only)',
+		},
+		hideIcon: {
+			control: 'boolean',
+			description: 'Hides the status icon',
+		},
+		status: {
+			control: 'select',
+			options: ['neutral', 'info', 'error', 'success', 'warning'],
+		},
+		variant: {
+			control: 'inline-radio',
+			options: ['default', 'inline'],
+		},
+	},
 };
 
 export default meta;
 
 type Story = StoryObj<typeof Alert>;
 
+// =============================================================================
+// Block Variant Stories
+// =============================================================================
+
+export const BlockDefault: Story = {
+	args: {
+		children: (
+			<>
+				<Heading>Test drive SSO</Heading>
+				<Text>
+					Verify your SSO configuration is working. You'll be redirected back here after a
+					successful test; this won't require all members to sign in with SSO yet.
+				</Text>
+				<ButtonGroup>
+					<Button>Test drive SSO</Button>
+					<Button variant="minimal">Cancel</Button>
+				</ButtonGroup>
+			</>
+		),
+		status: 'info',
+		isDismissable: true,
+		actionsLayout: 'stacked',
+	},
+	name: 'Block/Default',
+};
+
+export const BlockTones: Story = {
+	render: () => (
+		<div style={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
+			<Alert>
+				<Heading>Neutral alert</Heading>
+				<Text>This is a neutral alert with no specific status.</Text>
+			</Alert>
+			<Alert status="info" isDismissable>
+				<Heading>Info alert</Heading>
+				<Text>This is an informational alert.</Text>
+			</Alert>
+			<Alert status="error">
+				<Heading>Error alert</Heading>
+				<Text>This is an error alert.</Text>
+			</Alert>
+			<Alert status="success">
+				<Heading>Success alert</Heading>
+				<Text>This is a success alert.</Text>
+			</Alert>
+			<Alert status="warning">
+				<Heading>Warning alert</Heading>
+				<Text>This is a warning alert.</Text>
+			</Alert>
+		</div>
+	),
+	name: 'Block/Tones',
+};
+
 export const Neutral: Story = {
 	args: {
 		children: (
 			<>
-				<Heading>Heading</Heading>
-				<Text>Content</Text>
+				<Heading>Let's squash some bugs!</Heading>
+				<Text>View a recent error or find a specific error message, URL, or segment.</Text>
 			</>
 		),
 	},
+	name: 'Block/Neutral',
 };
 
-export const Info: Story = {
+export const BlockDismissable: Story = {
 	args: {
 		children: (
 			<>
-				<Heading>Heading</Heading>
-				<Text>Content</Text>
-			</>
-		),
-		status: 'info',
-	},
-};
-
-export const ErrorAlert: Story = {
-	args: {
-		children: (
-			<>
-				<Heading>Heading</Heading>
-				<Text>Content</Text>
-			</>
-		),
-		status: 'error',
-	},
-	name: 'Error',
-};
-
-export const Success: Story = {
-	args: {
-		children: (
-			<>
-				<Heading>Heading</Heading>
-				<Text>Content</Text>
-			</>
-		),
-		status: 'success',
-	},
-};
-
-export const Warning: Story = {
-	args: {
-		children: (
-			<>
-				<Heading>Heading</Heading>
-				<Text>Content</Text>
+				<Heading>Session expiring soon</Heading>
+				<Text>Your session will expire in 5 minutes due to inactivity.</Text>
 			</>
 		),
 		status: 'warning',
-	},
-};
-
-export const Inline: Story = {
-	args: {
-		children: <Text>Content</Text>,
-		variant: 'inline',
 		isDismissable: true,
-		onDismiss: () => undefined,
+		actionsLayout: 'stacked',
 	},
+	name: 'Block/Dismissable',
 };
 
-export const Actions: Story = {
+export const BlockWithActions: Story = {
 	args: {
 		children: (
 			<>
-				<Heading>Heading</Heading>
-				<Text>Content</Text>
+				<Heading>Test drive SSO</Heading>
+				<Text>
+					Test drive to verify SSO is working. If successful, you'll be redirected to this page by
+					your ldP. This will not require all account members to sign in with SSO.
+				</Text>
 				<ButtonGroup>
-					<Button>Label</Button>
-					<Button variant="minimal">Label</Button>
+					<Button>Test drive SSO</Button>
+					<Button variant="minimal">Secondary action</Button>
 				</ButtonGroup>
 			</>
 		),
+		status: 'info',
+		actionsLayout: 'stacked',
+	},
+	name: 'Block/With Actions',
+};
+
+export const BlockInlineActions: Story = {
+	args: {
+		children: (
+			<>
+				<AlertText>
+					<Heading>SDK update available</Heading>
+					<Text>A new SDK version is available with performance improvements and bug fixes.</Text>
+				</AlertText>
+				<ButtonGroup>
+					<Button>Update</Button>
+				</ButtonGroup>
+			</>
+		),
+		status: 'info',
+		actionsLayout: 'inline',
 		isDismissable: true,
 	},
+	name: 'Block/Inline Actions',
+};
+
+export const BlockWithoutHeader: Story = {
+	render: () => (
+		<div style={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
+			<Alert status="warning" actionsLayout="inline">
+				<AlertText>
+					<Text>Your session will expire in 5 minutes.</Text>
+				</AlertText>
+				<ButtonGroup>
+					<Button>Extend session</Button>
+				</ButtonGroup>
+			</Alert>
+			<Alert status="error" actionsLayout="inline" isDismissable>
+				<AlertText>
+					<Text>
+						Unable to save your changes. Try again, or contact support if the problem continues.
+					</Text>
+				</AlertText>
+			</Alert>
+			<Alert status="info" actionsLayout="inline" isDismissable>
+				<AlertText>
+					<Text>
+						A new relay proxy is available. Update to stay compatible with the latest SDK features.
+					</Text>
+				</AlertText>
+				<ButtonGroup>
+					<Button>Update</Button>
+				</ButtonGroup>
+			</Alert>
+			<Alert status="neutral" actionsLayout="inline">
+				<AlertText>
+					<Text>A new SDK version is available with performance improvements and bug fixes.</Text>
+				</AlertText>
+			</Alert>
+		</div>
+	),
+	name: 'Block/Without Header',
+};
+
+// =============================================================================
+// Inline Variant Stories
+// =============================================================================
+
+export const InlineDefault: Story = {
+	args: {
+		children: <Text>This flag is a prerequisite of 1 other flag in production.</Text>,
+		variant: 'inline',
+		status: 'info',
+		isDismissable: true,
+	},
+	name: 'Inline/Default',
+};
+
+export const InlineTones: Story = {
+	render: () => (
+		<div style={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
+			<Alert variant="inline">
+				<Text>This is a neutral inline alert.</Text>
+			</Alert>
+			<Alert variant="inline" status="info">
+				<Text>This is an info inline alert.</Text>
+			</Alert>
+			<Alert variant="inline" status="error">
+				<Text>This is an error inline alert.</Text>
+			</Alert>
+			<Alert variant="inline" status="success">
+				<Text>This is a success inline alert.</Text>
+			</Alert>
+			<Alert variant="inline" status="warning">
+				<Text>This is a warning inline alert.</Text>
+			</Alert>
+		</div>
+	),
+	name: 'Inline/Tones',
 };


### PR DESCRIPTION
## Summary

Restoring new styles from #1885 

<!-- What is changing and why? -->

## Screenshots (if appropriate):

<!-- Are there any visual changes that would be helpful to the reviewer to see? -->

## Testing approaches

<!-- How are these changes tested? -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes `Alert` layout/styling and icon/dismiss sizing, which may cause visual regressions or spacing changes for existing consumers.
> 
> **Overview**
> Refreshes `Alert` (block variant) visuals with new background/border tokens, updated spacing, and smaller status icon sizing, plus a repositioned dismiss control (now `IconButton` size `medium`).
> 
> Adds `actionsLayout` (`stacked` | `inline`, block-only) and `hideIcon` props, introduces a new `AlertText` wrapper to group heading/body for inline-action layouts, and updates Storybook stories/exports accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2b185d0485bafce550f6906da105e9729bad1c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- ld-jira-link -->
---
Related Jira issue: [DSYS-132: Update Alert Component](https://launchdarkly.atlassian.net/browse/DSYS-132)
<!-- end-ld-jira-link -->