### PR TITLE
feat(components): [DSYS-194] add description and errorMessage props to field components

### DIFF
--- a/.changeset/field-description-prop.md
+++ b/.changeset/field-description-prop.md
@@ -1,0 +1,7 @@
+---
+"@launchpad-ui/components": minor
+---
+
+Add ergonomic `description` and `errorMessage` props to field components: `TextField`, `NumberField`, `SearchField`, `Select`, `ComboBox`, `RadioGroup`, `CheckboxGroup`, `DateField`, and `TimeField`.
+
+These render the React Aria `description` slot (`<Text slot="description">`) and `FieldError` internally, matching the Figma library's flat `description` property and resolving the Code Connect drift. The change is additive and non-breaking: passing helper text as `<Text slot="description">` / `<FieldError>` children remains fully supported.

--- a/packages/components/figma/CheckboxGroup.figma.tsx
+++ b/packages/components/figma/CheckboxGroup.figma.tsx
@@ -25,7 +25,7 @@ figma.connect(
 		example: (props) => (
 			<>
 				{props.label}
-				<CheckboxGroup>{props.children}</CheckboxGroup>
+				<CheckboxGroup description={props.description}>{props.children}</CheckboxGroup>
 			</>
 		),
 	},

--- a/packages/components/figma/DateField.figma.tsx
+++ b/packages/components/figma/DateField.figma.tsx
@@ -11,17 +11,17 @@ figma.connect(
 				true: figma.children(['Label']),
 				false: undefined,
 			}),
-			helpText: figma.boolean('Help text?', {
+			description: figma.boolean('Help text?', {
 				true: figma.string('Help text'),
 				false: undefined,
 			}),
 			isInvalid: figma.enum('State', { Invalid: true }),
 			isDisabled: figma.enum('State', { Disabled: true }),
 		},
-		example: ({ label, isInvalid, isDisabled }) => (
+		example: ({ label, isInvalid, isDisabled, description }) => (
 			<>
 				{label}
-				<DateField isInvalid={isInvalid} isDisabled={isDisabled} />
+				<DateField isInvalid={isInvalid} isDisabled={isDisabled} description={description} />
 			</>
 		),
 	},

--- a/packages/components/figma/NumberField.figma.tsx
+++ b/packages/components/figma/NumberField.figma.tsx
@@ -11,11 +11,20 @@ figma.connect(
 				true: 10,
 				false: undefined,
 			}),
+			description: figma.boolean('Description?', {
+				true: figma.string('Description'),
+				false: undefined,
+			}),
 			isInvalid: figma.enum('State', { Invalid: true }),
 			isDisabled: figma.enum('State', { Disabled: true }),
 		},
-		example: ({ isInvalid, isDisabled, defaultValue }) => (
-			<NumberField isInvalid={isInvalid} isDisabled={isDisabled} defaultValue={defaultValue} />
+		example: ({ isInvalid, isDisabled, defaultValue, description }) => (
+			<NumberField
+				isInvalid={isInvalid}
+				isDisabled={isDisabled}
+				defaultValue={defaultValue}
+				description={description}
+			/>
 		),
 	},
 );
@@ -34,13 +43,22 @@ figma.connect(
 				true: 10,
 				false: undefined,
 			}),
+			description: figma.boolean('Description?', {
+				true: figma.string('Description'),
+				false: undefined,
+			}),
 			isInvalid: figma.enum('State', { Invalid: true }),
 			isDisabled: figma.enum('State', { Disabled: true }),
 		},
-		example: ({ isInvalid, isDisabled, defaultValue, label }) => (
+		example: ({ isInvalid, isDisabled, defaultValue, label, description }) => (
 			<>
 				{label}
-				<NumberField isInvalid={isInvalid} isDisabled={isDisabled} defaultValue={defaultValue} />
+				<NumberField
+					isInvalid={isInvalid}
+					isDisabled={isDisabled}
+					defaultValue={defaultValue}
+					description={description}
+				/>
 			</>
 		),
 	},

--- a/packages/components/figma/RadioGroup.figma.tsx
+++ b/packages/components/figma/RadioGroup.figma.tsx
@@ -11,10 +11,14 @@ figma.connect(
 				true: figma.children(['Label']),
 				false: undefined,
 			}),
+			description: figma.boolean('Description?', {
+				true: figma.string('Description'),
+				false: undefined,
+			}),
 			radios: figma.children(['.Radio']),
 		},
