### PR TITLE
chore: upgrade react-aria-components to 1.19.0

### DIFF
--- a/.changeset/upgrade-react-aria-1-19-0.md
+++ b/.changeset/upgrade-react-aria-1-19-0.md
@@ -1,0 +1,19 @@
+---
+"@launchpad-ui/components": patch
+"@launchpad-ui/focus-trap": patch
+"@launchpad-ui/navigation": patch
+"@launchpad-ui/dropdown": patch
+"@launchpad-ui/drawer": patch
+"@launchpad-ui/filter": patch
+"@launchpad-ui/modal": patch
+"@launchpad-ui/form": patch
+"@launchpad-ui/menu": patch
+---
+
+Upgrade `react-aria-components` to 1.19.0 along with the aligned `react-aria` (3.50.0), `react-stately` (3.48.0), and `@react-types/shared` (3.36.0) packages from the same release. The `@react-aria/*`, `@react-stately/*`, and `@internationalized/*` sub-packages were already at the matching versions and are unchanged.
+
+This release is additive — no breaking changes. Notable upstream additions:
+- `GridList` and `Tree` support full keyboard interaction with embedded text fields and other interactive elements via the `keyboardNavigationBehavior` prop.
+- `Autocomplete` and `Popover` gain inline-completion support, including a new `getTargetRect` prop on `Popover` for positioning overlays relative to arbitrary character positions.
+- `Menu`'s `onAction` callback now provides both the item key and its value.
+- `DragTypes.has()` accepts multiple MIME types and wildcards.

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -41,28 +41,28 @@
 		"@react-aria/interactions": "3.28.1",
 		"@react-aria/utils": "3.34.1",
 		"@react-stately/utils": "3.12.1",
-		"@react-types/shared": "3.35.0",
+		"@react-types/shared": "3.36.0",
 		"copyfiles": "2.4.1",
 		"react": "19.2.6",
-		"react-aria": "3.49.0",
-		"react-aria-components": "1.18.0",
+		"react-aria": "3.50.0",
+		"react-aria-components": "1.19.0",
 		"react-dom": "19.2.6",
 		"react-router": "7.15.1",
