### PR TITLE
feat(components): add optional switchLabels and variant props to Switch

### DIFF
--- a/.changeset/switch-hide-labels-primary-variant.md
+++ b/.changeset/switch-hide-labels-primary-variant.md
@@ -1,0 +1,5 @@
+---
+'@launchpad-ui/components': minor
+---
+
+Add `hideLabels` prop and `variant` prop to `Switch`. `hideLabels` hides the On/Off text and renders a compact track. `variant: "primary"` uses a blue background color for the selected state.

--- a/.changeset/switch-hide-labels-primary-variant.md
+++ b/.changeset/switch-hide-labels-primary-variant.md
@@ -2,4 +2,4 @@
 '@launchpad-ui/components': minor
 ---
 
-Add `hideLabels` prop and `variant` prop to `Switch`. `hideLabels` hides the On/Off text and renders a compact track. `variant: "primary"` uses a blue background color for the selected state.
+Add `switchLabels` prop and `variant` prop to `Switch`. Pass `switchLabels={false}` to hide On/Off labels and render a compact track. `variant: "primary"` uses a blue background color for the selected state.

--- a/packages/components/__tests__/Switch.spec.tsx
+++ b/packages/components/__tests__/Switch.spec.tsx
@@ -19,8 +19,8 @@ describe('Switch', () => {
 		expect(screen.getByText('On')).toBeVisible();
 	});
 
-	it('hides labels when hideLabels is set', () => {
-		render(<Switch hideLabels />);
+	it('hides labels when switchLabels is false', () => {
+		render(<Switch switchLabels={false} />);
 		expect(screen.queryByText('Off')).not.toBeInTheDocument();
 		expect(screen.queryByText('On')).not.toBeInTheDocument();
 	});

--- a/packages/components/__tests__/Switch.spec.tsx
+++ b/packages/components/__tests__/Switch.spec.tsx
@@ -8,4 +8,15 @@ describe('Switch', () => {
 		render(<Switch />);
 		expect(screen.getByRole('switch')).toBeVisible();
 	});
+
+	it('renders with hideLabels', () => {
+		render(<Switch hideLabels defaultSelected />);
+		expect(screen.getByRole('switch')).toBeVisible();
+		expect(screen.queryByText('On')).not.toBeInTheDocument();
+	});
+
+	it('renders with primary variant', () => {
+		render(<Switch variant="primary" defaultSelected />);
+		expect(screen.getByRole('switch')).toBeVisible();
+	});
 });

--- a/packages/components/__tests__/Switch.spec.tsx
+++ b/packages/components/__tests__/Switch.spec.tsx
@@ -9,9 +9,19 @@ describe('Switch', () => {
 		expect(screen.getByRole('switch')).toBeVisible();
 	});
 
