### PR TITLE
docs: add AGENTS.md as canonical cross-tool AI guidance

### DIFF
--- a/.cursor/BUGBOT.md
+++ b/.cursor/BUGBOT.md
@@ -1,5 +1,7 @@
 # Bugbot Instructions — launchpad-ui
 
+> This file is the **PR-review** rubric for Cursor Bugbot. Authoring standards (what to follow when *writing* code) live in [`AGENTS.md`](../AGENTS.md) — keep the two consistent.
+
 LaunchDarkly's design system. Public, versioned, consumed across LaunchDarkly frontend apps. Components here have been **vetted by design** and have corresponding Figma definitions. They are foundational and reused widely.
 
 ## Repo shape

--- a/.cursor/rules/launchpad.mdc
+++ b/.cursor/rules/launchpad.mdc
@@ -1,0 +1,18 @@
+---
+description: LaunchPad design-system authoring standards and PR workflow
+alwaysApply: true
+---
+
+You are working in LaunchDarkly's LaunchPad design system. Non-negotiables:
+
+- **Components stay generic** — no business logic, product-domain terms (flag/segment/project), app-specific fetching, or hardcoded LaunchDarkly URLs.
+- **React Aria Components is the foundation** — wrap/theme RAC primitives; never reimplement keyboard/ARIA/focus behavior.
+- **Named exports only** (no `export default` outside stories/config).
+- **Design tokens exclusively** via `--lp-*` CSS variables; prefer semantic aliases (`--lp-color-bg-ui-primary`) over primitives (`--lp-color-blue-500`); every style must work in light and dark themes.
+- **String union prop types**, never enums (`size="medium"`).
+- **CSS Modules** (`styles.foo`) + `class-variance-authority` for variants.
+- New public components need a `*.stories.tsx`; non-trivial package changes need a `.changeset/*.md`.
+
+The full standards, commands, architecture, and the step-by-step pull-request flow (branch naming, changeset, conventional commits, draft `gh pr create`) live in the canonical guidance:
+
+@AGENTS.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,119 @@
+# AGENTS.md
+
+Canonical guidance for AI agents and assistants working in this repository — Cursor, Claude Code, and any AGENTS.md-compatible tool. This is the single source of truth for LaunchPad's standards; other guidance files point here.
+
+## What this is
+
+LaunchPad is LaunchDarkly's design system: a pnpm + Nx monorepo of independently-versioned packages published to npm under `@launchpad-ui/*`. Components are vetted by design, have corresponding Figma definitions, and are consumed across LaunchDarkly's frontend apps.
+
+Components **must stay generic** — no business logic, no product-domain terms (flag/segment/project/environment/member/metric), no app-specific data fetching, and no hardcoded LaunchDarkly URLs or copy. If a feature needs any of that, it belongs in the consuming app, not here. (Exception: files under `packages/components/stories/recipes/` are example compositions, not components — they may combine primitives and use example copy, but accessibility, token, and theme rules still apply.)
+
+Node `>=22.14.0` (see `.nvmrc`), pnpm `11.0.1`. Run `pnpm install` to set up.
+
+## Commands
+
+```sh
+pnpm storybook          # local component development (Storybook on :3000)
+pnpm test               # all unit tests with coverage (builds tokens first)
+pnpm test:watch         # vitest watch mode
+pnpm test:ui            # vitest UI
+pnpm test:packages      # test only Nx-affected packages
+pnpm typecheck          # tsc --noEmit across the repo (builds tokens first)
+pnpm check              # biome check . --write (lint + format + organize imports)
+pnpm build              # build all packages (nx run-many)
+pnpm build:packages     # build only Nx-affected packages
+pnpm build:transform    # build @launchpad-ui/tokens only (prerequisite for many tasks)
+```
+
+**Run a single test file:** `pnpm vitest run packages/components/__tests__/Button.spec.tsx`
+**Run a single test by name:** `pnpm vitest run -t "renders disabled"`
+Tests live in each package's `__tests__/*.spec.{ts,tsx}` folder (the only glob Vitest includes). Vitest config is centralized in `vite.config.mts` at the repo root, not per-package.
+
+**Important:** tokens must be built before tests, typecheck, and Storybook will work — `pnpm build:transform` does this and is already prepended to the `test`, `typecheck`, and `storybook` scripts. If you run `vitest` directly, run `pnpm build:transform` first.
+
+**Coverage thresholds** (enforced, in `vite.config.mts`): lines 85%, statements 85%, functions 70%, branches 70%.
+
+## Architecture
+
+### Build & tooling
+- **Vite + Rolldown** (`vite: npm:rolldown-vite`) builds each package in ESM + CJS via library mode; a single shared `vite.config.mts` is referenced by every package's `build` script (`vite build -c ../../vite.config.mts && tsc`). Type declarations come from `tsc`.
+- **Nx** runs build/test/typecheck only on affected packages and caches results. `build` depends on `^build` (upstream packages build first).
+- **Lightning CSS** transforms CSS Modules (class pattern `[hash]_[local]`) and handles browserslist targeting.
+- **Biome** is the single tool for lint + format + import organization (100-char line width, single quotes for JS / double for JSX, type imports grouped first). It replaces ESLint/Prettier/Stylelint. `dist/` and other generated dirs are excluded.
+- **Vanilla Extract** is wired into the build and being evaluated for new components (see `docs/adr-006-scoped-styles.md`), but most existing components use CSS Modules.
+
+### Packages (`packages/*`)
+The primary published packages are `components`, `icons`, and `tokens`. Others (`button`, `modal`, `menu`, `popover`, `core`, `vars`, etc.) are older/standalone packages. **New component work generally goes into `@launchpad-ui/components`.**
+
+A package's typical shape: `src/` (one `.tsx` per component, plus `index.ts` barrel), `__tests__/`, `stories/`, `figma/` (Code Connect mappings), `dist/` (generated).
+
+### Tokens & icons
+- **Tokens** are authored in DTCG format and transformed by **Style Dictionary** into CSS custom properties + ES/CJS modules (`packages/tokens`).
+- **Icons** are an SVG sprite referenced by a React wrapper. **Do not add icons manually** — they live in Figma and are synced to `@launchpad-ui/icons` via the `sync-icons` GitHub Action.
+
+## Component standards
+
+Follow these when writing or changing component code:
+
+- **Use existing LaunchPad components and packages** (`@launchpad-ui/components`, `@launchpad-ui/icons`, etc.). Never create a custom component when a LaunchPad equivalent exists.
+- **React Aria Components is the foundation.** Wrap and theme RAC primitives; do not reimplement keyboard/ARIA/focus behavior. The sanctioned escape hatches are `defaultProps`, slots, `useContextProps`, and render-props composition — see https://react-aria.adobe.com/customization. (`docs/adr-008-component-foundation.md`)
+- **Named exports only.** `export default` is reserved for stories and config files (Biome-enforced).
+- **Named imports** following `import { Button, Alert } from '@launchpad-ui/components'` and `import { Icon } from '@launchpad-ui/icons'`.
+- **String union prop types, never enums** (`size="medium"`, not `Size.Medium`). (`docs/adr-002-string-unions-for-prop-types.md`)
+- **Design tokens exclusively** via `--lp-*` CSS variables. Never hardcode colors/spacing/radii/shadows/z-index. **Prefer semantic alias tokens** (`var(--lp-color-bg-ui-primary)`) over primitives (`var(--lp-color-blue-500)`). If no suitable alias exists, the right fix is usually to add one in `packages/tokens`. All styles must work in both light and dark themes via `[data-theme]`.
+- **CSS Modules** with scoped class names (`styles.foo`); `class-variance-authority` (cva) for variants (base + variants + defaultVariants). (`docs/adr-005-styles.md`, `docs/adr-006-scoped-styles.md`)
+- **Context + prop merging:** public components with overridable props use a `ComponentContext` + `useLPContextProps` pattern (see Button, Menu). Export both component and context.
+- **Prefer mid-level purpose-driven components** (`Picker`, `Menu`) over re-exposing raw `Popover + ListBox + Input` combinations to consumers.
+- **No cross-package relative imports** — packages reference each other via `@launchpad-ui/*` workspace specifiers, never `../../other-package/src`.
+- **React and React Aria belong in `peerDependencies`**, not `dependencies`, in component packages.
+- **JSDoc** is expected on exported components and public utilities (describe props, usage, and link relevant React Aria docs). Not required on internal helpers.
+- **Accessibility is a hard requirement** — components must pass axe (WCAG 2.0/2.1 A/AA), have proper ARIA + keyboard support, and manage focus correctly. (`docs/adr-001-automated-a11y-tests.md`, `docs/adr-007-a11y-tests-on-stories.md`)
+- **Stories are required** for new public components/variants (`*.stories.tsx`) — they drive discoverability plus Chromatic visual regression and axe a11y checks in CI.
+- **Tests:** RTL tests must use `render()` from the project's test utils (`test/setup.ts`), not directly from `@testing-library/react`. (`docs/adr-004-component-tests.md`)
+
+The full component list lives in `packages/components/src/index.ts`.
+
+## Opening a pull request
+
+Follow this flow end to end. The repo's PR gates are strict — a missing changeset or a non-conventional title will block the merge.
+
+1. **Branch off `main`** using `{name}/{type}/{description}`, e.g. `cwinters/feat/add-empty-state`.
+2. **Make your changes** following the standards above.
+3. **Add a changeset — REQUIRED.** Run `npx changeset` (or hand-author `.changeset/<slug>.md`). Format:
+   ```md
+   ---
+   '@launchpad-ui/components': minor
+   ---
+
+   Add `EmptyState` to display empty content views with an illustration, heading, and optional action.
+   ```
+   Bump rules: `patch` = bugfix/internal refactor (no API change); `minor` = new exported component, new prop, additive behavior; `major` = removed/renamed export, changed default, breaking type. The summary is consumed in changelogs org-wide — make it specific and human-readable, not boilerplate. `changeset-check.yml` **blocks merge** if no changeset is present.
+4. **Commit** with Conventional Commits (`feat(components): add EmptyState`) — enforced by commitlint via the `commit-msg` git hook. The `pre-commit` hook auto-runs Biome + syncpack, so let it format your staged files.
+5. **Push** the branch.
+6. **Open a draft PR:**
+   ```sh
+   gh pr create --draft \
+     --title "feat(components): add EmptyState" \
+     --body "$(cat <<'EOF'
+   ## Summary
+   <what changed and why — specific. "Replaced hardcoded 16px with var(--lp-spacing-400)", not "updated styles">
+
+   ## Screenshots (if appropriate)
+   <before/after for visual changes>
+
+   ## Testing approaches
+   <tests added, Storybook verification, Chromatic note>
+   EOF
+   )"
+   ```
+   The PR title must be a valid Conventional Commit — `lint-pr-title.yml` validates it (the title becomes the squash-merge commit). The body fills the three-section template in `.github/pull_request_template.md`.
+7. **A human reviews and marks the PR ready.** Draft is intentional: a design system warrants a human gate before review and Chromatic sign-off. Do not flip it to ready yourself.
+8. **CI checks to expect:** `verify.yml` (test / typecheck / Biome), `changeset-check.yml`, Chromatic visual snapshots (**visual diffs require human approval**), `package-size.yml`, `dependency-scan.yml`, plus the PR-comment bot (API-surface diff, story-coverage gaps). New public components need a `*.stories.tsx` or Story Coverage will flag them.
+
+Note: the Claude Code harness auto-appends `Co-Authored-By` trailers to commits and PR bodies — don't add them by hand.
+
+## Reference
+
+- `docs/` — ADRs covering a11y, prop types, builds, tests, styles, and component foundation; plus `tech-stack.md` and `ci.md`.
+- `CONTRIBUTING.md` — branch naming, changesets, testing expectations, the icon-sync workflow.
+- `.cursor/BUGBOT.md` — Cursor's automated PR-review bot rubric (review-time, complements the authoring standards here).