-		example: ({ label, radios }) => (
-			<RadioGroup defaultValue="1">
+		example: ({ label, radios, description }) => (
+			<RadioGroup defaultValue="1" description={description}>
 				{label}
 				<ButtonGroup role="presentation" spacing="compact">
 					{radios}

--- a/packages/components/figma/SearchField.figma.tsx
+++ b/packages/components/figma/SearchField.figma.tsx
@@ -11,11 +11,15 @@ figma.connect(
 				true: figma.children(['Label']),
 				false: undefined,
 			}),
+			description: figma.boolean('Description?', {
+				true: figma.string('Description'),
+				false: undefined,
+			}),
 			isInvalid: figma.enum('State', { Invalid: true }),
 			isDisabled: figma.enum('State', { Disabled: true }),
 		},
-		example: ({ label, isInvalid, isDisabled }) => (
-			<SearchField isInvalid={isInvalid} isDisabled={isDisabled}>
+		example: ({ label, isInvalid, isDisabled, description }) => (
+			<SearchField isInvalid={isInvalid} isDisabled={isDisabled} description={description}>
 				{label}
 				<Group>
 					{/* <Icon name="search" size="small" /> */}

--- a/packages/components/figma/Select.figma.tsx
+++ b/packages/components/figma/Select.figma.tsx
@@ -14,9 +14,17 @@ figma.connect(
 				true: 'Select an option',
 				false: undefined,
 			}),
+			description: figma.boolean('Description?', {
+				true: figma.string('Description'),
+				false: undefined,
+			}),
 		},
