### PR TITLE
docs(agents): warn non-engineers on feature/large-scope requests

### DIFF
--- a/.cursor/rules/launchpad.mdc
+++ b/.cursor/rules/launchpad.mdc
@@ -12,7 +12,7 @@ You are working in LaunchDarkly's LaunchPad design system. Non-negotiables:
 - **String union prop types**, never enums (`size="medium"`).
 - **CSS Modules** (`styles.foo`) + `class-variance-authority` for variants.
 - New public components need a `*.stories.tsx`; non-trivial package changes need a `.changeset/*.md`.
-- **Warn non-engineers on feature/large-scope work** — if the requester isn't an engineer (resolve via GitHub org team membership) and the ask is really a feature change or a large/complex change (business logic or product-domain terms in a component, a new dependency, a new package, or many-file changes), give an up-front complexity estimate and recommend an engineer own or review it before proceeding. It's a warning, not a block; engineers never see it. See the "Non-engineer scope warning" section in `AGENTS.md`.
+- **Warn non-engineers on feature/large-scope work** — if the requester isn't an engineer (resolve via GitHub org team membership) and the ask is really a feature change or a large/complex change (business logic or product-domain terms in a component, a new dependency, a new package, or many-file changes), give an up-front complexity estimate and recommend an engineer own or review it before proceeding. It's a warning, not a block; engineers never see it. If a warned requester proceeds anyway, add a visible scope note to the PR description (and a review label if one exists) so engineers know to review it more closely. See the "Non-engineer scope warning" section in `AGENTS.md`.
 
 The full standards, commands, architecture, and the step-by-step pull-request flow (branch naming, changeset, conventional commits, draft `gh pr create`) live in the canonical guidance:
 

--- a/.cursor/rules/launchpad.mdc
+++ b/.cursor/rules/launchpad.mdc
@@ -12,6 +12,7 @@ You are working in LaunchDarkly's LaunchPad design system. Non-negotiables:
 - **String union prop types**, never enums (`size="medium"`).
 - **CSS Modules** (`styles.foo`) + `class-variance-authority` for variants.
 - New public components need a `*.stories.tsx`; non-trivial package changes need a `.changeset/*.md`.
