### PR TITLE
chore: move React Aria packages to peerDependencies and enforce via syncpack

### DIFF
--- a/.changeset/move-react-deps-to-peer.md
+++ b/.changeset/move-react-deps-to-peer.md
@@ -1,0 +1,13 @@
+---
+'@launchpad-ui/components': patch
+'@launchpad-ui/form': patch
+'@launchpad-ui/menu': patch
+---
+
+Move React Aria packages out of `dependencies` to follow the peerDependencies policy (prevents duplicate React Aria copies being installed/bundled in consuming apps):
+
+- `@launchpad-ui/menu`: `react-aria` moved to `peerDependencies` (and `devDependencies`).
+- `@launchpad-ui/form`: `react-stately` moved to `peerDependencies` (and `devDependencies`).
+- `@launchpad-ui/components`: removed the unused `@react-aria/live-announcer` dependency.
+
+No public API changes.

--- a/.changeset/upgrade-react-aria-1-18-0.md
+++ b/.changeset/upgrade-react-aria-1-18-0.md
@@ -1,0 +1,16 @@
+---
+"@launchpad-ui/components": patch
+"@launchpad-ui/focus-trap": patch
+"@launchpad-ui/navigation": patch
+"@launchpad-ui/dropdown": patch
+"@launchpad-ui/drawer": patch
+"@launchpad-ui/filter": patch
+"@launchpad-ui/modal": patch
+"@launchpad-ui/form": patch
+"@launchpad-ui/menu": patch
+---
+
+Upgrade `react-aria-components` to 1.18.0 along with aligned `react-aria` (3.49.0), `react-stately` (3.47.0), `@react-aria/*`, `@react-stately/*`, `@react-types/*`, and `@internationalized/*` packages.
+
+Upstream behavior change worth noting:
+- `Checkbox`, `Radio`, and `Switch` are now soft-deprecated in favor of `CheckboxField`/`RadioField`/`SwitchField` (which add `description`/`FieldError` slot support). The deprecated components still work, but they now render an additional DOM wrapper around the label element.

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -92,3 +92,27 @@ jobs:
 
       - name: Run Biome
         run: biome ci .
+
+  dependencies:
+    name: Dependency Policy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: pnpm
+
+      # --ignore-scripts skips the postinstall syncpack run so the lint below is
+      # the single, clearly-attributed signal for dependency-type violations.
+      - name: Install Dependencies
+        run: pnpm install --ignore-scripts
+
+      # Enforces the peerDependencies policy in AGENTS.md (React & React Aria must
+      # never be in `dependencies`). Config lives in .syncpackrc.
+      - name: Lint dependency types (syncpack)
+        run: pnpm syncpack lint

