### PR TITLE
docs(agents): resolve non-engineer scope-warning login from email (no brute-forcing)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,7 +79,7 @@ Some requests come from people who are **not engineers** (designers, PMs, CX/rev
 
 ### 1. Determine the requester's role
 
-You know the requester's GitHub username from the session/request context. Resolve role by checking membership in the **engineer allowlist** of `launchdarkly` org teams — in **any** of these → engineer; otherwise → non-engineer:
+Resolve role by checking membership in the **engineer allowlist** of `launchdarkly` org teams — in **any** of these → engineer; otherwise → non-engineer:
 
 ```
 role-product-engineers   role-infrastructure-administrators
@@ -87,13 +87,27 @@ div-product-engineering  div-platform-engineering  div-release-engineering
 div-core-engineering     div-measure-engineering   div-service-platform-engineering
 ```
 
+The team-membership API is keyed by GitHub **login**, but the session reliably gives you the requester's **email** (git author email), not their login. Don't brute-force login variants from their name (`dberkowitz`, `dberkowitz-ld`, `daniel-berkowitz`, …) — that's slow and usually 404s. Resolve the login in **one** call from the email (GitHub attributes commits to a user by author email), then check that single login:
+
 ```sh
+LD_GH_TOKEN=$(awk '$1=="github.com/launchdarkly"{print $2}' /opt/.devin/.devin-integration-gh-credentials)
+
+# email -> login (maps e.g. dberkowitz@launchdarkly.com -> danberk-ld; hsadhvani@… -> hsadhvani)
+REQUESTER=$(GH_TOKEN="$LD_GH_TOKEN" gh api \
+  -H "Accept: application/vnd.github.cloak-preview+json" \
+  "/search/commits?q=author-email:${REQUESTER_EMAIL}&per_page=1" \
+  --jq '.items[0].author.login // empty' 2>/dev/null)
+
+# no login resolved => fail open (treat as engineer, no warning); don't run the membership loop with an empty login
+[ -z "${REQUESTER:-}" ] && { echo "engineer"; exit 0; }
+
 # org-team API needs the `launchdarkly` org token (default gh token 404s on launchdarkly/*)
-gh api "/orgs/launchdarkly/teams/<team>/memberships/<username>" --jq '.state'   # "active" == member
+gh api "/orgs/launchdarkly/teams/<team>/memberships/${REQUESTER}" --jq '.state'   # "active" == member
 ```
 
 - **Engineer → no warning, proceed normally.**
-- **Fail-open:** if the lookup errors (API/token/unknown user), treat as engineer and proceed — never block a real engineer on an API hiccup.
+- **Fail-open:** if the email doesn't resolve to a login, or a membership lookup errors (API/token/unknown user, non-404), treat as engineer and proceed — never block a real engineer on an API hiccup. Only a genuine 404 counts as "not on that team".
+- If the session already hands you a definite GitHub login, use it directly (still set `LD_GH_TOKEN`).
 
 ### 2. Estimate complexity and detect out-of-scope signals (non-engineers only)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,22 +92,23 @@ The team-membership API is keyed by GitHub **login**, but the session reliably g
 ```sh
 LD_GH_TOKEN=$(awk '$1=="github.com/launchdarkly"{print $2}' /opt/.devin/.devin-integration-gh-credentials)
 
-# email -> login (maps e.g. dberkowitz@launchdarkly.com -> danberk-ld; hsadhvani@… -> hsadhvani)
-REQUESTER=$(GH_TOKEN="$LD_GH_TOKEN" gh api \
+# Prefer a definite GitHub login from the session (REQUESTER); otherwise resolve it
+# from the requester's email in one call (GitHub attributes commits to a user by author
+# email). maps e.g. dberkowitz@launchdarkly.com -> danberk-ld; hsadhvani@… -> hsadhvani
+REQUESTER="${REQUESTER:-$(GH_TOKEN="$LD_GH_TOKEN" gh api \
   -H "Accept: application/vnd.github.cloak-preview+json" \
   "/search/commits?q=author-email:${REQUESTER_EMAIL}&per_page=1" \
-  --jq '.items[0].author.login // empty' 2>/dev/null)
+  --jq '.items[0].author.login // empty' 2>/dev/null)}"
 
-# no login resolved => fail open (treat as engineer, no warning); don't run the membership loop with an empty login
+# no login resolved => fail open (treat as engineer, no warning); don't run the membership check with an empty login
 [ -z "${REQUESTER:-}" ] && { echo "engineer"; exit 0; }
 
 # org-team API needs the `launchdarkly` org token (default gh token 404s on launchdarkly/*)
-gh api "/orgs/launchdarkly/teams/<team>/memberships/${REQUESTER}" --jq '.state'   # "active" == member
+GH_TOKEN="$LD_GH_TOKEN" gh api "/orgs/launchdarkly/teams/<team>/memberships/${REQUESTER}" --jq '.state'   # "active" == member
 ```
 
 - **Engineer → no warning, proceed normally.**
 - **Fail-open:** if the email doesn't resolve to a login, or a membership lookup errors (API/token/unknown user, non-404), treat as engineer and proceed — never block a real engineer on an API hiccup. Only a genuine 404 counts as "not on that team".
-- If the session already hands you a definite GitHub login, use it directly (still set `LD_GH_TOKEN`).
 
 ### 2. Estimate complexity and detect out-of-scope signals (non-engineers only)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,13 +89,13 @@ div-core-engineering     div-measure-engineering   div-service-platform-engineer
 
 The team-membership API is keyed by GitHub **login**, but the session reliably gives you the requester's **email** (git author email), not their login. Don't brute-force login variants from their name (`dberkowitz`, `dberkowitz-ld`, `daniel-berkowitz`, …) — that's slow and usually 404s. Resolve the login in **one** call from the email (GitHub attributes commits to a user by author email), then check that single login:
 
-```sh
-LD_GH_TOKEN=$(awk '$1=="github.com/launchdarkly"{print $2}' /opt/.devin/.devin-integration-gh-credentials)
+The org-team API needs a `launchdarkly` org token (the default agent token only sees `launchdarkly-labs` and 404s on `launchdarkly/*`). Use whatever `launchdarkly` org token your agent has available as `GH_TOKEN` — don't hardcode a token or a credentials path.
 
+```sh
 # Prefer a definite GitHub login from the session (REQUESTER); otherwise resolve it
 # from the requester's email in one call (GitHub attributes commits to a user by author
 # email). maps e.g. dberkowitz@launchdarkly.com -> danberk-ld; hsadhvani@… -> hsadhvani
-REQUESTER="${REQUESTER:-$(GH_TOKEN="$LD_GH_TOKEN" gh api \
+REQUESTER="${REQUESTER:-$(gh api \
   -H "Accept: application/vnd.github.cloak-preview+json" \
   "/search/commits?q=author-email:${REQUESTER_EMAIL}&per_page=1" \
   --jq '.items[0].author.login // empty' 2>/dev/null)}"
@@ -103,8 +103,7 @@ REQUESTER="${REQUESTER:-$(GH_TOKEN="$LD_GH_TOKEN" gh api \
 # no login resolved => fail open (treat as engineer, no warning); don't run the membership check with an empty login
 [ -z "${REQUESTER:-}" ] && { echo "engineer"; exit 0; }
 
-# org-team API needs the `launchdarkly` org token (default gh token 404s on launchdarkly/*)
-GH_TOKEN="$LD_GH_TOKEN" gh api "/orgs/launchdarkly/teams/<team>/memberships/${REQUESTER}" --jq '.state'   # "active" == member
+gh api "/orgs/launchdarkly/teams/<team>/memberships/${REQUESTER}" --jq '.state'   # "active" == member
 ```
 
 - **Engineer → no warning, proceed normally.**


### PR DESCRIPTION
## Summary

Mirrors gonfalon PR #67107 into LaunchPad's canonical `AGENTS.md`. The "Non-engineer scope warning" step 1 (role resolution) assumed we had the requester's GitHub **login**, but the session reliably gives us their **email**, not their login — so agents were guessing login variants from a name (`dberkowitz`, `dberkowitz-ld`, …), which is slow and mostly 404s.

This replaces the guesswork with a single deterministic lookup: resolve login **from the email** (GitHub attributes commits to a user by author email), then run the existing allowlist check on that one login.

```sh
gh api -H "Accept: application/vnd.github.cloak-preview+json" \
  "/search/commits?q=author-email:<email>&per_page=1" --jq '.items[0].author.login'
```

Verified mappings (one call each): `dberkowitz@launchdarkly.com` → `danberk-ld`, `hsadhvani@…` → `hsadhvani`, `zverrilli@…` → `zakk-verrilli-ld`, `bdomingo@…` → `bdomingo-ux`.

Fail-open is preserved: if the email doesn't resolve to a login, the snippet exits treating the requester as an engineer (no warning) rather than running the membership loop with an empty login (which would 404 on every team and wrongly resolve to non-engineer). Only `AGENTS.md` changed; the `.cursor` pointer references it by section and needed no edit.

## Screenshots (if appropriate):

N/A — docs-only change to agent guidance.

## Testing approaches

Docs-only. The email→login and login→allowlist `gh` calls were run manually against the `launchdarkly` org token for the users above. No component/product code touched.

Link to Devin session: https://app.devin.ai/sessions/09d988d87acb452185ffbdc83e610357
Requested by: @hsadhvani

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to agent guidance; no runtime, component, or CI behavior is modified.
> 
> **Overview**
> Updates **Non-engineer scope warning** step 1 in `AGENTS.md` so agents stop guessing GitHub logins from names when the session only provides the requester’s **email**.
> 
> The doc now describes a single **email → login** lookup via GitHub commit search (`author-email:` + cloak preview), then the existing `launchdarkly` org team allowlist check on that one login. It also spells out using a **`launchdarkly` org token** for team membership (default token 404s on `launchdarkly/*`).
> 
> **Fail-open** behavior is tightened: if no login resolves, exit as engineer before membership calls; API/token errors still fail open, with only a real 404 meaning “not on that team.”
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 142a1d6e5312d5d5894a7fa43c0be748eb1e028a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->