-	it('renders with hideLabels', () => {
-		render(<Switch hideLabels defaultSelected />);
-		expect(screen.getByRole('switch')).toBeVisible();
+	it('shows Off label when unselected', () => {
+		render(<Switch />);
+		expect(screen.getByText('Off')).toBeVisible();
+	});
+
+	it('shows On label when selected', () => {
+		render(<Switch defaultSelected />);
+		expect(screen.getByText('On')).toBeVisible();
+	});
+
+	it('hides labels when hideLabels is set', () => {
+		render(<Switch hideLabels />);
+		expect(screen.queryByText('Off')).not.toBeInTheDocument();
 		expect(screen.queryByText('On')).not.toBeInTheDocument();
 	});
 

--- a/packages/components/src/Switch.tsx
+++ b/packages/components/src/Switch.tsx
@@ -1,3 +1,4 @@
+import type { VariantProps } from 'class-variance-authority';
 import type { Ref } from 'react';
 import type { SwitchProps as AriaSwitchProps } from 'react-aria-components/Switch';
 import type { ContextValue } from 'react-aria-components/slots';
@@ -25,12 +26,9 @@ const switchStyles = cva(styles.switch, {
 	},
 });
 
-interface SwitchProps extends AriaSwitchProps {
+interface SwitchVariants extends VariantProps<typeof switchStyles> {}
+interface SwitchProps extends AriaSwitchProps, SwitchVariants {
 	ref?: Ref<HTMLLabelElement>;
-	/** Hide the On/Off labels inside the track. */
-	hideLabels?: boolean;
-	/** Color variant for the selected state. */
-	variant?: 'default' | 'primary';
 }
 
 const SwitchContext = createContext<ContextValue<SwitchProps, HTMLLabelElement>>(null);
@@ -40,8 +38,9 @@ const SwitchContext = createContext<ContextValue<SwitchProps, HTMLLabelElement>>
  *
  * https://react-spectrum.adobe.com/react-aria/Switch.html
  */
-const Switch = ({ ref, hideLabels, variant, ...props }: SwitchProps) => {
+const Switch = ({ ref, ...props }: SwitchProps) => {
 	[props, ref] = useLPContextProps(props, ref, SwitchContext);
+	const { hideLabels, variant } = props;
 	return (
 		<AriaSwitch
 			{...props}
@@ -65,4 +64,4 @@ const Switch = ({ ref, hideLabels, variant, ...props }: SwitchProps) => {
 };
 
 export { Switch, SwitchContext, switchStyles };
-export type { SwitchProps };
+export type { SwitchProps, SwitchVariants };

--- a/packages/components/src/Switch.tsx
+++ b/packages/components/src/Switch.tsx
@@ -37,6 +37,8 @@ const SwitchContext = createContext<ContextValue<SwitchProps, HTMLLabelElement>>
 /**
  * A switch allows a user to turn a setting on or off.
  *
+ * Provide an accessible name via `children` (visible label) or `aria-label` (visually hidden label).
+ *
  * https://react-spectrum.adobe.com/react-aria/Switch.html
  */
 const Switch = ({ ref, ...props }: SwitchProps) => {

--- a/packages/components/src/Switch.tsx
+++ b/packages/components/src/Switch.tsx
@@ -10,10 +10,27 @@ import { Switch as AriaSwitch } from 'react-aria-components/Switch';
 import styles from './styles/Switch.module.css';
 import { useLPContextProps } from './utils';
 
-const switchStyles = cva(styles.switch);
+const switchStyles = cva(styles.switch, {
+	variants: {
+		variant: {
+			default: '',
+			primary: styles.primary,
+		},
+		hideLabels: {
+			true: styles.compact,
+		},
+	},
+	defaultVariants: {
+		variant: 'default',
+	},
+});
 
 interface SwitchProps extends AriaSwitchProps {
 	ref?: Ref<HTMLLabelElement>;
+	/** Hide the On/Off labels inside the track. */
+	hideLabels?: boolean;
+	/** Color variant for the selected state. */
+	variant?: 'default' | 'primary';
 }
 
 const SwitchContext = createContext<ContextValue<SwitchProps, HTMLLabelElement>>(null);
@@ -23,22 +40,22 @@ const SwitchContext = createContext<ContextValue<SwitchProps, HTMLLabelElement>>
  *
  * https://react-spectrum.adobe.com/react-aria/Switch.html
  */
-const Switch = ({ ref, ...props }: SwitchProps) => {
+const Switch = ({ ref, hideLabels, variant, ...props }: SwitchProps) => {
 	[props, ref] = useLPContextProps(props, ref, SwitchContext);
 	return (
 		<AriaSwitch
 			{...props}
 			ref={ref}
 			className={composeRenderProps(props.className, (className, renderProps) =>
-				switchStyles({ ...renderProps, className }),
+				switchStyles({ ...renderProps, variant, hideLabels, className }),
 			)}
 		>
 			{composeRenderProps(props.children, (children, { isSelected }) => (
 				<>
 					<div className={styles.track}>
-						{isSelected && <div className={styles.label}>On</div>}
+						{!hideLabels && isSelected && <div className={styles.label}>On</div>}
 						<span className={styles.handle} />
-						{!isSelected && <div className={styles.label}>Off</div>}
+						{!hideLabels && !isSelected && <div className={styles.label}>Off</div>}
 					</div>
 					{children}
 				</>

--- a/packages/components/src/Switch.tsx
+++ b/packages/components/src/Switch.tsx
@@ -17,7 +17,7 @@ const switchStyles = cva(styles.switch, {
 			default: '',
 			primary: styles.primary,
 		},
-		hideLabels: {
+		compact: {
 			true: styles.compact,
 		},
 	},
@@ -26,9 +26,10 @@ const switchStyles = cva(styles.switch, {
 	},
 });
 
-interface SwitchVariants extends VariantProps<typeof switchStyles> {}
-interface SwitchProps extends AriaSwitchProps, SwitchVariants {
+interface SwitchProps extends AriaSwitchProps, Omit<VariantProps<typeof switchStyles>, 'compact'> {
 	ref?: Ref<HTMLLabelElement>;
+	/** Pass `false` to hide On/Off labels and render a compact track. */
+	switchLabels?: false;
 }
 
 const SwitchContext = createContext<ContextValue<SwitchProps, HTMLLabelElement>>(null);
@@ -40,13 +41,14 @@ const SwitchContext = createContext<ContextValue<SwitchProps, HTMLLabelElement>>
  */
 const Switch = ({ ref, ...props }: SwitchProps) => {
 	[props, ref] = useLPContextProps(props, ref, SwitchContext);
-	const { hideLabels, variant } = props;
+	const { switchLabels, variant } = props;
+	const hideLabels = switchLabels === false ? true : undefined;
 	return (
 		<AriaSwitch
 			{...props}
 			ref={ref}
 			className={composeRenderProps(props.className, (className, renderProps) =>
-				switchStyles({ ...renderProps, variant, hideLabels, className }),
+				switchStyles({ ...renderProps, variant, compact: hideLabels, className }),
 			)}
 		>
 			{composeRenderProps(props.children, (children, { isSelected }) => (
@@ -64,4 +66,4 @@ const Switch = ({ ref, ...props }: SwitchProps) => {
 };
 
 export { Switch, SwitchContext, switchStyles };
-export type { SwitchProps, SwitchVariants };
+export type { SwitchProps };

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -66,7 +66,7 @@ export type { SearchFieldProps } from './SearchField';
 export type { ListBoxSectionProps, MenuSectionProps } from './Section';
 export type { SelectProps, SelectValueProps } from './Select';
 export type { SeparatorProps } from './Separator';
-export type { SwitchProps } from './Switch';
+export type { SwitchProps, SwitchVariants } from './Switch';
 export type {
 	CellProps,
 	ColumnProps,

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -66,7 +66,7 @@ export type { SearchFieldProps } from './SearchField';
 export type { ListBoxSectionProps, MenuSectionProps } from './Section';
 export type { SelectProps, SelectValueProps } from './Select';
 export type { SeparatorProps } from './Separator';
-export type { SwitchProps, SwitchVariants } from './Switch';
+export type { SwitchProps } from './Switch';
 export type {
 	CellProps,
 	ColumnProps,

--- a/packages/components/src/styles/Switch.module.css
+++ b/packages/components/src/styles/Switch.module.css
@@ -75,6 +75,25 @@
 	}
 }
 
+.switch.primary[data-selected] {
+	& .track {
+		background-color: var(--lp-color-bg-interactive-primary-base);
+		border-color: var(--lp-color-bg-interactive-primary-base);
+	}
+}
+
+.switch.compact {
+	& .track {
+		width: var(--lp-size-40);
+	}
+}
+
+.switch.compact[data-selected] {
+	& .handle {
+		transform: translateX(100%);
+	}
+}
+
 .switch[data-disabled] {
 	opacity: 60%;
 }

--- a/packages/components/src/styles/Switch.module.css
+++ b/packages/components/src/styles/Switch.module.css
@@ -78,7 +78,14 @@
 .switch.primary[data-selected] {
 	& .track {
 		background-color: var(--lp-color-bg-interactive-primary-base);
-		border-color: var(--lp-color-bg-interactive-primary-base);
+		border: 1px solid var(--lp-color-bg-interactive-primary-base);
+	}
+
+	& .handle {
+		box-shadow:
+			0 0 1px 0 rgb(64 91 255 / 0.75),
+			0 0 2px 0 rgb(64 91 255 / 0.06),
+			0 0 1px 0 rgb(64 91 255 / 0.35);
 	}
 }
 

--- a/packages/components/stories/Switch.stories.tsx
+++ b/packages/components/stories/Switch.stories.tsx
@@ -40,9 +40,9 @@ export const Primary: Story = {
 };
 
 export const HideLabels: Story = {
-	args: { hideLabels: true },
+	args: { switchLabels: false },
 };
 
 export const PrimaryHideLabels: Story = {
-	args: { defaultSelected: true, variant: 'primary', hideLabels: true },
+	args: { defaultSelected: true, variant: 'primary', switchLabels: false },
 };

--- a/packages/components/stories/Switch.stories.tsx
+++ b/packages/components/stories/Switch.stories.tsx
@@ -5,6 +5,12 @@ import { Switch } from '../src/Switch';
 const meta: Meta<typeof Switch> = {
 	component: Switch,
 	title: 'Components/Forms/Switch',
+	argTypes: {
+		variant: {
+			control: 'select',
+			options: ['default', 'primary'],
+		},
+	},
 	parameters: {
 		figma: {
 			design:
@@ -27,4 +33,16 @@ export const On: Story = {
 
 export const States: Story = {
 	args: { isDisabled: true },
+};
+
+export const Primary: Story = {
+	args: { defaultSelected: true, variant: 'primary' },
+};
+
+export const HideLabels: Story = {
+	args: { hideLabels: true },
+};
+
+export const PrimaryHideLabels: Story = {
+	args: { defaultSelected: true, variant: 'primary', hideLabels: true },
 };

--- a/packages/components/stories/Switch.stories.tsx
+++ b/packages/components/stories/Switch.stories.tsx
@@ -40,9 +40,18 @@ export const Primary: Story = {
 };
 
 export const HideLabels: Story = {
-	args: { switchLabels: false },
+	args: { switchLabels: false, 'aria-label': 'Toggle setting' },
 };
 
 export const PrimaryHideLabels: Story = {
-	args: { defaultSelected: true, variant: 'primary', switchLabels: false },
+	args: {
+		defaultSelected: true,
+		variant: 'primary',
+		switchLabels: false,
+		'aria-label': 'Toggle setting',
+	},
+};
+
+export const WithChildren: Story = {
+	args: { children: 'Dark mode' },
 };


### PR DESCRIPTION
## Summary

Minor change to the `Switch` component to add an optional `switchLabels` prop to hide On/Off text, and an optional `variant` prop with a `primary` option for a blue selected state.

## Screenshots (if appropriate):

<img width="227" height="618" alt="Screenshot 2026-06-03 at 1 22 47 PM" src="https://github.com/user-attachments/assets/118d857d-cdb0-4ac4-b5ee-937099967030" /> <img width="238" height="623" alt="Screenshot 2026-06-03 at 1 22 27 PM" src="https://github.com/user-attachments/assets/68dfaeb8-e7e5-434b-ba09-eba2b2472d08" />



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive, backward-compatible UI API on a form control with tests and stories; no auth, data, or breaking changes.
> 
> **Overview**
> Extends **`Switch`** with optional presentation props while keeping default behavior unchanged.
> 
> **`switchLabels={false}`** suppresses the built-in **On/Off** text and applies a **compact** track (narrower width, adjusted handle travel). Docs note that **`children`** or **`aria-label`** should supply an accessible name when labels are hidden.
> 
> **`variant="primary"`** styles the selected state with the interactive primary (blue) background instead of the default green. Styling is wired through **CVA** (`variant` + internal `compact` when labels are hidden).
> 
> Adds unit tests, Storybook stories, and a **minor** changeset for `@launchpad-ui/components`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c71e120c76406da82707fce831f06805fe5c789. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/launchdarkly/launchpad-ui/pull/1917" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->