### PR TITLE
docs(agents): fetch canonical requester-role-lookup from gonfalon

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,35 +79,16 @@ Some requests come from people who are **not engineers** (designers, PMs, CX/rev
 
 ### 1. Determine the requester's role
 
-Resolve role by checking membership in the **engineer allowlist** of `launchdarkly` org teams — in **any** of these → engineer; otherwise → non-engineer:
-
-```
-role-product-engineers   role-infrastructure-administrators
-div-product-engineering  div-platform-engineering  div-release-engineering
-div-core-engineering     div-measure-engineering   div-service-platform-engineering
-```
-
-The team-membership API is keyed by GitHub **login**, but the session reliably gives you the requester's **email** (git author email), not their login. Don't brute-force login variants from their name (`dberkowitz`, `dberkowitz-ld`, `daniel-berkowitz`, …) — that's slow and usually 404s. Resolve the login in **one** call from the email (GitHub attributes commits to a user by author email), then check that single login:
-
-The org-team API needs a `launchdarkly` org token (the default agent token only sees `launchdarkly-labs` and 404s on `launchdarkly/*`). Use whatever `launchdarkly` org token your agent has available as `GH_TOKEN` — don't hardcode a token or a credentials path.
+Follow the canonical **`requester-role-lookup`** skill, maintained in the private gonfalon repo. Fetch it with the same `launchdarkly` org token the role check itself needs (use whatever org token your agent has available as `GH_TOKEN` — don't hardcode a token or a credentials path):
 
 ```sh
-# Prefer a definite GitHub login from the session (REQUESTER); otherwise resolve it
-# from the requester's email in one call (GitHub attributes commits to a user by author
-# email). maps e.g. dberkowitz@launchdarkly.com -> danberk-ld; hsadhvani@… -> hsadhvani
-REQUESTER="${REQUESTER:-$(gh api \
-  -H "Accept: application/vnd.github.cloak-preview+json" \
-  "/search/commits?q=author-email:${REQUESTER_EMAIL}&per_page=1" \
-  --jq '.items[0].author.login // empty' 2>/dev/null)}"
-
-# no login resolved => fail open (treat as engineer, no warning); don't run the membership check with an empty login
-[ -z "${REQUESTER:-}" ] && { echo "engineer"; exit 0; }
-
-gh api "/orgs/launchdarkly/teams/<team>/memberships/${REQUESTER}" --jq '.state'   # "active" == member
+gh api /repos/launchdarkly/gonfalon/contents/.agents/skills/requester-role-lookup/SKILL.md --jq .content | base64 -d
 ```
 
+It identifies the requester (session-provided GitHub login first, then git author email → login via commit search — never an agent's `[bot]` identity), checks the engineer allowlist of `launchdarkly` org teams, and answers with exactly one word: `engineer` or `non-engineer`.
+
 - **Engineer → no warning, proceed normally.**
-- **Fail-open:** if the email doesn't resolve to a login, or a membership lookup errors (API/token/unknown user, non-404), treat as engineer and proceed — never block a real engineer on an API hiccup. Only a genuine 404 counts as "not on that team".
+- **Fail-open:** if you can't fetch the skill (no org token) or its lookup is inconclusive, treat the requester as an engineer and proceed — never block a real engineer on an API hiccup.
 
 ### 2. Estimate complexity and detect out-of-scope signals (non-engineers only)
 


### PR DESCRIPTION
## Summary

Replaces the inline copy of the non-engineer scope warning's role-lookup section (engineer team allowlist + bash) with a runtime fetch of the canonical `requester-role-lookup` skill from gonfalon. The two copies had already drifted, and this also removes the internal org team allowlist from this public repo. Fetching uses the same `launchdarkly` org token the membership check already requires, and fails open (treat as engineer) when the skill can't be fetched.

Pairs with https://github.com/launchdarkly/gonfalon/pull/67192 — merge that first so the canonical skill file exists on gonfalon `main`.

## Testing approaches

- Verified the canonical-fetch `gh api` command returns the new skill file from the gonfalon branch

## Feature flags

N/A — documentation-only change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to agent guidance; no runtime code or component behavior in LaunchPad is modified.
> 
> **Overview**
> **`AGENTS.md`** no longer documents the inline engineer-team allowlist and bash membership lookup for the non-engineer scope warning. Agents are directed to load the canonical **`requester-role-lookup`** skill from private **gonfalon** at runtime via `gh api` (same `launchdarkly` org token as before).
> 
> Fail-open guidance now covers **unable to fetch the skill** (e.g. no org token) or an **inconclusive lookup**, not only per-team API errors. Complexity sizing and out-of-scope rules in the same section are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit afa044752a8c33952af298a26cab7e9fc1e87c22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->