+- **Warn non-engineers on feature/large-scope work** — if the requester isn't an engineer (resolve via GitHub org team membership) and the ask is really a feature change or a large/complex change (business logic or product-domain terms in a component, a new dependency, a new package, or many-file changes), give an up-front complexity estimate and recommend an engineer own or review it before proceeding. It's a warning, not a block; engineers never see it. See the "Non-engineer scope warning" section in `AGENTS.md`.
 
 The full standards, commands, architecture, and the step-by-step pull-request flow (branch naming, changeset, conventional commits, draft `gh pr create`) live in the canonical guidance:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,7 +102,7 @@ Size buckets (from the real distribution of merged LaunchPad PRs — typical PR 
 Out-of-scope signals (any one bumps the work to at least Large — LaunchPad components must stay generic):
 
 - **Business logic, product-domain terms** (flag/segment/project/environment/member/metric), **app-specific data fetching**, or **hardcoded LaunchDarkly URLs/copy** in a component — these belong in the consuming app, not here.
-- A **new package**, a **new public component/variant** with non-trivial behavior, or a change to a broadly-consumed component (imported in **≥10 files or ≥3 packages** — estimate with `grep -rl "<ComponentName>" packages | wc -l`).
+- A **new package**, a **new public component/variant** with non-trivial behavior, or a change to a broadly-consumed component (imported in **≥10 files or ≥3 packages** — estimate with `grep -rlw "ComponentName" packages | wc -l` (bare name, no angle brackets — real usages are `<ComponentName …>`/`</ComponentName>`/imports, so brackets would miss them; `-w` keeps it from matching longer names)).
 - **New dependency:** adding/bumping a dependency in any `package.json` or lockfile — **always flag** (X-large signal on its own); new deps carry security/supply-chain, bundle-size, and licensing implications a non-engineer can't vet.
 - Changes spanning **many files** or **more than one package**.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,6 +114,14 @@ For a non-engineer + Large/X-large/out-of-scope signal, before writing code say 
 
 Then recommend an engineer own it / open it for engineering review (or ask clarifying questions), and **proceed if they still want to**. Keep components generic even when you proceed.
 
+### 4. If a warned requester proceeds anyway, flag it on the PR
+
+If you gave the heads-up and the non-engineer chose to proceed, make that **visible to engineers on the resulting PR** so it gets the right review scrutiny — an overridden warning must not disappear into a normal-looking PR. When you open (or update) the PR, add a clearly-marked callout at the top of the description, e.g.:
+
+> ⚠️ **Scope note (non-engineer request):** This change was flagged as a **{Large/X-large}** / feature-scope change and was requested by a non-engineer (@{requester}). They were given a heads-up recommending engineer involvement and chose to proceed. **Please review accordingly** — {concrete reason}.
+
+If the repo has a suitable label (e.g. `needs-engineer-review`), apply it too. Don't invent a required label or block the merge — this is a heads-up for reviewers, not a gate. Keep it factual and neutral. If the requester scoped the work back down to something small/presentation-only, no PR note is needed.
+
 ## Opening a pull request
 
 Follow this flow end to end. The repo's PR gates are strict — a missing changeset or a non-conventional title will block the merge.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,6 +73,47 @@ Follow these when writing or changing component code:
 
 The full component list lives in `packages/components/src/index.ts`.
 
+## Non-engineer scope warning (warn, don't block)
+
+Some requests come from people who are **not engineers** (designers, PMs, CX/revenue teammates) and are framed as a "small tweak" but actually ask for a feature change or a large/complex change. When that happens, give an honest heads-up *before* writing code — say how big it looks and recommend an engineer own or review it — **then proceed if they still want to.** This is a *warning*, not a gate: it never blocks anyone, and engineers never see it. Run this check at the **start** of an implementation request.
+
+### 1. Determine the requester's role
+
+You know the requester's GitHub username from the session/request context. Resolve role by checking membership in the **engineer allowlist** of `launchdarkly` org teams — in **any** of these → engineer; otherwise → non-engineer:
+
+```
+role-product-engineers   role-infrastructure-administrators
+div-product-engineering  div-platform-engineering  div-release-engineering
+div-core-engineering     div-measure-engineering   div-service-platform-engineering
+```
+
+```sh
+# org-team API needs the `launchdarkly` org token (default gh token 404s on launchdarkly/*)
+gh api "/orgs/launchdarkly/teams/<team>/memberships/<username>" --jq '.state'   # "active" == member
+```
+
+- **Engineer → no warning, proceed normally.**
+- **Fail-open:** if the lookup errors (API/token/unknown user), treat as engineer and proceed — never block a real engineer on an API hiccup.
+
+### 2. Estimate complexity and detect out-of-scope signals (non-engineers only)
+
+Size buckets (from the real distribution of merged LaunchPad PRs — typical PR ≈ 4 files / <60 lines): **Small** ≤3 files & presentation-only; **Medium** 4–7 files; **Large** 8–15 files or ~250–700 lines or any signal below; **X-large** >15 files or >~700 lines or a new dependency.
+
+Out-of-scope signals (any one bumps the work to at least Large — LaunchPad components must stay generic):
+
+- **Business logic, product-domain terms** (flag/segment/project/environment/member/metric), **app-specific data fetching**, or **hardcoded LaunchDarkly URLs/copy** in a component — these belong in the consuming app, not here.
+- A **new package**, a **new public component/variant** with non-trivial behavior, or a change to a broadly-consumed component (imported in **≥10 files or ≥3 packages** — estimate with `grep -rl "<ComponentName>" packages | wc -l`).
+- **New dependency:** adding/bumping a dependency in any `package.json` or lockfile — **always flag** (X-large signal on its own); new deps carry security/supply-chain, bundle-size, and licensing implications a non-engineer can't vet.
+- Changes spanning **many files** or **more than one package**.
+
+### 3. Warn (don't block)
+
+For a non-engineer + Large/X-large/out-of-scope signal, before writing code say plainly, e.g.:
+
+> Heads-up: this looks like a **{Large/X-large}** change — {concrete reason, e.g. "it adds product-specific logic to a generic component" / "it adds a new dependency (`foo`)" / "it touches ~9 files across 2 packages"}. That's **feature / engineering-scope work an engineer usually owns**, not a small design-system tweak. I'd recommend looping in an engineer or opening it for engineering review. I can still proceed if you'd like — want me to, or scope it down first?
+
+Then recommend an engineer own it / open it for engineering review (or ask clarifying questions), and **proceed if they still want to**. Keep components generic even when you proceed.
+
 ## Opening a pull request
 
 Follow this flow end to end. The repo's PR gates are strict — a missing changeset or a non-conventional title will block the merge.

--- a/AI_PROMPT_HEADER.md
+++ b/AI_PROMPT_HEADER.md
@@ -19,6 +19,7 @@ Copy this into your first message, then add your request:
 - Keep components **generic** — no business logic, product-domain terms, or hardcoded LaunchDarkly URLs.
 - Meet **WCAG 2.0/2.1 A/AA** accessibility; new public components need a `*.stories.tsx` and tests using the project's `render()` util.
 - Use the `ComponentContext` + `useLPContextProps` pattern for overridable props; include JSDoc on exported components.
+- If you're **not an engineer** and the request is really a feature change or a large/complex change (business logic or product-domain terms in a component, a new dependency, a new package, or many-file changes), the assistant should give a complexity estimate and recommend an engineer own or review it before proceeding (a warning, not a block). See the "Non-engineer scope warning" section in `AGENTS.md`.
 
 ---
 

--- a/AI_PROMPT_HEADER.md
+++ b/AI_PROMPT_HEADER.md
@@ -19,7 +19,7 @@ Copy this into your first message, then add your request:
 - Keep components **generic** — no business logic, product-domain terms, or hardcoded LaunchDarkly URLs.
 - Meet **WCAG 2.0/2.1 A/AA** accessibility; new public components need a `*.stories.tsx` and tests using the project's `render()` util.
 - Use the `ComponentContext` + `useLPContextProps` pattern for overridable props; include JSDoc on exported components.
-- If you're **not an engineer** and the request is really a feature change or a large/complex change (business logic or product-domain terms in a component, a new dependency, a new package, or many-file changes), the assistant should give a complexity estimate and recommend an engineer own or review it before proceeding (a warning, not a block). See the "Non-engineer scope warning" section in `AGENTS.md`.
+- If you're **not an engineer** and the request is really a feature change or a large/complex change (business logic or product-domain terms in a component, a new dependency, a new package, or many-file changes), the assistant should give a complexity estimate and recommend an engineer own or review it before proceeding (a warning, not a block) — and if it proceeds anyway, add a visible scope note to the PR so engineers know to review it more closely. See the "Non-engineer scope warning" section in `AGENTS.md`.
 
 ---
 


### PR DESCRIPTION
## Summary

Adds a **"Non-engineer scope warning"** section to `AGENTS.md` (LaunchPad's canonical, cross-tool AI guidance) so AI coding agents (Cursor, Claude Code, Devin, any AGENTS.md-compatible tool) **warn — not block — when the requester is not an engineer and the ask is really a feature change or a large/complex change** rather than a small design-system tweak. Engineers are unaffected.

The section covers:
1. **Role lookup** — resolve the requester's GitHub username against an engineer allowlist of `launchdarkly` org teams (`role-product-engineers`, `role-infrastructure-administrators`, `div-*-engineering`). In any → engineer → no warning. **Fail-open** on lookup errors (never block a real engineer). Note: the org-team API needs the `launchdarkly` org token.
2. **Complexity estimate + out-of-scope signals** — size buckets (small/medium/large/x-large) derived from the real distribution of merged LaunchPad PRs (typical ≈ 4 files / <60 lines). Signals: business logic / product-domain terms / app-specific fetching / hardcoded LD URLs in a component; a new package or broadly-consumed component change; a new dependency (always flagged); many-file / multi-package spread.
3. **Warn, don't block** — surface an up-front heads-up recommending engineer handoff / review, then proceed if the requester still wants to. Components stay generic regardless.

Referenced (not duplicated) from `.cursor/rules/launchpad.mdc` and `AI_PROMPT_HEADER.md`.

This is the LaunchPad companion to gonfalon PR launchdarkly/gonfalon#67061, kept consistent across repos (duplicated per-repo intentionally, since Cursor/Claude only read files in the current repo).

## Screenshots (if appropriate):

N/A — documentation-only change, no visual/component impact.

## Testing approaches

Docs-only; no package code changed (no changeset needed). Verified the GitHub role lookup end-to-end against the engineer allowlist: an engineer resolves as ENGINEER; several non-engineers resolve as NON-ENG and would be warned. Thresholds are grounded in the actual merged-PR distribution for this repo.

Link to Devin session: https://app.devin.ai/sessions/09d988d87acb452185ffbdc83e610357
Requested by: @hsadhvani

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only; no runtime, package, or CI behavior changes.
> 
> **Overview**
> Adds a **non-engineer scope warning** workflow to LaunchPad’s AI agent guidance so coding assistants **warn (never block)** when a non-engineer asks for feature-scale or out-of-scope design-system work.
> 
> **`AGENTS.md`** gains a new section covering GitHub org-team role lookup (engineer allowlist, fail-open on API errors), PR-sized complexity buckets, out-of-scope signals (product logic, new deps/packages, broad component changes), sample warning copy, and a PR description callout (plus optional label) when someone proceeds anyway.
> 
> **`.cursor/rules/launchpad.mdc`** and **`AI_PROMPT_HEADER.md`** each add a short bullet pointing agents at that section so Cursor and paste-in prompts stay aligned with the canonical doc.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dacc1c6ebde9baa93b476901ea76fb2c23dc7ab3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->