--- a/AI_PROMPT_HEADER.md
+++ b/AI_PROMPT_HEADER.md
@@ -1,96 +1,41 @@
 # AI Code Generation Prompt Header
 
-This document contains a standardized prompt header to use when working with AI assistants (Claude, ChatGPT, etc.) to generate code for the LaunchDarkly LaunchPad UI project. This ensures consistent, high-quality code that follows our established patterns and standards.
+This document provides a copy-paste prompt header for chat-based AI assistants (Claude, ChatGPT, etc.) when generating code for LaunchPad.
+
+> **Single source of truth:** the authoritative standards now live in [`AGENTS.md`](AGENTS.md), which Cursor, Claude Code, and other AGENTS.md-compatible agents read automatically. This file exists for assistants that *don't* read repo files on their own — paste the header below to give them the same standards.
 
 ## The Prompt Header
 
-Copy and paste this entire section at the beginning of any AI conversation when generating code:
+Copy this into your first message, then add your request:
 
 ---
 
-**Always follow these LaunchDarkly LaunchPad UI standards:**
+**Follow the LaunchDarkly LaunchPad design-system standards (full detail in the repo's `AGENTS.md`):**
 
-- **Use only approved LaunchPad components** from `@launchpad-ui/components`, `@launchpad-ui/icons`, and other LaunchPad packages. Never create custom components when LaunchPad equivalents exist.
-
-- **Import components using named imports** following the pattern: `import { Button, Alert, Icon } from '@launchpad-ui/components'` and `import { Icon, StatusIcon } from '@launchpad-ui/icons'`. Never use default exports (enforced by Biome linting).
-
-- **Use design tokens exclusively** with CSS variables prefixed `--lp-` for colors, spacing, typography, borders, and shadows. Examples: `var(--lp-color-bg-ui-primary)`, `var(--lp-spacing-400)`, `var(--lp-border-radius-medium)`. Never hardcode values.
-
-- **Follow React Aria Components foundation** - all components extend React Aria Components with additional LaunchPad styling and tokens. Use proper ARIA attributes and semantic HTML for accessibility compliance.
-
-- **Use string union types for props** instead of enums (e.g., `size="medium"`, `variant="primary"`, `status="error"`). This reduces bundle size and improves DX without requiring additional imports.
-
-- **Apply CSS Modules for styling** with scoped class names using the pattern `styles.className`. Use `class-variance-authority` (cva) for component variants with the structure: base styles + variants + defaultVariants.
-
-- **Include comprehensive JSDoc comments** for all components and exported functions, especially describing props, usage examples, and referencing React Aria documentation URLs.
-
-- **Follow Biome code formatting rules** - single quotes for strings, double quotes for JSX attributes, 100 character line width, organized imports with type imports first, and no default exports except for stories/config files.
-
-- **Ensure accessibility compliance** - components must pass automated a11y tests using Playwright and axe-core. Include proper ARIA labels, focus management, and keyboard navigation support.
-
-- **Use Context patterns for component composition** - create `ComponentContext` for shared state and `useLPContextProps` utility for prop merging. Export both component and context for advanced use cases.
-
-- **Test components using React Testing Library** with `@testing-library/react` utilities, focusing on user interactions and accessibility. Use `render()` from the project's test utils, not directly from RTL.
+- Use existing `@launchpad-ui/*` components — never recreate what already exists. Import with named imports; no default exports.
+- Build on **React Aria Components** — wrap/theme RAC primitives, never reimplement keyboard/ARIA/focus behavior.
+- Style with **CSS Modules** + `class-variance-authority`; use **`--lp-*` design tokens exclusively**, preferring semantic aliases (`--lp-color-bg-ui-primary`) over primitives. Everything must work in light and dark themes.
+- Use **string union prop types**, not enums (`size="medium"`).
+- Keep components **generic** — no business logic, product-domain terms, or hardcoded LaunchDarkly URLs.
+- Meet **WCAG 2.0/2.1 A/AA** accessibility; new public components need a `*.stories.tsx` and tests using the project's `render()` util.
+- Use the `ComponentContext` + `useLPContextProps` pattern for overridable props; include JSDoc on exported components.
 
 ---
 
-## How to Use
-
-### 1. Copy the Header
-Copy the entire prompt header section above (everything between the horizontal rules).
-
-### 2. Start Your AI Conversation
-Paste the header at the beginning of your first message to the AI, then add your specific code generation request.
-
-### 3. Example Usage
+## Example Usage
 
 ```
 [Paste the prompt header here]
 
-Now please create a React component for a user settings form that includes:
-- Text inputs for name and email
-- Toggle switches for notifications
-- A save button with loading state
-- Proper validation and error handling
-
-Make it accessible and follow the LaunchPad design system.
+Now create a user settings form with text inputs, notification toggles, and a save button with a loading state. Make it accessible and follow the LaunchPad design system.
 ```
-
-## What This Ensures
-
-Using this prompt header guarantees that AI-generated code will:
-- Use existing LaunchPad components instead of creating new ones
-- Follow design token system for consistent styling
-- Meet accessibility standards (WCAG 2.1 AA)
-- Use correct TypeScript patterns and import conventions
-- Pass Biome linting rules
-- Follow React Aria Components foundation
-- Include proper JSDoc documentation
-- Use established testing patterns
 
 ## Available Components
 
-Key components available in `@launchpad-ui/components`:
-- **Buttons**: `Button`, `IconButton`, `LinkButton`, `ToggleButton`
-- **Forms**: `TextField`, `TextArea`, `Checkbox`, `Radio`, `Select`, `Switch`
-- **Feedback**: `Alert`, `Toast`, `ProgressBar`, `Meter`
-- **Layout**: `Modal`, `Popover`, `Drawer`, `Tabs`, `Disclosure`
-- **Data**: `Table`, `ListBox`, `GridList`, `Menu`, `ComboBox`
-- **Typography**: `Text`, `Heading`, `Label`, `Code`
-- **Navigation**: `Link`, `Breadcrumbs`, `Navigation`
-
-And many more! See the [full component list](packages/components/src/index.ts).
-
-## Team Guidelines
-
-- **Always use this header** when working with AI assistants for code generation
-- **Share this document** with new team members during onboarding
-- **Update the header** as our component library and standards evolve
-- **Report issues** if AI-generated code doesn't follow these standards despite using the header
+See the full component list in [`packages/components/src/index.ts`](packages/components/src/index.ts).
 
 ## Related Documentation
 
-- [Component Architecture Decision Records](docs/)
-- [Accessibility Testing Guidelines](docs/adr-007-a11y-tests-on-stories.md)
-- [Styling Conventions](docs/adr-005-styles.md)
-- [Component Foundation](docs/adr-008-component-foundation.md) 
+- [`AGENTS.md`](AGENTS.md) — canonical standards, commands, architecture, and the PR workflow
+- [`docs/`](docs/) — Architecture Decision Records
+- [`CONTRIBUTING.md`](CONTRIBUTING.md) — branch naming, changesets, testing

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,9 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+LaunchPad is LaunchDarkly's design system — a pnpm + Nx monorepo of independently-versioned packages published under `@launchpad-ui/*`, built on React Aria Components with `--lp-*` design tokens.
+
+All standards, commands, architecture notes, and the pull-request workflow live in the canonical, cross-tool guidance file, imported below. Treat it as the source of truth:
+
+@AGENTS.md


### PR DESCRIPTION
## Summary

Establishes `AGENTS.md` as the single source of truth for LaunchPad's AI-assistant guidance, and adds a step-by-step pull-request workflow that agents can follow.

**Why:** Standards were duplicated across `AI_PROMPT_HEADER.md` (which is copy/paste only) and `.cursor/BUGBOT.md`, and they drift. There was also no `CLAUDE.md`. More importantly, `.cursor/BUGBOT.md` is Cursor's *review-bot* config — not the rules Cursor's composer/agent reads while writing code — so designers using Cursor (which doesn't always run Claude) had **no project rules at all**. There was also no documented way for an agent to open a PR despite strict gates (changeset blocks merge, PR title is semantically validated, conventional commits enforced).

**What changed:**
- **`AGENTS.md` (new)** — canonical, model-agnostic guidance: overview, commands, architecture, the merged component standards, and a new **"Opening a pull request"** section (branch naming → changeset → conventional commit → draft `gh pr create` → CI checklist). Read natively by Cursor and AGENTS.md-compatible agents.
- **`.cursor/rules/launchpad.mdc` (new)** — an `alwaysApply` Cursor rule so the agent always has standards in context regardless of model; references `@AGENTS.md`.
- **`CLAUDE.md`** — slimmed to a pointer that imports `@AGENTS.md`.
- **`AI_PROMPT_HEADER.md`** — trimmed to a copy-paste header that defers to `AGENTS.md`.
- **`.cursor/BUGBOT.md`** — one line noting it's the review rubric; authoring standards live in `AGENTS.md`. Review content untouched.

## Screenshots (if appropriate)

N/A — documentation and editor-config only; no UI or component changes.

## Testing approaches

- Verified every path/ADR referenced in the new docs exists.
- Confirmed the documented PR gates match reality: `changeset-check.yml` runs `changesets status` (skips on `skip changeset` label), `lint-pr-title.yml` uses the semantic-PR action.
- Confirmed the spacing-token example is the real token (`--lp-spacing-400`).
- No package source changed, so no changeset is required.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and Cursor rule files only; no runtime, API, or dependency changes.
> 
> **Overview**
> **Consolidates LaunchPad AI authoring guidance** into a new **`AGENTS.md`** as the single source of truth: repo overview, commands, architecture, component standards, and a new **Opening a pull request** flow (branch naming, changesets, conventional commits, draft `gh pr create`, CI expectations).
> 
> **`.cursor/rules/launchpad.mdc`** is added as an **`alwaysApply`** Cursor rule with non‑negotiables and a pointer to **`AGENTS.md`**, so agents get standards while writing code—not only via Bugbot at review time. **`CLAUDE.md`** and **`AI_PROMPT_HEADER.md`** are shortened to defer to **`AGENTS.md`**; **`AI_PROMPT_HEADER.md`** keeps a compact copy‑paste header for chat tools that do not read the repo. **`.cursor/BUGBOT.md`** gains a one‑line note that review rubric stays there while authoring standards live in **`AGENTS.md`** (review content unchanged).
> 
> No package or component source changes; documentation and editor config only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5436702ad3dd2acfa98861794af8ea0f2514aa86. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->