--- a/.syncpackrc
+++ b/.syncpackrc
@@ -13,6 +13,25 @@
       ]
     },
     {
+      "label": "React and React Aria must be peerDependencies (+ devDependencies), never dependencies",
+      "dependencies": [
+        "react",
+        "react-dom",
+        "react-aria",
+        "react-aria-components",
+        "react-stately",
+        "react-router",
+        "react-hook-form",
+        "@react-aria/**",
+        "@react-stately/**",
+        "@react-types/**"
+      ],
+      "dependencyTypes": [
+        "prod"
+      ],
+      "isBanned": true
+    },
+    {
       "dependencyTypes": [
         "peer",
         "dev",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,7 +65,7 @@ Follow these when writing or changing component code:
 - **Context + prop merging:** public components with overridable props use a `ComponentContext` + `useLPContextProps` pattern (see Button, Menu). Export both component and context.
 - **Prefer mid-level purpose-driven components** (`Picker`, `Menu`) over re-exposing raw `Popover + ListBox + Input` combinations to consumers.
 - **No cross-package relative imports** — packages reference each other via `@launchpad-ui/*` workspace specifiers, never `../../other-package/src`.
-- **React and React Aria belong in `peerDependencies`**, not `dependencies`, in component packages.
+- **React and React Aria belong in `peerDependencies`**, not `dependencies`, in component packages. This is enforced by syncpack (`.syncpackrc` bans `react`, `react-dom`, `react-aria`, `react-aria-components`, `react-stately`, `react-router`, `react-hook-form`, and `@react-aria`/`@react-stately`/`@react-types` scopes from `dependencies`); `syncpack lint` runs in pre-commit, `postinstall`, and the **Dependency Policy** CI job. Add the package to `peerDependencies` and `devDependencies` instead.
 - **JSDoc** is expected on exported components and public utilities (describe props, usage, and link relevant React Aria docs). Not required on internal helpers.
 - **Accessibility is a hard requirement** — components must pass axe (WCAG 2.0/2.1 A/AA), have proper ARIA + keyboard support, and manage focus correctly. (`docs/adr-001-automated-a11y-tests.md`, `docs/adr-007-a11y-tests-on-stories.md`)
 - **Stories are required** for new public components/variants (`*.stories.tsx`) — they drive discoverability plus Chromatic visual regression and axe a11y checks in CI.

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -30,39 +30,39 @@
 		"test": "vitest run --coverage"
 	},
 	"dependencies": {
-		"@internationalized/date": "3.12.1",
+		"@internationalized/date": "3.12.2",
 		"@launchpad-ui/icons": "workspace:~",
 		"@launchpad-ui/tokens": "workspace:~",
-		"@react-aria/live-announcer": "3.5.0",
+		"@react-aria/live-announcer": "3.5.1",
 		"class-variance-authority": "0.7.0"
 	},
 	"devDependencies": {
-		"@react-aria/focus": "3.22.0",
-		"@react-aria/interactions": "3.28.0",
-		"@react-aria/utils": "3.34.0",
-		"@react-stately/utils": "3.12.0",
-		"@react-types/shared": "3.34.0",
+		"@react-aria/focus": "3.22.1",
+		"@react-aria/interactions": "3.28.1",
+		"@react-aria/utils": "3.34.1",
+		"@react-stately/utils": "3.12.1",
+		"@react-types/shared": "3.35.0",
 		"copyfiles": "2.4.1",
 		"react": "19.2.6",
-		"react-aria": "3.48.0",
-		"react-aria-components": "1.17.0",
+		"react-aria": "3.49.0",
+		"react-aria-components": "1.18.0",
 		"react-dom": "19.2.6",
 		"react-router": "7.15.1",
-		"react-stately": "3.46.0"
+		"react-stately": "3.47.0"
 	},
 	"peerDependencies": {
-		"@react-aria/focus": "3.22.0",
-		"@react-aria/interactions": "3.28.0",
-		"@react-aria/utils": "3.34.0",
-		"@react-stately/utils": "3.12.0",
-		"@react-types/shared": "3.34.0",
+		"@react-aria/focus": "3.22.1",
+		"@react-aria/interactions": "3.28.1",
+		"@react-aria/utils": "3.34.1",
+		"@react-stately/utils": "3.12.1",
+		"@react-types/shared": "3.35.0",
 		"react": "19.2.6",
-		"react-aria": "3.48.0",
-		"react-aria-components": "1.17.0",
+		"react-aria": "3.49.0",
+		"react-aria-components": "1.18.0",
 		"react-dom": "19.2.6",
 		"react-hook-form": "7.59.0",
 		"react-router": "7.15.1",
-		"react-stately": "3.46.0"
+		"react-stately": "3.47.0"
 	},
 	"exports": {
 		".": {

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -33,7 +33,6 @@
 		"@internationalized/date": "3.12.2",
 		"@launchpad-ui/icons": "workspace:~",
 		"@launchpad-ui/tokens": "workspace:~",
-		"@react-aria/live-announcer": "3.5.1",
 		"class-variance-authority": "0.7.0"
 	},
 	"devDependencies": {

--- a/packages/drawer/package.json
+++ b/packages/drawer/package.json
@@ -35,12 +35,12 @@
 	},
 	"devDependencies": {
 		"react": "19.2.6",
-		"react-aria": "3.48.0",
+		"react-aria": "3.49.0",
 		"react-dom": "19.2.6"
 	},
 	"peerDependencies": {
 		"react": "19.2.6",
-		"react-aria": "3.48.0",
+		"react-aria": "3.49.0",
 		"react-dom": "19.2.6"
 	},
 	"exports": {

--- a/packages/dropdown/package.json
+++ b/packages/dropdown/package.json
@@ -32,13 +32,13 @@
 		"classix": "2.2.0"
 	},
 	"devDependencies": {
-		"@react-aria/utils": "3.34.0",
-		"@react-types/shared": "3.34.0",
+		"@react-aria/utils": "3.34.1",
+		"@react-types/shared": "3.35.0",
 		"react": "19.2.6",
 		"react-dom": "19.2.6"
 	},
 	"peerDependencies": {
-		"@react-aria/utils": "3.34.0",
+		"@react-aria/utils": "3.34.1",
 		"react": "19.2.6",
 		"react-dom": "19.2.6"
 	},

--- a/packages/filter/package.json
+++ b/packages/filter/package.json
@@ -34,12 +34,12 @@
 	},
 	"devDependencies": {
 		"react": "19.2.6",
-		"react-aria": "3.48.0",
+		"react-aria": "3.49.0",
 		"react-dom": "19.2.6"
 	},
 	"peerDependencies": {
 		"react": "19.2.6",
-		"react-aria": "3.48.0",
+		"react-aria": "3.49.0",
 		"react-dom": "19.2.6"
 	},
 	"exports": {

--- a/packages/focus-trap/package.json
+++ b/packages/focus-trap/package.json
@@ -24,12 +24,12 @@
 	},
 	"devDependencies": {
 		"react": "19.2.6",
-		"react-aria": "3.48.0",
+		"react-aria": "3.49.0",
 		"react-dom": "19.2.6"
 	},
 	"peerDependencies": {
 		"react": "19.2.6",
-		"react-aria": "3.48.0",
+		"react-aria": "3.49.0",
 		"react-dom": "19.2.6"
 	},
 	"exports": {

--- a/packages/form/package.json
+++ b/packages/form/package.json
@@ -29,16 +29,16 @@
 		"@launchpad-ui/tokens": "workspace:~",
 		"@launchpad-ui/tooltip": "workspace:~",
 		"classix": "2.2.0",
-		"react-stately": "3.46.0"
+		"react-stately": "3.47.0"
 	},
 	"devDependencies": {
 		"react": "19.2.6",
-		"react-aria": "3.48.0",
+		"react-aria": "3.49.0",
 		"react-dom": "19.2.6"
 	},
 	"peerDependencies": {
 		"react": "19.2.6",
-		"react-aria": "3.48.0",
+		"react-aria": "3.49.0",
 		"react-dom": "19.2.6"
 	},
 	"exports": {

--- a/packages/form/package.json
+++ b/packages/form/package.json
@@ -28,18 +28,19 @@
 		"@launchpad-ui/icons": "workspace:~",
 		"@launchpad-ui/tokens": "workspace:~",
 		"@launchpad-ui/tooltip": "workspace:~",
-		"classix": "2.2.0",
-		"react-stately": "3.47.0"
+		"classix": "2.2.0"
 	},
 	"devDependencies": {
 		"react": "19.2.6",
 		"react-aria": "3.49.0",
-		"react-dom": "19.2.6"
+		"react-dom": "19.2.6",
+		"react-stately": "3.47.0"
 	},
 	"peerDependencies": {
 		"react": "19.2.6",
 		"react-aria": "3.49.0",
-		"react-dom": "19.2.6"
+		"react-dom": "19.2.6",
+		"react-stately": "3.47.0"
 	},
 	"exports": {
 		".": {

--- a/packages/menu/package.json
+++ b/packages/menu/package.json
@@ -31,15 +31,16 @@
 		"@launchpad-ui/tooltip": "workspace:~",
 		"@radix-ui/react-slot": "1.2.0",
 		"classix": "2.2.0",
-		"react-aria": "3.49.0",
 		"react-virtual": "2.10.4"
 	},
 	"devDependencies": {
 		"react": "19.2.6",
+		"react-aria": "3.49.0",
 		"react-dom": "19.2.6"
 	},
 	"peerDependencies": {
 		"react": "19.2.6",
+		"react-aria": "3.49.0",
 		"react-dom": "19.2.6"
 	},
 	"exports": {

--- a/packages/menu/package.json
+++ b/packages/menu/package.json
@@ -31,7 +31,7 @@
 		"@launchpad-ui/tooltip": "workspace:~",
 		"@radix-ui/react-slot": "1.2.0",
 		"classix": "2.2.0",
-		"react-aria": "3.48.0",
+		"react-aria": "3.49.0",
 		"react-virtual": "2.10.4"
 	},
 	"devDependencies": {

--- a/packages/modal/package.json
+++ b/packages/modal/package.json
@@ -34,12 +34,12 @@
 	},
 	"devDependencies": {
 		"react": "19.2.6",
-		"react-aria": "3.48.0",
+		"react-aria": "3.49.0",
 		"react-dom": "19.2.6"
 	},
 	"peerDependencies": {
 		"react": "19.2.6",
-		"react-aria": "3.48.0",
+		"react-aria": "3.49.0",
 		"react-dom": "19.2.6"
 	},
 	"exports": {

--- a/packages/navigation/package.json
+++ b/packages/navigation/package.json
@@ -34,19 +34,19 @@
 		"classix": "2.2.0"
 	},
 	"devDependencies": {
-		"@react-aria/utils": "3.34.0",
-		"@react-types/shared": "3.34.0",
+		"@react-aria/utils": "3.34.1",
+		"@react-types/shared": "3.35.0",
 		"react": "19.2.6",
 		"react-dom": "19.2.6",
 		"react-router": "7.15.1",
-		"react-stately": "3.46.0"
+		"react-stately": "3.47.0"
 	},
 	"peerDependencies": {
-		"@react-aria/utils": "3.34.0",
+		"@react-aria/utils": "3.34.1",
 		"react": "19.2.6",
 		"react-dom": "19.2.6",
 		"react-router": "7.15.1",
-		"react-stately": "3.46.0"
+		"react-stately": "3.47.0"
 	},
 	"exports": {
 		".": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -251,9 +251,6 @@ importers:
       '@launchpad-ui/tokens':
         specifier: workspace:~
         version: link:../tokens
-      '@react-aria/live-announcer':
-        specifier: 3.5.1
-        version: 3.5.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       class-variance-authority:
         specifier: 0.7.0
         version: 0.7.0
@@ -481,9 +478,6 @@ importers:
       classix:
         specifier: 2.2.0
         version: 2.2.0
-      react-stately:
-        specifier: 3.47.0
-        version: 3.47.0(react@19.2.6)
     devDependencies:
       react:
         specifier: 19.2.6
@@ -494,6 +488,9 @@ importers:
       react-dom:
         specifier: 19.2.6
         version: 19.2.6(react@19.2.6)
+      react-stately:
+        specifier: 3.47.0
+        version: 3.47.0(react@19.2.6)
 
   packages/icons:
     dependencies:
@@ -537,9 +534,6 @@ importers:
       classix:
         specifier: 2.2.0
         version: 2.2.0
-      react-aria:
-        specifier: 3.49.0
-        version: 3.49.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react-virtual:
         specifier: 2.10.4
         version: 2.10.4(react@19.2.6)
@@ -547,6 +541,9 @@ importers:
       react:
         specifier: 19.2.6
         version: 19.2.6
+      react-aria:
+        specifier: 3.49.0
+        version: 3.49.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react-dom:
         specifier: 19.2.6
         version: 19.2.6(react@19.2.6)
@@ -1697,12 +1694,6 @@ packages:
 
   '@react-aria/interactions@3.28.1':
     resolution: {integrity: sha512-Bqb+HrD5I5MHS2SKBhISYqo2SW8Y2dfzgF/Y1lIJq7xqLxheo9vzxPGEHhz+XzkgGfoqEJx8A6a3C7uiqS3HWA==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  '@react-aria/live-announcer@3.5.1':
-    resolution: {integrity: sha512-kLvwHjM3D7KgdquiAhUpRnMLKFrvl2r8naDXqPUlSWGRG15wsJRLhQOHLxGp0Umyg7KcSA+OD1mhQV5aRv0P1w==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
@@ -6292,13 +6283,6 @@ snapshots:
   '@react-aria/interactions@3.28.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@react-types/shared': 3.35.0(react@19.2.6)
-      '@swc/helpers': 0.5.23
-      react: 19.2.6
-      react-aria: 3.49.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      react-dom: 19.2.6(react@19.2.6)
-
-  '@react-aria/live-announcer@3.5.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
-    dependencies:
       '@swc/helpers': 0.5.23
       react: 19.2.6
       react-aria: 3.49.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1278,9 +1278,6 @@ packages:
       '@types/node':
         optional: true
 
-  '@internationalized/date@3.12.1':
-    resolution: {integrity: sha512-6IedsVWXyq4P9Tj+TxuU8WGWM70hYLl12nbYU8jkikVpa6WXapFazPUcHUMDMoWftIDE2ILDkFFte6W2nFCkRQ==}
-
   '@internationalized/date@3.12.2':
     resolution: {integrity: sha512-FY1Y+H64NDs+HAF6omlnWxm3mEpfgaCSWtL5l551ZZfImA+kGjPFgrnJrGjH6lfmLL0g8Z/mBu1R3kufeCp6Jw==}
 
@@ -1721,11 +1718,6 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  '@react-types/shared@3.34.0':
-    resolution: {integrity: sha512-gp6xo/s2lX54AlTjOiqwDnxA7UW79BNvI9dB9pr3LZTzRKCd1ZA+ZbgKw/ReIiWuvvVw/8QFJpnqeeFyLocMcQ==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
   '@react-types/shared@3.35.0':
     resolution: {integrity: sha512-iNWvuzEwANttpQpdlu8nPBtdHb0mcCMj1ZTH//iRB5E/14IAnyRlR25rxH7pNLyzHINsPGEKnWvpwDMCT6vziQ==}
@@ -4326,12 +4318,6 @@ packages:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  react-aria@3.48.0:
-    resolution: {integrity: sha512-jQjd4rBEIMqecBaAKYJbVGK6EqIHLa5znVQ7jwFyK5vCyljoj6KhgtiahmcIPsG5vG5vEDLw+ba+bEWn6A2P4w==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
   react-aria@3.49.0:
     resolution: {integrity: sha512-4+oK9FwJQWYhyA5zLfj/feOGY0zZbkE1muoF4gyxMroHVypjcYaRSTlJwvxph2zIlxt757KX6xIK2wJ5Aw1Kog==}
     peerDependencies:
@@ -4373,11 +4359,6 @@ packages:
     peerDependenciesMeta:
       react-dom:
         optional: true
-
-  react-stately@3.46.0:
-    resolution: {integrity: sha512-OdxhWvHgs2L4OJGIs7hnuTr5WjjMM6enhNEAMRqiekhF8+ITvA2LRwNftOZwcogaoCslGYq5S2VQTQwnm0GbCA==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
   react-stately@3.47.0:
     resolution: {integrity: sha512-H3ar+SOWP920EbVg7qWfP3fZjZiwhlEJAEJQqjt+w8oKijCwFgr0+R4941PIHscOXRNRvEOjvWilitImC0DdBg==}
@@ -5923,10 +5904,6 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.19.19
 
-  '@internationalized/date@3.12.1':
-    dependencies:
-      '@swc/helpers': 0.5.23
-
   '@internationalized/date@3.12.2':
     dependencies:
       '@swc/helpers': 0.5.23
@@ -6309,42 +6286,38 @@ snapshots:
     dependencies:
       '@swc/helpers': 0.5.23
       react: 19.2.6
-      react-aria: 3.48.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      react-aria: 3.49.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react-dom: 19.2.6(react@19.2.6)
 
   '@react-aria/interactions@3.28.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
-      '@react-types/shared': 3.34.0(react@19.2.6)
+      '@react-types/shared': 3.35.0(react@19.2.6)
       '@swc/helpers': 0.5.23
       react: 19.2.6
-      react-aria: 3.48.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      react-aria: 3.49.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react-dom: 19.2.6(react@19.2.6)
 
   '@react-aria/live-announcer@3.5.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@swc/helpers': 0.5.23
       react: 19.2.6
-      react-aria: 3.48.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      react-aria: 3.49.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react-dom: 19.2.6(react@19.2.6)
 
   '@react-aria/utils@3.34.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@swc/helpers': 0.5.23
       react: 19.2.6
-      react-aria: 3.48.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      react-aria: 3.49.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react-dom: 19.2.6(react@19.2.6)
-      react-stately: 3.46.0(react@19.2.6)
+      react-stately: 3.47.0(react@19.2.6)
 
   '@react-stately/utils@3.12.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@swc/helpers': 0.5.23
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
-      react-stately: 3.46.0(react@19.2.6)
-
-  '@react-types/shared@3.34.0(react@19.2.6)':
-    dependencies:
-      react: 19.2.6
+      react-stately: 3.47.0(react@19.2.6)
 
   '@react-types/shared@3.35.0(react@19.2.6)':
     dependencies:
@@ -7519,7 +7492,7 @@ snapshots:
 
   dotenv-expand@11.0.7:
     dependencies:
-      dotenv: 16.4.7
+      dotenv: 16.6.1
 
   dotenv@16.4.7: {}
 
@@ -8772,7 +8745,7 @@ snapshots:
       bl: 4.1.0
       chalk: 4.1.2
       cli-cursor: 3.1.0
-      cli-spinners: 2.6.1
+      cli-spinners: 2.9.2
       is-interactive: 1.0.0
       log-symbols: 4.1.0
       strip-ansi: 6.0.1
@@ -9008,20 +8981,6 @@ snapshots:
       react-dom: 19.2.6(react@19.2.6)
       react-stately: 3.47.0(react@19.2.6)
 
-  react-aria@3.48.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
-    dependencies:
-      '@internationalized/date': 3.12.1
-      '@internationalized/number': 3.6.7
-      '@internationalized/string': 3.2.9
-      '@react-types/shared': 3.34.0(react@19.2.6)
-      '@swc/helpers': 0.5.23
-      aria-hidden: 1.2.6
-      clsx: 2.1.1
-      react: 19.2.6
-      react-dom: 19.2.6(react@19.2.6)
-      react-stately: 3.46.0(react@19.2.6)
-      use-sync-external-store: 1.6.0(react@19.2.6)
-
   react-aria@3.49.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
       '@internationalized/date': 3.12.2
@@ -9075,16 +9034,6 @@ snapshots:
       set-cookie-parser: 2.7.2
     optionalDependencies:
       react-dom: 19.2.6(react@19.2.6)
-
-  react-stately@3.46.0(react@19.2.6):
-    dependencies:
-      '@internationalized/date': 3.12.1
-      '@internationalized/number': 3.6.7
-      '@internationalized/string': 3.2.9
-      '@react-types/shared': 3.34.0(react@19.2.6)
-      '@swc/helpers': 0.5.23
-      react: 19.2.6
-      use-sync-external-store: 1.6.0(react@19.2.6)
 
   react-stately@3.47.0(react@19.2.6):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -243,8 +243,8 @@ importers:
   packages/components:
     dependencies:
       '@internationalized/date':
-        specifier: 3.12.1
-        version: 3.12.1
+        specifier: 3.12.2
+        version: 3.12.2
       '@launchpad-ui/icons':
         specifier: workspace:~
         version: link:../icons
@@ -252,8 +252,8 @@ importers:
         specifier: workspace:~
         version: link:../tokens
       '@react-aria/live-announcer':
-        specifier: 3.5.0
-        version: 3.5.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: 3.5.1
+        version: 3.5.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       class-variance-authority:
         specifier: 0.7.0
         version: 0.7.0
@@ -262,20 +262,20 @@ importers:
         version: 7.59.0(react@19.2.6)
     devDependencies:
       '@react-aria/focus':
-        specifier: 3.22.0
-        version: 3.22.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: 3.22.1
+        version: 3.22.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@react-aria/interactions':
-        specifier: 3.28.0
-        version: 3.28.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: 3.28.1
+        version: 3.28.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@react-aria/utils':
-        specifier: 3.34.0
-        version: 3.34.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: 3.34.1
+        version: 3.34.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@react-stately/utils':
-        specifier: 3.12.0
-        version: 3.12.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: 3.12.1
+        version: 3.12.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@react-types/shared':
-        specifier: 3.34.0
-        version: 3.34.0(react@19.2.6)
+        specifier: 3.35.0
+        version: 3.35.0(react@19.2.6)
       copyfiles:
         specifier: 2.4.1
         version: 2.4.1
@@ -283,11 +283,11 @@ importers:
         specifier: 19.2.6
         version: 19.2.6
       react-aria:
-        specifier: 3.48.0
-        version: 3.48.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: 3.49.0
+        version: 3.49.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react-aria-components:
-        specifier: 1.17.0
-        version: 1.17.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: 1.18.0
+        version: 1.18.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react-dom:
         specifier: 19.2.6
         version: 19.2.6(react@19.2.6)
@@ -295,8 +295,8 @@ importers:
         specifier: 7.15.1
         version: 7.15.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react-stately:
-        specifier: 3.46.0
-        version: 3.46.0(react@19.2.6)
+        specifier: 3.47.0
+        version: 3.47.0(react@19.2.6)
 
   packages/core:
     dependencies:
@@ -381,8 +381,8 @@ importers:
         specifier: 19.2.6
         version: 19.2.6
       react-aria:
-        specifier: 3.48.0
-        version: 3.48.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: 3.49.0
+        version: 3.49.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react-dom:
         specifier: 19.2.6
         version: 19.2.6(react@19.2.6)
@@ -406,11 +406,11 @@ importers:
         version: 2.2.0
     devDependencies:
       '@react-aria/utils':
-        specifier: 3.34.0
-        version: 3.34.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: 3.34.1
+        version: 3.34.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@react-types/shared':
-        specifier: 3.34.0
-        version: 3.34.0(react@19.2.6)
+        specifier: 3.35.0
+        version: 3.35.0(react@19.2.6)
       react:
         specifier: 19.2.6
         version: 19.2.6
@@ -446,8 +446,8 @@ importers:
         specifier: 19.2.6
         version: 19.2.6
       react-aria:
-        specifier: 3.48.0
-        version: 3.48.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: 3.49.0
+        version: 3.49.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react-dom:
         specifier: 19.2.6
         version: 19.2.6(react@19.2.6)
@@ -458,8 +458,8 @@ importers:
         specifier: 19.2.6
         version: 19.2.6
       react-aria:
-        specifier: 3.48.0
-        version: 3.48.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: 3.49.0
+        version: 3.49.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react-dom:
         specifier: 19.2.6
         version: 19.2.6(react@19.2.6)
@@ -482,15 +482,15 @@ importers:
         specifier: 2.2.0
         version: 2.2.0
       react-stately:
-        specifier: 3.46.0
-        version: 3.46.0(react@19.2.6)
+        specifier: 3.47.0
+        version: 3.47.0(react@19.2.6)
     devDependencies:
       react:
         specifier: 19.2.6
         version: 19.2.6
       react-aria:
-        specifier: 3.48.0
-        version: 3.48.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: 3.49.0
+        version: 3.49.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react-dom:
         specifier: 19.2.6
         version: 19.2.6(react@19.2.6)
@@ -538,8 +538,8 @@ importers:
         specifier: 2.2.0
         version: 2.2.0
       react-aria:
-        specifier: 3.48.0
-        version: 3.48.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: 3.49.0
+        version: 3.49.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react-virtual:
         specifier: 2.10.4
         version: 2.10.4(react@19.2.6)
@@ -579,8 +579,8 @@ importers:
         specifier: 19.2.6
         version: 19.2.6
       react-aria:
-        specifier: 3.48.0
-        version: 3.48.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: 3.49.0
+        version: 3.49.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react-dom:
         specifier: 19.2.6
         version: 19.2.6(react@19.2.6)
@@ -613,11 +613,11 @@ importers:
         version: 2.2.0
     devDependencies:
       '@react-aria/utils':
-        specifier: 3.34.0
-        version: 3.34.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: 3.34.1
+        version: 3.34.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@react-types/shared':
-        specifier: 3.34.0
-        version: 3.34.0(react@19.2.6)
+        specifier: 3.35.0
+        version: 3.35.0(react@19.2.6)
       react:
         specifier: 19.2.6
         version: 19.2.6
@@ -628,8 +628,8 @@ importers:
         specifier: 7.15.1
         version: 7.15.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react-stately:
-        specifier: 3.46.0
-        version: 3.46.0(react@19.2.6)
+        specifier: 3.47.0
+        version: 3.47.0(react@19.2.6)
 
   packages/overlay:
     dependencies:
@@ -1281,6 +1281,9 @@ packages:
   '@internationalized/date@3.12.1':
     resolution: {integrity: sha512-6IedsVWXyq4P9Tj+TxuU8WGWM70hYLl12nbYU8jkikVpa6WXapFazPUcHUMDMoWftIDE2ILDkFFte6W2nFCkRQ==}
 
+  '@internationalized/date@3.12.2':
+    resolution: {integrity: sha512-FY1Y+H64NDs+HAF6omlnWxm3mEpfgaCSWtL5l551ZZfImA+kGjPFgrnJrGjH6lfmLL0g8Z/mBu1R3kufeCp6Jw==}
+
   '@internationalized/number@3.6.7':
     resolution: {integrity: sha512-3ji1fcrT+FPAK86UqEhB/psHixYo6niWPJtt7+qRaYFynt/BaJG8GhAPimtWUpEiVSTq8ZM8L5psMxGquiB/Vg==}
 
@@ -1689,38 +1692,43 @@ packages:
   '@reach/observe-rect@1.2.0':
     resolution: {integrity: sha512-Ba7HmkFgfQxZqqaeIWWkNK0rEhpxVQHIoVyW1YDSkGsGIXzcaW4deC8B0pZrNSSyLTdIk7y+5olKt5+g0GmFIQ==}
 
-  '@react-aria/focus@3.22.0':
-    resolution: {integrity: sha512-ZfDOVuVhqDsM9mkNji3QUZ/d40JhlVgXrDkrfXylM1035QCrcTHN7m2DpbE95sU2A8EQb4wikvt5jM6K/73BPg==}
+  '@react-aria/focus@3.22.1':
+    resolution: {integrity: sha512-CPxtkyrBi/HYY5P3lE/57sQ6qfa0lN8E55TOm89H0kNGv0lKt+/0zP7lWERzBjRr5IxBVrQX4gFEowBN52LPaA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  '@react-aria/interactions@3.28.0':
-    resolution: {integrity: sha512-OXwdU1EWFdMxmr/K1CXNGJzmNlCClByb+PuCaqUyzBymHPCGVhawirLIon/CrIN5psh3AiWpHSh4H0WeJdVpng==}
+  '@react-aria/interactions@3.28.1':
+    resolution: {integrity: sha512-Bqb+HrD5I5MHS2SKBhISYqo2SW8Y2dfzgF/Y1lIJq7xqLxheo9vzxPGEHhz+XzkgGfoqEJx8A6a3C7uiqS3HWA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  '@react-aria/live-announcer@3.5.0':
-    resolution: {integrity: sha512-1b+Txq00WQ/PJPCsZT+CI5qP86DrfFGPuJL5ifKtdMVXrxNGJWrfu7jTj6q9AbAOOXLG11BJ6blILu7sZeRPxg==}
+  '@react-aria/live-announcer@3.5.1':
+    resolution: {integrity: sha512-kLvwHjM3D7KgdquiAhUpRnMLKFrvl2r8naDXqPUlSWGRG15wsJRLhQOHLxGp0Umyg7KcSA+OD1mhQV5aRv0P1w==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  '@react-aria/utils@3.34.0':
-    resolution: {integrity: sha512-ZM1ZXIqpwGTJjjL6o3JhlZkEaBpQdxuOCqLEvwEwooaj5GsYI3E9UfOl5vy3UW6bYiEEWl9pNBntrb9CR9kItQ==}
+  '@react-aria/utils@3.34.1':
+    resolution: {integrity: sha512-H6+rGZL+0f58bBNaUMfctEnT+NogqwAk+nHiB8sR3K+YlQ37GTuCijy2U/pPvQtFMS5mURrjZeBH5JNNXsx14A==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  '@react-stately/utils@3.12.0':
-    resolution: {integrity: sha512-7q+iHz9cENvro1dVKgdTxNh1i1mtWuLUI6UHp10TAgpxM9DyRDvmuN35zLXYCmMDgx3WLY2xkwqoez8xd+CdxQ==}
+  '@react-stately/utils@3.12.1':
+    resolution: {integrity: sha512-NqKfzrknpfwiewx7R2vk1P+CneClInPDsIhw15+jOcUYSEfej0nta4cJywuKQJ2gsPwqX/ojDNixedCve9FWGw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
   '@react-types/shared@3.34.0':
     resolution: {integrity: sha512-gp6xo/s2lX54AlTjOiqwDnxA7UW79BNvI9dB9pr3LZTzRKCd1ZA+ZbgKw/ReIiWuvvVw/8QFJpnqeeFyLocMcQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@react-types/shared@3.35.0':
+    resolution: {integrity: sha512-iNWvuzEwANttpQpdlu8nPBtdHb0mcCMj1ZTH//iRB5E/14IAnyRlR25rxH7pNLyzHINsPGEKnWvpwDMCT6vziQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
@@ -4312,14 +4320,20 @@ packages:
       '@vanilla-extract/css': ^1
       '@vanilla-extract/dynamic': ^2
 
-  react-aria-components@1.17.0:
-    resolution: {integrity: sha512-0EyisMgvsFJ2aML3crDYv2tW5vT2Ryf8PGzY/g63JjDdCbLshlwazhS8JNtPF1vkTkungJJ6sVJbKyX+YKSoFA==}
+  react-aria-components@1.18.0:
+    resolution: {integrity: sha512-FhRQjuDkH4WhgFv+O2sYTzK3JzdZTGpBeaqfRlfTo+DcSZzD8elJEkytHe7SDpcexVKeire8NVd7OruZHfCVoA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
   react-aria@3.48.0:
     resolution: {integrity: sha512-jQjd4rBEIMqecBaAKYJbVGK6EqIHLa5znVQ7jwFyK5vCyljoj6KhgtiahmcIPsG5vG5vEDLw+ba+bEWn6A2P4w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  react-aria@3.49.0:
+    resolution: {integrity: sha512-4+oK9FwJQWYhyA5zLfj/feOGY0zZbkE1muoF4gyxMroHVypjcYaRSTlJwvxph2zIlxt757KX6xIK2wJ5Aw1Kog==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
@@ -4362,6 +4376,11 @@ packages:
 
   react-stately@3.46.0:
     resolution: {integrity: sha512-OdxhWvHgs2L4OJGIs7hnuTr5WjjMM6enhNEAMRqiekhF8+ITvA2LRwNftOZwcogaoCslGYq5S2VQTQwnm0GbCA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  react-stately@3.47.0:
+    resolution: {integrity: sha512-H3ar+SOWP920EbVg7qWfP3fZjZiwhlEJAEJQqjt+w8oKijCwFgr0+R4941PIHscOXRNRvEOjvWilitImC0DdBg==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
@@ -5908,6 +5927,10 @@ snapshots:
     dependencies:
       '@swc/helpers': 0.5.23
 
+  '@internationalized/date@3.12.2':
+    dependencies:
+      '@swc/helpers': 0.5.23
+
   '@internationalized/number@3.6.7':
     dependencies:
       '@swc/helpers': 0.5.23
@@ -6282,14 +6305,14 @@ snapshots:
 
   '@reach/observe-rect@1.2.0': {}
 
-  '@react-aria/focus@3.22.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@react-aria/focus@3.22.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@swc/helpers': 0.5.23
       react: 19.2.6
       react-aria: 3.48.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react-dom: 19.2.6(react@19.2.6)
 
-  '@react-aria/interactions@3.28.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@react-aria/interactions@3.28.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@react-types/shared': 3.34.0(react@19.2.6)
       '@swc/helpers': 0.5.23
@@ -6297,14 +6320,14 @@ snapshots:
       react-aria: 3.48.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react-dom: 19.2.6(react@19.2.6)
 
-  '@react-aria/live-announcer@3.5.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@react-aria/live-announcer@3.5.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@swc/helpers': 0.5.23
       react: 19.2.6
       react-aria: 3.48.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react-dom: 19.2.6(react@19.2.6)
 
-  '@react-aria/utils@3.34.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@react-aria/utils@3.34.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@swc/helpers': 0.5.23
       react: 19.2.6
@@ -6312,7 +6335,7 @@ snapshots:
       react-dom: 19.2.6(react@19.2.6)
       react-stately: 3.46.0(react@19.2.6)
 
-  '@react-stately/utils@3.12.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@react-stately/utils@3.12.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@swc/helpers': 0.5.23
       react: 19.2.6
@@ -6320,6 +6343,10 @@ snapshots:
       react-stately: 3.46.0(react@19.2.6)
 
   '@react-types/shared@3.34.0(react@19.2.6)':
+    dependencies:
+      react: 19.2.6
+
+  '@react-types/shared@3.35.0(react@19.2.6)':
     dependencies:
       react: 19.2.6
 
@@ -8970,16 +8997,16 @@ snapshots:
       '@vanilla-extract/css': 1.20.1
       '@vanilla-extract/dynamic': 2.1.2
 
-  react-aria-components@1.17.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+  react-aria-components@1.18.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
-      '@internationalized/date': 3.12.1
-      '@react-types/shared': 3.34.0(react@19.2.6)
+      '@internationalized/date': 3.12.2
+      '@react-types/shared': 3.35.0(react@19.2.6)
       '@swc/helpers': 0.5.23
       client-only: 0.0.1
       react: 19.2.6
-      react-aria: 3.48.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      react-aria: 3.49.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react-dom: 19.2.6(react@19.2.6)
-      react-stately: 3.46.0(react@19.2.6)
+      react-stately: 3.47.0(react@19.2.6)
 
   react-aria@3.48.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
@@ -8993,6 +9020,20 @@ snapshots:
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
       react-stately: 3.46.0(react@19.2.6)
+      use-sync-external-store: 1.6.0(react@19.2.6)
+
+  react-aria@3.49.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+    dependencies:
+      '@internationalized/date': 3.12.2
+      '@internationalized/number': 3.6.7
+      '@internationalized/string': 3.2.9
+      '@react-types/shared': 3.35.0(react@19.2.6)
+      '@swc/helpers': 0.5.23
+      aria-hidden: 1.2.6
+      clsx: 2.1.1
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+      react-stately: 3.47.0(react@19.2.6)
       use-sync-external-store: 1.6.0(react@19.2.6)
 
   react-docgen-typescript@2.4.0(typescript@5.9.3):
@@ -9041,6 +9082,16 @@ snapshots:
       '@internationalized/number': 3.6.7
       '@internationalized/string': 3.2.9
       '@react-types/shared': 3.34.0(react@19.2.6)
+      '@swc/helpers': 0.5.23
+      react: 19.2.6
+      use-sync-external-store: 1.6.0(react@19.2.6)
+
+  react-stately@3.47.0(react@19.2.6):
+    dependencies:
+      '@internationalized/date': 3.12.2
+      '@internationalized/number': 3.6.7
+      '@internationalized/string': 3.2.9
+      '@react-types/shared': 3.35.0(react@19.2.6)
       '@swc/helpers': 0.5.23
       react: 19.2.6
       use-sync-external-store: 1.6.0(react@19.2.6)


### PR DESCRIPTION
## Summary

Addresses [Devin's review feedback on #1914](https://github.com/launchdarkly/launchpad-ui/pull/1914): React Aria packages were sitting in `dependencies` in violation of the AGENTS.md rule *"React and React Aria belong in `peerDependencies`, not `dependencies`"*. Rather than just spot-fixing the two flagged lines, this audits the whole repo and adds tooling so the rule is enforced mechanically instead of relying on agents/reviewers to catch it.

**Manifest fixes** (the only 3 violations repo-wide):
- `@launchpad-ui/menu`: `react-aria` moved from `dependencies` → `peerDependencies` (+ `devDependencies`). It's imported directly (`react-aria/useSeparator`, `FocusRing`, `FocusScope`).
- `@launchpad-ui/form`: `react-stately` moved from `dependencies` → `peerDependencies` (+ `devDependencies`). Imported directly (`react-stately/useNumberFieldState`).
- `@launchpad-ui/components`: removed `@react-aria/live-announcer` — added in #1795 but **unused** (no references anywhere in the package; it dropped out of the lockfile entirely once removed).

Leaving these as direct deps risks duplicate React Aria copies being installed/bundled in consuming apps. No public API changes.

**Tooling enforcement** (the "don't rely on agents" part):
- `.syncpackrc`: a `isBanned` version group forbidding `react`, `react-dom`, `react-aria`, `react-aria-components`, `react-stately`, `react-router`, `react-hook-form`, and the `@react-aria` / `@react-stately` / `@react-types` scopes from `dependencies` (`prod`) only — they remain allowed in `peer`/`dev`. `@internationalized/*` is intentionally excluded (plain JS lib, legitimately a regular dep).
- syncpack already runs in **pre-commit** and **`postinstall`**, so this is enforced on every commit and install. Added an explicit **Dependency Policy** job to `verify.yml` for a clearly-attributed CI signal.
- `AGENTS.md`: documented that the rule is syncpack-enforced.

I confirmed the rule works by running `syncpack lint` *before* fixing the manifests — it flagged exactly the 3 violations; after the fixes it reports clean.

> Note: this PR is **stacked on `ag/chore/upgrade-react-aria-1.18.0`** (#1914) and targets that branch, so the diff is scoped to the dependency/tooling changes. Retarget to `main` if #1914 merges first.

## Screenshots (if appropriate)

N/A — dependency metadata and tooling only.

## Testing approaches

- `pnpm syncpack lint` — flags the 3 violations before the fix, clean after.
- `pnpm build` — all 21 projects build successfully.
- `pnpm typecheck` — passes (exit 0, no TS errors).
- `pnpm exec biome ci .` — clean (only pre-existing local `.claude/settings.local.json`, which is gitignored).
- `pnpm storybook` — Storybook 9.1.20 starts cleanly on :3000, story index serves HTTP 200, no errors.
- Pre-commit hook (lint-staged + `syncpack lint`) passed on commit.