-		example: ({ label }) => (
-			<Select selectedKey="1" onSelectionChange={(key) => console.log(key)}>
+		example: ({ label, description }) => (
+			<Select
+				selectedKey="1"
+				onSelectionChange={(key) => console.log(key)}
+				description={description}
+			>
 				{label}
 				<Button>
 					<SelectValue />

--- a/packages/components/figma/TextField.figma.tsx
+++ b/packages/components/figma/TextField.figma.tsx
@@ -19,6 +19,10 @@ figma.connect(
 				true: figma.textContent('Value'),
 				false: undefined,
 			}),
+			description: figma.boolean('Description?', {
+				true: figma.textContent('Description'),
+				false: undefined,
+			}),
 			multiline: figma.boolean('Multi Line'),
 			variant: figma.boolean('Minimal', {
 				true: 'minimal',
@@ -32,9 +36,9 @@ figma.connect(
 			isDisabled: figma.enum('State', { Disabled: true }),
 			validationMessage: figma.textContent('Validation message'),
 		},
-		example: ({ children, variant, placeholder, value, isDisabled }) => {
+		example: ({ children, variant, placeholder, value, isDisabled, description }) => {
 			return (
-				<TextField isDisabled={isDisabled}>
+				<TextField isDisabled={isDisabled} description={description}>
 					{children}
 					<Input variant={variant} placeholder={placeholder} value={value} />
 				</TextField>
@@ -66,6 +70,10 @@ figma.connect(
 				true: figma.textContent('Value'),
 				false: undefined,
 			}),
+			description: figma.boolean('Description?', {
+				true: figma.textContent('Description'),
+				false: undefined,
+			}),
 			isDisabled: figma.enum('State', { Disabled: true }),
 			validationMessage: figma.textContent('Validation message'),
 		},
@@ -77,9 +85,10 @@ figma.connect(
 			isDisabled,
 			isInvalid,
 			validationMessage,
+			description,
 		}) => {
 			return (
-				<TextField isDisabled={isDisabled} isInvalid={isInvalid}>
+				<TextField isDisabled={isDisabled} isInvalid={isInvalid} description={description}>
 					{children}
 					<Input variant={variant} placeholder={placeholder} value={value} />
 					<FieldError>{validationMessage}</FieldError>
@@ -107,11 +116,15 @@ figma.connect(
 				true: figma.textContent('Value'),
 				false: undefined,
 			}),
+			description: figma.boolean('Description?', {
+				true: figma.textContent('Description'),
+				false: undefined,
+			}),
 			isDisabled: figma.enum('State', { Disabled: true }),
 		},
-		example: ({ children, placeholder, value, isDisabled }) => {
+		example: ({ children, placeholder, value, isDisabled, description }) => {
 			return (
-				<TextField isDisabled={isDisabled}>
+				<TextField isDisabled={isDisabled} description={description}>
 					{children}
 					<TextArea placeholder={placeholder} value={value} />
 				</TextField>
@@ -136,12 +149,24 @@ figma.connect(
 				false: undefined,
 			}),
 			value: figma.textContent('Value'),
+			description: figma.boolean('Description?', {
+				true: figma.textContent('Description'),
+				false: undefined,
+			}),
 			isDisabled: figma.enum('State', { Disabled: true }),
 			validationMessage: figma.textContent('Validation message'),
 		},
-		example: ({ children, placeholder, value, isDisabled, isInvalid, validationMessage }) => {
+		example: ({
+			children,
+			placeholder,
+			value,
+			isDisabled,
+			isInvalid,
+			validationMessage,
+			description,
+		}) => {
 			return (
-				<TextField isDisabled={isDisabled} isInvalid={isInvalid}>
+				<TextField isDisabled={isDisabled} isInvalid={isInvalid} description={description}>
 					{children}
 					<TextArea placeholder={placeholder} value={value} />
 					<FieldError>{validationMessage}</FieldError>

--- a/packages/components/src/CheckboxGroup.tsx
+++ b/packages/components/src/CheckboxGroup.tsx
@@ -7,12 +7,13 @@ import { createContext } from 'react';
 import { CheckboxGroup as AriaCheckboxGroup } from 'react-aria-components/CheckboxGroup';
 import { composeRenderProps } from 'react-aria-components/composeRenderProps';
 
+import { type FieldHelperProps, renderFieldHelpers } from './fieldHelpers';
 import styles from './styles/CheckboxGroup.module.css';
 import { useLPContextProps } from './utils';
 
 const checkboxGroupStyles = cva(styles.group);
 
-interface CheckboxGroupProps extends AriaCheckboxGroupProps {
+interface CheckboxGroupProps extends AriaCheckboxGroupProps, FieldHelperProps {
 	ref?: Ref<HTMLDivElement>;
 }
 
@@ -23,7 +24,7 @@ const CheckboxGroupContext = createContext<ContextValue<CheckboxGroupProps, HTML
  *
  * https://react-spectrum.adobe.com/react-aria/CheckboxGroup.html
  */
-const CheckboxGroup = ({ ref, ...props }: CheckboxGroupProps) => {
+const CheckboxGroup = ({ ref, description, errorMessage, ...props }: CheckboxGroupProps) => {
 	[props, ref] = useLPContextProps(props, ref, CheckboxGroupContext);
 	return (
 		<AriaCheckboxGroup
@@ -32,7 +33,11 @@ const CheckboxGroup = ({ ref, ...props }: CheckboxGroupProps) => {
 			className={composeRenderProps(props.className, (className, renderProps) =>
 				checkboxGroupStyles({ ...renderProps, className }),
 			)}
-		/>
+		>
+			{composeRenderProps(props.children, (children) =>
+				renderFieldHelpers(children, { description, errorMessage }),
+			)}
+		</AriaCheckboxGroup>
 	);
 };
 

--- a/packages/components/src/ComboBox.tsx
+++ b/packages/components/src/ComboBox.tsx
@@ -11,6 +11,7 @@ import { composeRenderProps } from 'react-aria-components/composeRenderProps';
 import { GroupContext } from 'react-aria-components/Group';
 import { Provider } from 'react-aria-components/slots';
 
+import { type FieldHelperProps, renderFieldHelpers } from './fieldHelpers';
 import { IconButton } from './IconButton';
 import { PopoverContext } from './Popover';
 import styles from './styles/ComboBox.module.css';
@@ -18,7 +19,7 @@ import { useLPContextProps } from './utils';
 
 const comboBoxStyles = cva(styles.box);
 
-interface ComboBoxProps<T extends object> extends AriaComboBoxProps<T> {
+interface ComboBoxProps<T extends object> extends AriaComboBoxProps<T>, FieldHelperProps {
 	ref?: Ref<HTMLDivElement>;
 }
 
@@ -32,7 +33,12 @@ const ComboBoxContext = createContext<ContextValue<ComboBoxProps<any>, HTMLDivEl
  *
  * https://react-spectrum.adobe.com/react-aria/ComboBox.html
  */
-const ComboBox = <T extends object>({ ref, ...props }: ComboBoxProps<T>) => {
+const ComboBox = <T extends object>({
+	ref,
+	description,
+	errorMessage,
+	...props
+}: ComboBoxProps<T>) => {
 	[props, ref] = useLPContextProps(props, ref, ComboBoxContext);
 	const { menuTrigger = 'focus' } = props;
 	const groupRef = useRef<HTMLDivElement>(null);
@@ -72,7 +78,7 @@ const ComboBox = <T extends object>({ ref, ...props }: ComboBoxProps<T>) => {
 						],
 					]}
 				>
-					{children}
+					{renderFieldHelpers(children, { description, errorMessage })}
 				</Provider>
 			))}
 		</AriaComboBox>

--- a/packages/components/src/DateField.tsx
+++ b/packages/components/src/DateField.tsx
@@ -21,6 +21,7 @@ import {
 } from 'react-aria-components/DateField';
 import { TimeField as AriaTimeField } from 'react-aria-components/TimeField';
 
+import { type FieldHelperProps, renderFieldHelpers } from './fieldHelpers';
 import styles from './styles/DateField.module.css';
 import { useLPContextProps } from './utils';
 
@@ -28,7 +29,7 @@ const dateFieldStyles = cva(styles.field);
 const dateInputStyles = cva(styles.input);
 const dateSegmentStyles = cva(styles.segment);
 
-interface DateFieldProps<T extends DateValue> extends AriaDateFieldProps<T> {
+interface DateFieldProps<T extends DateValue> extends AriaDateFieldProps<T>, FieldHelperProps {
 	ref?: Ref<HTMLDivElement>;
 }
 
@@ -40,7 +41,7 @@ interface DateSegmentProps extends AriaDateSegmentProps {
 	ref?: Ref<HTMLDivElement>;
 }
 
-interface TimeFieldProps<T extends TimeValue> extends AriaTimeFieldProps<T> {
+interface TimeFieldProps<T extends TimeValue> extends AriaTimeFieldProps<T>, FieldHelperProps {
 	ref?: Ref<HTMLDivElement>;
 }
 
@@ -54,7 +55,12 @@ const TimeFieldContext =
  *
  * https://react-spectrum.adobe.com/react-aria/DateField.html
  */
-const DateField = <T extends DateValue>({ ref, ...props }: DateFieldProps<T>) => {
+const DateField = <T extends DateValue>({
+	ref,
+	description,
+	errorMessage,
+	...props
+}: DateFieldProps<T>) => {
 	[props, ref] = useLPContextProps(props, ref, DateFieldContext);
 	return (
 		<AriaDateField
@@ -63,7 +69,11 @@ const DateField = <T extends DateValue>({ ref, ...props }: DateFieldProps<T>) =>
 			className={composeRenderProps(props.className, (className, renderProps) =>
 				dateFieldStyles({ ...renderProps, className }),
 			)}
-		/>
+		>
+			{composeRenderProps(props.children, (children) =>
+				renderFieldHelpers(children, { description, errorMessage }),
+			)}
+		</AriaDateField>
 	);
 };
 
@@ -106,7 +116,12 @@ const DateSegment = ({ ref, ...props }: DateSegmentProps) => {
  *
  * https://react-spectrum.adobe.com/react-aria/TimeField.html
  */
-const TimeField = <T extends TimeValue>({ ref, ...props }: TimeFieldProps<T>) => {
+const TimeField = <T extends TimeValue>({
+	ref,
+	description,
+	errorMessage,
+	...props
+}: TimeFieldProps<T>) => {
 	[props, ref] = useLPContextProps(props, ref, TimeFieldContext);
 	return (
 		<AriaTimeField
@@ -115,7 +130,11 @@ const TimeField = <T extends TimeValue>({ ref, ...props }: TimeFieldProps<T>) =>
 			className={composeRenderProps(props.className, (className, renderProps) =>
 				dateFieldStyles({ ...renderProps, className }),
 			)}
-		/>
+		>
+			{composeRenderProps(props.children, (children) =>
+				renderFieldHelpers(children, { description, errorMessage }),
+			)}
+		</AriaTimeField>
 	);
 };
 

--- a/packages/components/src/NumberField.tsx
+++ b/packages/components/src/NumberField.tsx
@@ -7,12 +7,13 @@ import { createContext } from 'react';
 import { composeRenderProps } from 'react-aria-components/composeRenderProps';
 import { NumberField as AriaNumberField } from 'react-aria-components/NumberField';
 
+import { type FieldHelperProps, renderFieldHelpers } from './fieldHelpers';
 import styles from './styles/NumberField.module.css';
 import { useLPContextProps } from './utils';
 
 const numberFieldStyles = cva(styles.number);
 
-interface NumberFieldProps extends AriaNumberFieldProps {
+interface NumberFieldProps extends AriaNumberFieldProps, FieldHelperProps {
 	ref?: Ref<HTMLDivElement>;
 }
 
@@ -23,7 +24,7 @@ const NumberFieldContext = createContext<ContextValue<NumberFieldProps, HTMLDivE
  *
  * https://react-spectrum.adobe.com/react-aria/NumberField.html
  */
-const NumberField = ({ ref, ...props }: NumberFieldProps) => {
+const NumberField = ({ ref, description, errorMessage, ...props }: NumberFieldProps) => {
 	[props, ref] = useLPContextProps(props, ref, NumberFieldContext);
 	const {
 		formatOptions = {
@@ -40,7 +41,11 @@ const NumberField = ({ ref, ...props }: NumberFieldProps) => {
 			className={composeRenderProps(props.className, (className, renderProps) =>
 				numberFieldStyles({ ...renderProps, className }),
 			)}
-		/>
+		>
+			{composeRenderProps(props.children, (children) =>
+				renderFieldHelpers(children, { description, errorMessage }),
+			)}
+		</AriaNumberField>
 	);
 };
 

--- a/packages/components/src/RadioGroup.tsx
+++ b/packages/components/src/RadioGroup.tsx
@@ -7,12 +7,13 @@ import { createContext } from 'react';
 import { composeRenderProps } from 'react-aria-components/composeRenderProps';
 import { RadioGroup as AriaRadioGroup } from 'react-aria-components/RadioGroup';
 
+import { type FieldHelperProps, renderFieldHelpers } from './fieldHelpers';
 import styles from './styles/RadioGroup.module.css';
 import { useLPContextProps } from './utils';
 
 const radioGroupStyles = cva(styles.group);
 
-interface RadioGroupProps extends AriaRadioGroupProps {
+interface RadioGroupProps extends AriaRadioGroupProps, FieldHelperProps {
 	ref?: Ref<HTMLDivElement>;
 }
 
@@ -23,7 +24,7 @@ const RadioGroupContext = createContext<ContextValue<RadioGroupProps, HTMLDivEle
  *
  * https://react-spectrum.adobe.com/react-aria/RadioGroup.html
  */
-const RadioGroup = ({ ref, ...props }: RadioGroupProps) => {
+const RadioGroup = ({ ref, description, errorMessage, ...props }: RadioGroupProps) => {
 	[props, ref] = useLPContextProps(props, ref, RadioGroupContext);
 	return (
 		<AriaRadioGroup
@@ -32,7 +33,11 @@ const RadioGroup = ({ ref, ...props }: RadioGroupProps) => {
 			className={composeRenderProps(props.className, (className, renderProps) =>
 				radioGroupStyles({ ...renderProps, className }),
 			)}
-		/>
+		>
+			{composeRenderProps(props.children, (children) =>
+				renderFieldHelpers(children, { description, errorMessage }),
+			)}
+		</AriaRadioGroup>
 	);
 };
 

--- a/packages/components/src/SearchField.tsx
+++ b/packages/components/src/SearchField.tsx
@@ -7,12 +7,13 @@ import { createContext } from 'react';
 import { composeRenderProps } from 'react-aria-components/composeRenderProps';
 import { SearchField as AriaSearchField } from 'react-aria-components/SearchField';
 
+import { type FieldHelperProps, renderFieldHelpers } from './fieldHelpers';
 import styles from './styles/SearchField.module.css';
 import { useLPContextProps } from './utils';
 
 const searchFieldStyles = cva(styles.search);
 
-interface SearchFieldProps extends AriaSearchFieldProps {
+interface SearchFieldProps extends AriaSearchFieldProps, FieldHelperProps {
 	ref?: Ref<HTMLDivElement>;
 }
 
@@ -23,7 +24,7 @@ const SearchFieldContext = createContext<ContextValue<SearchFieldProps, HTMLDivE
  *
  * https://react-spectrum.adobe.com/react-aria/SearchField.html
  */
-const SearchField = ({ ref, ...props }: SearchFieldProps) => {
+const SearchField = ({ ref, description, errorMessage, ...props }: SearchFieldProps) => {
 	[props, ref] = useLPContextProps(props, ref, SearchFieldContext);
 	return (
 		<AriaSearchField
@@ -32,7 +33,11 @@ const SearchField = ({ ref, ...props }: SearchFieldProps) => {
 			className={composeRenderProps(props.className, (className, renderProps) =>
 				searchFieldStyles({ ...renderProps, className }),
 			)}
-		/>
+		>
+			{composeRenderProps(props.children, (children) =>
+				renderFieldHelpers(children, { description, errorMessage }),
+			)}
+		</AriaSearchField>
 	);
 };
 

--- a/packages/components/src/Select.tsx
+++ b/packages/components/src/Select.tsx
@@ -12,6 +12,7 @@ import { Select as AriaSelect, SelectValue as AriaSelectValue } from 'react-aria
 import { Provider } from 'react-aria-components/slots';
 
 import { ButtonContext } from './Button';
+import { type FieldHelperProps, renderFieldHelpers } from './fieldHelpers';
 import baseStyles from './styles/base.module.css';
 import styles from './styles/Select.module.css';
 import { useLPContextProps } from './utils';
@@ -19,7 +20,7 @@ import { useLPContextProps } from './utils';
 const selectStyles = cva(styles.select);
 const selectValueStyles = cva(styles.value);
 
-interface SelectProps<T extends object> extends AriaSelectProps<T> {
+interface SelectProps<T extends object> extends AriaSelectProps<T>, FieldHelperProps {
 	ref?: Ref<HTMLDivElement>;
 }
 
@@ -38,7 +39,7 @@ const SelectValueContext =
  *
  * https://react-spectrum.adobe.com/react-aria/Select.html
  */
-const Select = <T extends object>({ ref, ...props }: SelectProps<T>) => {
+const Select = <T extends object>({ ref, description, errorMessage, ...props }: SelectProps<T>) => {
 	[props, ref] = useLPContextProps(props, ref, SelectContext);
 	return (
 		<AriaSelect
@@ -61,7 +62,7 @@ const Select = <T extends object>({ ref, ...props }: SelectProps<T>) => {
 						],
 					]}
 				>
-					{children}
+					{renderFieldHelpers(children, { description, errorMessage })}
 				</Provider>
 			))}
 		</AriaSelect>

--- a/packages/components/src/TextField.tsx
+++ b/packages/components/src/TextField.tsx
@@ -9,12 +9,13 @@ import { GroupContext } from 'react-aria-components/Group';
 import { Provider } from 'react-aria-components/slots';
 import { TextField as AriaTextField } from 'react-aria-components/TextField';
 
+import { type FieldHelperProps, renderFieldHelpers } from './fieldHelpers';
 import styles from './styles/TextField.module.css';
 import { useLPContextProps } from './utils';
 
 const textFieldStyles = cva(styles.field);
 
-interface TextFieldProps extends AriaTextFieldProps {
+interface TextFieldProps extends AriaTextFieldProps, FieldHelperProps {
 	ref?: Ref<HTMLDivElement>;
 }
 
@@ -25,7 +26,7 @@ const TextFieldContext = createContext<ContextValue<TextFieldProps, HTMLDivEleme
  *
  * https://react-spectrum.adobe.com/react-aria/TextField.html
  */
-const TextField = ({ ref, ...props }: TextFieldProps) => {
+const TextField = ({ ref, description, errorMessage, ...props }: TextFieldProps) => {
 	[props, ref] = useLPContextProps(props, ref, TextFieldContext);
 	return (
 		<AriaTextField
@@ -36,7 +37,9 @@ const TextField = ({ ref, ...props }: TextFieldProps) => {
 			)}
 		>
 			{composeRenderProps(props.children, (children, { isInvalid, isDisabled }) => (
-				<Provider values={[[GroupContext, { isInvalid, isDisabled }]]}>{children}</Provider>
+				<Provider values={[[GroupContext, { isInvalid, isDisabled }]]}>
+					{renderFieldHelpers(children, { description, errorMessage })}
+				</Provider>
 			))}
 		</AriaTextField>
 	);

--- a/packages/components/src/fieldHelpers.tsx
+++ b/packages/components/src/fieldHelpers.tsx
@@ -1,0 +1,25 @@
+import type { ReactNode } from 'react';
+
+import { FieldError } from './FieldError';
+import { Text } from './Text';
+
+interface FieldHelperProps {
+	/** Helper text describing the field, rendered below the input. */
+	description?: ReactNode;
+	/** Error message shown when the field is invalid. */
+	errorMessage?: ReactNode;
+}
+
+const renderFieldHelpers = (
+	children: ReactNode,
+	{ description, errorMessage }: FieldHelperProps,
+) => (
+	<>
+		{children}
+		{description != null && <Text slot="description">{description}</Text>}
+		{errorMessage != null && <FieldError>{errorMessage}</FieldError>}
+	</>
+);
+
+export { renderFieldHelpers };
+export type { FieldHelperProps };

--- a/packages/components/stories/TextField.stories.tsx
+++ b/packages/components/stories/TextField.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import type { ComponentType } from 'react';
 
 import { vars } from '@launchpad-ui/vars';
-import { userEvent, within } from 'storybook/test';
+import { expect, userEvent, within } from 'storybook/test';
 
 import { FieldError } from '../src/FieldError';
 import { Input } from '../src/Input';
@@ -38,6 +38,34 @@ export default meta;
 type Story = StoryObj<typeof TextField>;
 
 export const Example: Story = {
+	args: {
+		description: 'Description',
+		children: (
+			<>
+				<Label>Label</Label>
+				<Input placeholder="Enter a value" />
+			</>
+		),
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const input = canvas.getByRole('textbox');
+		const description = canvas.getByText('Description');
+
+		// The description prop renders helper text and links it to the input for screen readers.
+		await expect(description).toBeInTheDocument();
+		await expect(input).toHaveAttribute(
+			'aria-describedby',
+			expect.stringContaining(description.id),
+		);
+	},
+};
+
+/**
+ * The `description` prop is a convenience for rendering helper text. The same result can still be
+ * achieved by passing a `<Text slot="description">` child directly, which remains fully supported.
+ */
+export const DescriptionAsSlot: Story = {
 	args: {
 		children: (
 			<>


### PR DESCRIPTION
## Summary

Resolves the `description` prop drift between the LaunchPad React components and the Figma library ([DSYS-194](https://launchdarkly.atlassian.net/browse/DSYS-194)).

The Figma library exposes a flat `description` property on field components, but in code helper text was only expressible as a slotted child (`<Text slot="description">`). This mismatch broke Code Connect mappings.

This PR adds ergonomic `description` and `errorMessage` props to the field wrappers, implemented through a single shared helper so the slot-rendering logic lives in exactly one place.

- New `renderFieldHelpers()` + `FieldHelperProps` in `src/fieldHelpers.tsx` — the single source of truth that renders the RAC `<Text slot="description">` and `<FieldError>` slots.
- Props added to: `TextField`, `NumberField`, `SearchField`, `Select`, `ComboBox`, `RadioGroup`, `CheckboxGroup`, `DateField`, `TimeField`.
- Single controls (`Checkbox`, `Switch`, `Radio`, `Label`) intentionally **not** changed — per RAC/React Spectrum convention, helper text belongs at the group level.
- Code Connect (`.figma.tsx`) mappings updated to map Figma's `description` to the new prop.
- `TextField` story updated (prop + back-compat slot story) with a `play` test asserting render + `aria-describedby` wiring.
- `minor` changeset (additive, non-breaking — existing slotted children keep working).

## Review focus

**Please review `TextField` first** — it is the reference implementation. Scrutinize:
- `src/fieldHelpers.tsx` (the shared helper — the only real logic)
- `src/TextField.tsx`
- `figma/TextField.figma.tsx`

The other 8 components apply the **identical** mechanical change: destructure `description, errorMessage` out of props and route children through `renderFieldHelpers`. Once the `TextField` approach is approved, the rest are replicas.

## Test plan

- [ ] `pnpm --filter @launchpad-ui/components test` — run the `TextField` `play` test
- [ ] Storybook: verify the `TextField` `Example` renders the description and `DescriptionAsSlot` still works
- [ ] `figma connect publish` validation — confirm the Figma `Description` property/layer names in the updated `.figma.tsx` files match the actual Figma components (several were added following the existing `'Description?'` / `'Description'` convention and need verification against the live file)

Made with [Cursor](https://cursor.com)

[DSYS-194]: https://launchdarkly.atlassian.net/browse/DSYS-194?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/launchdarkly/launchpad-ui/pull/1941" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->