-		"react-stately": "3.47.0"
+		"react-stately": "3.48.0"
 	},
 	"peerDependencies": {
 		"@react-aria/focus": "3.22.1",
 		"@react-aria/interactions": "3.28.1",
 		"@react-aria/utils": "3.34.1",
 		"@react-stately/utils": "3.12.1",
-		"@react-types/shared": "3.35.0",
+		"@react-types/shared": "3.36.0",
 		"react": "19.2.6",
-		"react-aria": "3.49.0",
-		"react-aria-components": "1.18.0",
+		"react-aria": "3.50.0",
+		"react-aria-components": "1.19.0",
 		"react-dom": "19.2.6",
 		"react-hook-form": "7.59.0",
 		"react-router": "7.15.1",
-		"react-stately": "3.47.0"
+		"react-stately": "3.48.0"
 	},
 	"exports": {
 		".": {

--- a/packages/drawer/package.json
+++ b/packages/drawer/package.json
@@ -35,12 +35,12 @@
 	},
 	"devDependencies": {
 		"react": "19.2.6",
-		"react-aria": "3.49.0",
+		"react-aria": "3.50.0",
 		"react-dom": "19.2.6"
 	},
 	"peerDependencies": {
 		"react": "19.2.6",
-		"react-aria": "3.49.0",
+		"react-aria": "3.50.0",
 		"react-dom": "19.2.6"
 	},
 	"exports": {

--- a/packages/dropdown/package.json
+++ b/packages/dropdown/package.json
@@ -33,7 +33,7 @@
 	},
 	"devDependencies": {
 		"@react-aria/utils": "3.34.1",
-		"@react-types/shared": "3.35.0",
+		"@react-types/shared": "3.36.0",
 		"react": "19.2.6",
 		"react-dom": "19.2.6"
 	},

--- a/packages/filter/package.json
+++ b/packages/filter/package.json
@@ -34,12 +34,12 @@
 	},
 	"devDependencies": {
 		"react": "19.2.6",
-		"react-aria": "3.49.0",
+		"react-aria": "3.50.0",
 		"react-dom": "19.2.6"
 	},
 	"peerDependencies": {
 		"react": "19.2.6",
-		"react-aria": "3.49.0",
+		"react-aria": "3.50.0",
 		"react-dom": "19.2.6"
 	},
 	"exports": {

--- a/packages/focus-trap/package.json
+++ b/packages/focus-trap/package.json
@@ -24,12 +24,12 @@
 	},
 	"devDependencies": {
 		"react": "19.2.6",
-		"react-aria": "3.49.0",
+		"react-aria": "3.50.0",
 		"react-dom": "19.2.6"
 	},
 	"peerDependencies": {
 		"react": "19.2.6",
-		"react-aria": "3.49.0",
+		"react-aria": "3.50.0",
 		"react-dom": "19.2.6"
 	},
 	"exports": {

--- a/packages/form/package.json
+++ b/packages/form/package.json
@@ -29,16 +29,16 @@
 		"@launchpad-ui/tokens": "workspace:~",
 		"@launchpad-ui/tooltip": "workspace:~",
 		"classix": "2.2.0",
-		"react-stately": "3.47.0"
+		"react-stately": "3.48.0"
 	},
 	"devDependencies": {
 		"react": "19.2.6",
-		"react-aria": "3.49.0",
+		"react-aria": "3.50.0",
 		"react-dom": "19.2.6"
 	},
 	"peerDependencies": {
 		"react": "19.2.6",
-		"react-aria": "3.49.0",
+		"react-aria": "3.50.0",
 		"react-dom": "19.2.6"
 	},
 	"exports": {

--- a/packages/menu/package.json
+++ b/packages/menu/package.json
@@ -31,7 +31,7 @@
 		"@launchpad-ui/tooltip": "workspace:~",
 		"@radix-ui/react-slot": "1.2.0",
 		"classix": "2.2.0",
-		"react-aria": "3.49.0",
+		"react-aria": "3.50.0",
 		"react-virtual": "2.10.4"
 	},
 	"devDependencies": {

--- a/packages/modal/package.json
+++ b/packages/modal/package.json
@@ -34,12 +34,12 @@
 	},
 	"devDependencies": {
 		"react": "19.2.6",
-		"react-aria": "3.49.0",
+		"react-aria": "3.50.0",
 		"react-dom": "19.2.6"
 	},
 	"peerDependencies": {
 		"react": "19.2.6",
-		"react-aria": "3.49.0",
+		"react-aria": "3.50.0",
 		"react-dom": "19.2.6"
 	},
 	"exports": {

--- a/packages/navigation/package.json
+++ b/packages/navigation/package.json
@@ -35,18 +35,18 @@
 	},
 	"devDependencies": {
 		"@react-aria/utils": "3.34.1",
-		"@react-types/shared": "3.35.0",
+		"@react-types/shared": "3.36.0",
 		"react": "19.2.6",
 		"react-dom": "19.2.6",
 		"react-router": "7.15.1",
-		"react-stately": "3.47.0"
+		"react-stately": "3.48.0"
 	},
 	"peerDependencies": {
 		"@react-aria/utils": "3.34.1",
 		"react": "19.2.6",
 		"react-dom": "19.2.6",
 		"react-router": "7.15.1",
-		"react-stately": "3.47.0"
+		"react-stately": "3.48.0"
 	},
 	"exports": {
 		".": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -274,8 +274,8 @@ importers:
         specifier: 3.12.1
         version: 3.12.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@react-types/shared':
-        specifier: 3.35.0
-        version: 3.35.0(react@19.2.6)
+        specifier: 3.36.0
+        version: 3.36.0(react@19.2.6)
       copyfiles:
         specifier: 2.4.1
         version: 2.4.1
@@ -283,11 +283,11 @@ importers:
         specifier: 19.2.6
         version: 19.2.6
       react-aria:
-        specifier: 3.49.0
-        version: 3.49.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: 3.50.0
+        version: 3.50.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react-aria-components:
-        specifier: 1.18.0
-        version: 1.18.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: 1.19.0
+        version: 1.19.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react-dom:
         specifier: 19.2.6
         version: 19.2.6(react@19.2.6)
@@ -295,8 +295,8 @@ importers:
         specifier: 7.15.1
         version: 7.15.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react-stately:
-        specifier: 3.47.0
-        version: 3.47.0(react@19.2.6)
+        specifier: 3.48.0
+        version: 3.48.0(react@19.2.6)
 
   packages/core:
     dependencies:
@@ -381,8 +381,8 @@ importers:
         specifier: 19.2.6
         version: 19.2.6
       react-aria:
-        specifier: 3.49.0
-        version: 3.49.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: 3.50.0
+        version: 3.50.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react-dom:
         specifier: 19.2.6
         version: 19.2.6(react@19.2.6)
@@ -409,8 +409,8 @@ importers:
         specifier: 3.34.1
         version: 3.34.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@react-types/shared':
-        specifier: 3.35.0
-        version: 3.35.0(react@19.2.6)
+        specifier: 3.36.0
+        version: 3.36.0(react@19.2.6)
       react:
         specifier: 19.2.6
         version: 19.2.6
@@ -446,8 +446,8 @@ importers:
         specifier: 19.2.6
         version: 19.2.6
       react-aria:
-        specifier: 3.49.0
-        version: 3.49.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: 3.50.0
+        version: 3.50.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react-dom:
         specifier: 19.2.6
         version: 19.2.6(react@19.2.6)
@@ -458,8 +458,8 @@ importers:
         specifier: 19.2.6
         version: 19.2.6
       react-aria:
-        specifier: 3.49.0
-        version: 3.49.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: 3.50.0
+        version: 3.50.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react-dom:
         specifier: 19.2.6
         version: 19.2.6(react@19.2.6)
@@ -482,15 +482,15 @@ importers:
         specifier: 2.2.0
         version: 2.2.0
       react-stately:
-        specifier: 3.47.0
-        version: 3.47.0(react@19.2.6)
+        specifier: 3.48.0
+        version: 3.48.0(react@19.2.6)
     devDependencies:
       react:
         specifier: 19.2.6
         version: 19.2.6
       react-aria:
-        specifier: 3.49.0
-        version: 3.49.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: 3.50.0
+        version: 3.50.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react-dom:
         specifier: 19.2.6
         version: 19.2.6(react@19.2.6)
@@ -538,8 +538,8 @@ importers:
         specifier: 2.2.0
         version: 2.2.0
       react-aria:
-        specifier: 3.49.0
-        version: 3.49.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: 3.50.0
+        version: 3.50.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react-virtual:
         specifier: 2.10.4
         version: 2.10.4(react@19.2.6)
@@ -579,8 +579,8 @@ importers:
         specifier: 19.2.6
         version: 19.2.6
       react-aria:
-        specifier: 3.49.0
-        version: 3.49.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: 3.50.0
+        version: 3.50.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react-dom:
         specifier: 19.2.6
         version: 19.2.6(react@19.2.6)
@@ -616,8 +616,8 @@ importers:
         specifier: 3.34.1
         version: 3.34.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@react-types/shared':
-        specifier: 3.35.0
-        version: 3.35.0(react@19.2.6)
+        specifier: 3.36.0
+        version: 3.36.0(react@19.2.6)
       react:
         specifier: 19.2.6
         version: 19.2.6
@@ -628,8 +628,8 @@ importers:
         specifier: 7.15.1
         version: 7.15.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react-stately:
-        specifier: 3.47.0
-        version: 3.47.0(react@19.2.6)
+        specifier: 3.48.0
+        version: 3.48.0(react@19.2.6)
 
   packages/overlay:
     dependencies:
@@ -1719,8 +1719,8 @@ packages:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  '@react-types/shared@3.35.0':
-    resolution: {integrity: sha512-iNWvuzEwANttpQpdlu8nPBtdHb0mcCMj1ZTH//iRB5E/14IAnyRlR25rxH7pNLyzHINsPGEKnWvpwDMCT6vziQ==}
+  '@react-types/shared@3.36.0':
+    resolution: {integrity: sha512-DkP/H0C2YjjS7gZWKNqOmU8a16qHPjQNdzMwmTq9SzplM6Iw0kVMTZ0OIoe6FOgGqa+FwMsE2QbPjh/n3g/jXQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
@@ -2486,9 +2486,6 @@ packages:
   axe-core@4.11.4:
     resolution: {integrity: sha512-KunSNx+TVpkAw/6ULfhnx+HWRecjqZGTOyquAoWHYLRSdK1tB5Ihce1ZW+UY3fj33bYAFWPu7W/GRSmmrCGuxA==}
     engines: {node: '>=4'}
-
-  axios@1.16.1:
-    resolution: {integrity: sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==}
 
   axios@1.17.0:
     resolution: {integrity: sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw==}
@@ -4312,14 +4309,14 @@ packages:
       '@vanilla-extract/css': ^1
       '@vanilla-extract/dynamic': ^2
 
-  react-aria-components@1.18.0:
-    resolution: {integrity: sha512-FhRQjuDkH4WhgFv+O2sYTzK3JzdZTGpBeaqfRlfTo+DcSZzD8elJEkytHe7SDpcexVKeire8NVd7OruZHfCVoA==}
+  react-aria-components@1.19.0:
+    resolution: {integrity: sha512-2smSS5nqJ8cGYMQezuUXveZm7eMyHCqTN6mDpylQBYLYbdF5dxCCuW1DHn1VKLe1DybSfPvX/cZtJlDmvFfn8A==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  react-aria@3.49.0:
-    resolution: {integrity: sha512-4+oK9FwJQWYhyA5zLfj/feOGY0zZbkE1muoF4gyxMroHVypjcYaRSTlJwvxph2zIlxt757KX6xIK2wJ5Aw1Kog==}
+  react-aria@3.50.0:
+    resolution: {integrity: sha512-S0Os6QZk33fzUAKu1QLT9afoUaCBt1ZNdoiq0n2YMVgKIdNIQS8zxiZ8O9hYE6QyDkHKjD6q39LQZ+qaSAIgjw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
@@ -4360,8 +4357,8 @@ packages:
       react-dom:
         optional: true
 
-  react-stately@3.47.0:
-    resolution: {integrity: sha512-H3ar+SOWP920EbVg7qWfP3fZjZiwhlEJAEJQqjt+w8oKijCwFgr0+R4941PIHscOXRNRvEOjvWilitImC0DdBg==}
+  react-stately@3.48.0:
+    resolution: {integrity: sha512-ImicSAG+lTotAe5izcs1fz49Zk48w7pDusqYg04WaPhCoej8BJ24soMu3iLXIrsi273s4P1gZrYGrqReMfgEEA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
@@ -6286,40 +6283,40 @@ snapshots:
     dependencies:
       '@swc/helpers': 0.5.23
       react: 19.2.6
-      react-aria: 3.49.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      react-aria: 3.50.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react-dom: 19.2.6(react@19.2.6)
 
   '@react-aria/interactions@3.28.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
-      '@react-types/shared': 3.35.0(react@19.2.6)
+      '@react-types/shared': 3.36.0(react@19.2.6)
       '@swc/helpers': 0.5.23
       react: 19.2.6
-      react-aria: 3.49.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      react-aria: 3.50.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react-dom: 19.2.6(react@19.2.6)
 
   '@react-aria/live-announcer@3.5.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@swc/helpers': 0.5.23
       react: 19.2.6
-      react-aria: 3.49.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      react-aria: 3.50.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react-dom: 19.2.6(react@19.2.6)
 
   '@react-aria/utils@3.34.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@swc/helpers': 0.5.23
       react: 19.2.6
-      react-aria: 3.49.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      react-aria: 3.50.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react-dom: 19.2.6(react@19.2.6)
-      react-stately: 3.47.0(react@19.2.6)
+      react-stately: 3.48.0(react@19.2.6)
 
   '@react-stately/utils@3.12.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@swc/helpers': 0.5.23
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
-      react-stately: 3.47.0(react@19.2.6)
+      react-stately: 3.48.0(react@19.2.6)
 
-  '@react-types/shared@3.35.0(react@19.2.6)':
+  '@react-types/shared@3.36.0(react@19.2.6)':
     dependencies:
       react: 19.2.6
 
@@ -7074,16 +7071,6 @@ snapshots:
       possible-typed-array-names: 1.1.0
 
   axe-core@4.11.4: {}
-
-  axios@1.16.1:
-    dependencies:
-      follow-redirects: 1.16.0
-      form-data: 4.0.5
-      https-proxy-agent: 5.0.1
-      proxy-from-env: 2.1.0
-    transitivePeerDependencies:
-      - debug
-      - supports-color
 
   axios@1.17.0:
     dependencies:
@@ -8631,7 +8618,7 @@ snapshots:
       '@yarnpkg/lockfile': 1.1.0
       '@yarnpkg/parsers': 3.0.2
       '@zkochan/js-yaml': 0.0.7
-      axios: 1.16.1
+      axios: 1.17.0
       chalk: 4.1.2
       cli-cursor: 3.1.0
       cli-spinners: 2.6.1
@@ -8970,29 +8957,29 @@ snapshots:
       '@vanilla-extract/css': 1.20.1
       '@vanilla-extract/dynamic': 2.1.2
 
-  react-aria-components@1.18.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+  react-aria-components@1.19.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
       '@internationalized/date': 3.12.2
-      '@react-types/shared': 3.35.0(react@19.2.6)
+      '@react-types/shared': 3.36.0(react@19.2.6)
       '@swc/helpers': 0.5.23
       client-only: 0.0.1
       react: 19.2.6
-      react-aria: 3.49.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      react-aria: 3.50.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react-dom: 19.2.6(react@19.2.6)
-      react-stately: 3.47.0(react@19.2.6)
+      react-stately: 3.48.0(react@19.2.6)
 
-  react-aria@3.49.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+  react-aria@3.50.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
       '@internationalized/date': 3.12.2
       '@internationalized/number': 3.6.7
       '@internationalized/string': 3.2.9
-      '@react-types/shared': 3.35.0(react@19.2.6)
+      '@react-types/shared': 3.36.0(react@19.2.6)
       '@swc/helpers': 0.5.23
       aria-hidden: 1.2.6
       clsx: 2.1.1
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
-      react-stately: 3.47.0(react@19.2.6)
+      react-stately: 3.48.0(react@19.2.6)
       use-sync-external-store: 1.6.0(react@19.2.6)
 
   react-docgen-typescript@2.4.0(typescript@5.9.3):
@@ -9035,12 +9022,12 @@ snapshots:
     optionalDependencies:
       react-dom: 19.2.6(react@19.2.6)
 
-  react-stately@3.47.0(react@19.2.6):
+  react-stately@3.48.0(react@19.2.6):
     dependencies:
       '@internationalized/date': 3.12.2
       '@internationalized/number': 3.6.7
       '@internationalized/string': 3.2.9
-      '@react-types/shared': 3.35.0(react@19.2.6)
+      '@react-types/shared': 3.36.0(react@19.2.6)
       '@swc/helpers': 0.5.23
       react: 19.2.6
       use-sync-external-store: 1.6.0(react@19.2.6)


### PR DESCRIPTION
> [!NOTE]
> ~~Do not merge until we've met the repo's 7-day minimum-release age policy, on June 25, 2026.~~ Good to go!

## Summary

Upgrades `react-aria-components` from **1.18.0 → 1.19.0**, along with the aligned packages from the same upstream release:

- `react-aria`: 3.49.0 → 3.50.0
- `react-stately`: 3.47.0 → 3.48.0
- `@react-types/shared`: 3.35.0 → 3.36.0

The `@react-aria/*`, `@react-stately/utils`, and `@internationalized/date` sub-packages were already pinned at the versions that ship with this release, so they're unchanged. Bumps are applied to both `dependencies`/`devDependencies` and `peerDependencies` across all nine affected packages (`components`, `drawer`, `dropdown`, `filter`, `focus-trap`, `form`, `menu`, `modal`, `navigation`).

`pnpm dedupe` was run so `react-aria`, `react-stately`, and `@react-types/shared` each resolve to a **single instance** (3.50.0 / 3.48.0 / 3.36.0). Without it, the `@react-aria/*` shims' floating `^3.48.0` range keeps the prior 3.49.0 copy in the tree, yielding duplicate `PressResponderContext` / `FocusableContext` instances that break `aria-disabled` propagation (`Perceivable.spec.tsx`) — the same regression encountered in the 1.18.0 bump (#1914).

This is a purely additive upstream release — no breaking changes — so no component code changes were required. Notable upstream additions (not yet surfaced by LaunchPad): `keyboardNavigationBehavior` for `GridList`/`Tree`, inline-completion support + `getTargetRect` on `Popover`/`Autocomplete`, `Menu` `onAction` now passing the item value, and `DragTypes.has()` wildcard matching.

## Screenshots (if appropriate)

N/A — dependency-only upgrade with no intended visual change. Chromatic will confirm no visual regressions.

## Testing approaches

- `pnpm typecheck` — clean (0 diagnostics)
- `pnpm test` — **268/268 unit tests pass**, coverage above thresholds; `Perceivable.spec.tsx` (the duplicate-context canary) passes
- `pnpm build` — all 21 projects build successfully
- `biome check` — clean on all changed files
- Verified the dependency tree resolves to a single copy of `react-aria@3.50.0` / `react-stately@3.48.0` / `@react-types/shared@3.36.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wide dependency bump across accessibility-focused UI packages can change focus, keyboard, and disabled-state behavior at runtime even without local code edits; lockfile dedupe is important to avoid duplicate react-aria context instances.
> 
> **Overview**
> This PR **aligns the monorepo on React Aria 1.19.0** by bumping `react-aria-components` (1.18.0 → 1.19.0), `react-aria` (3.49.0 → 3.50.0), `react-stately` (3.47.0 → 3.48.0), and `@react-types/shared` (3.35.0 → 3.36.0) in **devDependencies**, **peerDependencies**, and where applicable **dependencies** for `@launchpad-ui/components`, `drawer`, `dropdown`, `filter`, `focus-trap`, `form`, `menu`, `modal`, and `navigation`.
> 
> A **changeset** records patch releases for those packages and notes upstream additive features (e.g. `keyboardNavigationBehavior`, Popover `getTargetRect`, Menu `onAction` value). **`pnpm-lock.yaml`** is refreshed so the tree resolves to a single copy of the upgraded packages (and drops an unused `axios@1.16.1` entry in favor of 1.17.0 via nx). **No LaunchPad component or test source files are modified** in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14d56ea23b2980ad5bdcdd43da66a5979be6e6c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->