### PR TITLE
fix(components): lock nested scroll parent when Popover is open

### DIFF
--- a/.changeset/popover-scroll-parent-lock.md
+++ b/.changeset/popover-scroll-parent-lock.md
@@ -2,4 +2,4 @@
 '@launchpad-ui/components': patch
 ---
 
-`Popover` now also prevents scrolling of the trigger's nearest scrollable ancestor while open. React Aria's built-in scroll lock only targets `document.documentElement`, so in apps that scroll inside a nested container (e.g. an app shell with `overflow: auto` on a layout element) the page still scrolled behind an open `Popover`, `Select`, `Menu`, etc. The lock is a no-op when the document itself is the scroller and is skipped for non-modal popovers.
+`Popover` now also prevents scrolling of the trigger's scrollable ancestors while open. React Aria's built-in scroll lock only targets `document.documentElement`, so in apps that scroll inside nested containers (e.g. an app shell with `overflow: auto` on layout elements) the page still scrolled behind an open `Popover`, `Select`, `Menu`, etc. The lock now applies to every scrollable ancestor of the trigger regardless of whether it currently overflows, mirroring the document-level lock. It is a no-op when the document itself is the scroller and is skipped for non-modal popovers.

--- a/.changeset/popover-scroll-parent-lock.md
+++ b/.changeset/popover-scroll-parent-lock.md
@@ -1,0 +1,5 @@
+---
+'@launchpad-ui/components': patch
+---
+
+`Popover` now also prevents scrolling of the trigger's nearest scrollable ancestor while open. React Aria's built-in scroll lock only targets `document.documentElement`, so in apps that scroll inside a nested container (e.g. an app shell with `overflow: auto` on a layout element) the page still scrolled behind an open `Popover`, `Select`, `Menu`, etc. The lock is a no-op when the document itself is the scroller and is skipped for non-modal popovers.

--- a/packages/components/__tests__/usePreventScrollParent.spec.tsx
+++ b/packages/components/__tests__/usePreventScrollParent.spec.tsx
@@ -1,0 +1,121 @@
+import { useRef, useState } from 'react';
+import { describe, expect, it } from 'vitest';
+
+import { render, screen, userEvent } from '../../../test/utils';
+import { usePreventScrollParent } from '../src/usePreventScrollParent';
+
+const defineDimensions = (
+	element: HTMLElement,
+	{ scrollHeight, clientHeight, offsetWidth, clientWidth }: Record<string, number>,
+) => {
+	Object.defineProperty(element, 'scrollHeight', { value: scrollHeight, configurable: true });
+	Object.defineProperty(element, 'clientHeight', { value: clientHeight, configurable: true });
+	Object.defineProperty(element, 'offsetWidth', { value: offsetWidth, configurable: true });
+	Object.defineProperty(element, 'clientWidth', { value: clientWidth, configurable: true });
+};
+
+const Harness = ({ isNonModal }: { isNonModal?: boolean }) => {
+	const triggerRef = useRef<HTMLButtonElement>(null);
+	const scrollRef = useRef<HTMLDivElement>(null);
+	const [isOpen, setIsOpen] = useState(false);
+
+	usePreventScrollParent({ triggerRef, isOpen, isDisabled: isNonModal });
+
+	return (
+		<div
+			data-test-id="scroller"
+			ref={(node) => {
+				scrollRef.current = node;
+				if (node) {
+					node.style.overflow = 'auto';
+					defineDimensions(node, {
+						scrollHeight: 1000,
+						clientHeight: 500,
+						offsetWidth: 500,
+						clientWidth: 485,
+					});
+				}
+			}}
+		>
+			<button type="button" ref={triggerRef} onClick={() => setIsOpen((open) => !open)}>
+				toggle
+			</button>
+		</div>
+	);
+};
+
+describe('usePreventScrollParent', () => {
+	it("locks the trigger's scroll parent while open and restores it on close", async () => {
+		const user = userEvent.setup();
+		render(<Harness />);
+
+		const scroller = screen.getByTestId('scroller');
+		expect(scroller.style.overflow).toBe('auto');
+
+		await user.click(screen.getByRole('button'));
+		expect(scroller.style.overflow).toBe('hidden');
+
+		await user.click(screen.getByRole('button'));
+		expect(scroller.style.overflow).toBe('auto');
+	});
+
+	it('does not lock when disabled (non-modal)', async () => {
+		const user = userEvent.setup();
+		render(<Harness isNonModal />);
+
+		const scroller = screen.getByTestId('scroller');
+		await user.click(screen.getByRole('button'));
+		expect(scroller.style.overflow).toBe('auto');
+	});
+
+	it('reference counts nested overlays sharing a scroll parent', async () => {
+		const user = userEvent.setup();
+		render(<NestedHarness />);
+
+		const scroller = screen.getByTestId('scroller');
+		expect(scroller.style.overflow).toBe('auto');
+
+		await user.click(screen.getByRole('button', { name: 'toggle-a' }));
+		await user.click(screen.getByRole('button', { name: 'toggle-b' }));
+		expect(scroller.style.overflow).toBe('hidden');
+
+		await user.click(screen.getByRole('button', { name: 'toggle-a' }));
+		expect(scroller.style.overflow).toBe('hidden');
+
+		await user.click(screen.getByRole('button', { name: 'toggle-b' }));
+		expect(scroller.style.overflow).toBe('auto');
+	});
+});
+
+const NestedOverlay = ({ label }: { label: string }) => {
+	const triggerRef = useRef<HTMLButtonElement>(null);
+	const [isOpen, setIsOpen] = useState(false);
+
+	usePreventScrollParent({ triggerRef, isOpen });
+
+	return (
+		<button type="button" ref={triggerRef} onClick={() => setIsOpen((open) => !open)}>
+			{label}
+		</button>
+	);
+};
+
+const NestedHarness = () => (
+	<div
+		data-test-id="scroller"
+		ref={(node) => {
+			if (node) {
+				node.style.overflow = 'auto';
+				defineDimensions(node, {
+					scrollHeight: 1000,
+					clientHeight: 500,
+					offsetWidth: 500,
+					clientWidth: 485,
+				});
+			}
+		}}
+	>
+		<NestedOverlay label="toggle-a" />
+		<NestedOverlay label="toggle-b" />
+	</div>
+);

--- a/packages/components/__tests__/usePreventScrollParent.spec.tsx
+++ b/packages/components/__tests__/usePreventScrollParent.spec.tsx
@@ -59,6 +59,38 @@ describe('usePreventScrollParent', () => {
 		expect(scroller.style.overflow).toBe('auto');
 	});
 
+	it('locks a scroll parent that is not currently overflowing', async () => {
+		const user = userEvent.setup();
+		render(<NotOverflowingHarness />);
+
+		const scroller = screen.getByTestId('scroller');
+		expect(scroller.style.overflow).toBe('auto');
+
+		await user.click(screen.getByRole('button'));
+		expect(scroller.style.overflow).toBe('hidden');
+
+		await user.click(screen.getByRole('button'));
+		expect(scroller.style.overflow).toBe('auto');
+	});
+
+	it('locks every nested scroll container between the trigger and the document', async () => {
+		const user = userEvent.setup();
+		render(<NestedScrollersHarness />);
+
+		const outer = screen.getByTestId('outer');
+		const inner = screen.getByTestId('inner');
+		expect(outer.style.overflow).toBe('auto');
+		expect(inner.style.overflow).toBe('auto');
+
+		await user.click(screen.getByRole('button'));
+		expect(outer.style.overflow).toBe('hidden');
+		expect(inner.style.overflow).toBe('hidden');
+
+		await user.click(screen.getByRole('button'));
+		expect(outer.style.overflow).toBe('auto');
+		expect(inner.style.overflow).toBe('auto');
+	});
+
 	it('does not lock when disabled (non-modal)', async () => {
 		const user = userEvent.setup();
 		render(<Harness isNonModal />);
@@ -86,6 +118,63 @@ describe('usePreventScrollParent', () => {
 		expect(scroller.style.overflow).toBe('auto');
 	});
 });
+
+const NotOverflowingHarness = ({ isNonModal }: { isNonModal?: boolean }) => {
+	const triggerRef = useRef<HTMLButtonElement>(null);
+	const [isOpen, setIsOpen] = useState(false);
+
+	usePreventScrollParent({ triggerRef, isOpen, isDisabled: isNonModal });
+
+	return (
+		<div
+			data-test-id="scroller"
+			ref={(node) => {
+				if (node) {
+					node.style.overflow = 'auto';
+					defineDimensions(node, {
+						scrollHeight: 500,
+						clientHeight: 500,
+						offsetWidth: 500,
+						clientWidth: 500,
+					});
+				}
+			}}
+		>
+			<button type="button" ref={triggerRef} onClick={() => setIsOpen((open) => !open)}>
+				toggle
+			</button>
+		</div>
+	);
+};
+
+const NestedScrollersHarness = () => {
+	const triggerRef = useRef<HTMLButtonElement>(null);
+	const [isOpen, setIsOpen] = useState(false);
+
+	usePreventScrollParent({ triggerRef, isOpen });
+
+	const makeScroller = (node: HTMLDivElement | null) => {
+		if (node) {
+			node.style.overflow = 'auto';
+			defineDimensions(node, {
+				scrollHeight: 1000,
+				clientHeight: 500,
+				offsetWidth: 500,
+				clientWidth: 485,
+			});
+		}
+	};
+
+	return (
+		<div data-test-id="outer" ref={makeScroller}>
+			<div data-test-id="inner" ref={makeScroller}>
+				<button type="button" ref={triggerRef} onClick={() => setIsOpen((open) => !open)}>
+					toggle
+				</button>
+			</div>
+		</div>
+	);
+};
 
 const NestedOverlay = ({ label }: { label: string }) => {
 	const triggerRef = useRef<HTMLButtonElement>(null);

--- a/packages/components/src/Popover.tsx
+++ b/packages/components/src/Popover.tsx
@@ -7,15 +7,27 @@ import type {
 import type { ContextValue } from 'react-aria-components/slots';
 
 import { cva } from 'class-variance-authority';
-import { createContext } from 'react';
+import { createContext, useContext } from 'react';
 import { composeRenderProps } from 'react-aria-components/composeRenderProps';
+import { OverlayTriggerStateContext } from 'react-aria-components/Dialog';
 import {
 	OverlayArrow as AriaOverlayArrow,
 	Popover as AriaPopover,
+	PopoverContext as AriaPopoverContext,
 } from 'react-aria-components/Popover';
 
 import styles from './styles/Popover.module.css';
+import { usePreventScrollParent } from './usePreventScrollParent';
 import { useLPContextProps } from './utils';
+
+const getTriggerRef = (
+	contextValue: ContextValue<AriaPopoverProps, HTMLElement>,
+): AriaPopoverProps['triggerRef'] | undefined => {
+	if (contextValue && typeof contextValue === 'object' && 'triggerRef' in contextValue) {
+		return contextValue.triggerRef;
+	}
+	return undefined;
+};
 
 interface PopoverProps extends AriaPopoverProps, VariantProps<typeof popoverStyles> {
 	ref?: Ref<HTMLElement>;
@@ -48,6 +60,13 @@ const overlayArrowStyles = cva(styles.arrow);
 const Popover = ({ ref, ...props }: PopoverProps) => {
 	[props, ref] = useLPContextProps(props, ref, PopoverContext);
 	const { offset = 4, crossOffset = 0, width = 'default' } = props;
+
+	const triggerState = useContext(OverlayTriggerStateContext);
+	const ariaPopoverContext = useContext(AriaPopoverContext);
+	const triggerRef = props.triggerRef ?? getTriggerRef(ariaPopoverContext);
+	const isOpen = props.isOpen ?? triggerState?.isOpen ?? false;
+
+	usePreventScrollParent({ triggerRef, isOpen, isDisabled: props.isNonModal ?? false });
 
 	return (
 		<AriaPopover

--- a/packages/components/src/usePreventScrollParent.ts
+++ b/packages/components/src/usePreventScrollParent.ts
@@ -1,0 +1,116 @@
+import type { RefObject } from 'react';
+
+import { isScrollable, useLayoutEffect } from '@react-aria/utils';
+
+interface PreventScrollParentOptions {
+	/** Ref to the element that triggers the overlay. Its nearest scrollable ancestor is locked. */
+	triggerRef?: RefObject<Element | null> | null;
+	/** Whether the overlay is currently open. */
+	isOpen: boolean;
+	/** Disables the lock (e.g. for non-modal overlays, matching React Aria's `usePreventScroll`). */
+	isDisabled?: boolean;
+}
+
+interface Lock {
+	count: number;
+	restore: () => void;
+}
+
+const locks = new Map<HTMLElement, Lock>();
+
+const lock = (element: HTMLElement) => {
+	const existing = locks.get(element);
+	if (existing) {
+		existing.count++;
+		return;
+	}
+
+	const { overflow, scrollbarGutter, paddingRight } = element.style;
+	const scrollbarWidth = element.offsetWidth - element.clientWidth;
+
+	if (scrollbarWidth > 0) {
+		if (
+			typeof CSS !== 'undefined' &&
+			typeof CSS.supports === 'function' &&
+			CSS.supports('scrollbar-gutter', 'stable')
+		) {
+			element.style.scrollbarGutter = 'stable';
+		} else {
+			const currentPadding =
+				Number.parseInt(window.getComputedStyle(element).paddingRight, 10) || 0;
+			element.style.paddingRight = `${currentPadding + scrollbarWidth}px`;
+		}
+	}
+	element.style.overflow = 'hidden';
+
+	locks.set(element, {
+		count: 1,
+		restore: () => {
+			element.style.overflow = overflow;
+			element.style.scrollbarGutter = scrollbarGutter;
+			element.style.paddingRight = paddingRight;
+		},
+	});
+};
+
+const unlock = (element: HTMLElement) => {
+	const existing = locks.get(element);
+	if (!existing) {
+		return;
+	}
+	existing.count--;
+	if (existing.count === 0) {
+		existing.restore();
+		locks.delete(element);
+	}
+};
+
+/**
+ * Finds the nearest ancestor of `start` to lock. An element already locked by this hook is a valid
+ * target even though its `overflow` is now `hidden` (which `isScrollable` would otherwise reject),
+ * so nested overlays sharing a scroll container reference-count the same element. Returns `null`
+ * when the document itself is the scroller, leaving those apps to React Aria's own lock.
+ */
+const findScrollParent = (start: Element): HTMLElement | null => {
+	const root = document.scrollingElement ?? document.documentElement;
+	let node = start.parentElement;
+	while (node && node !== document.body && node !== root) {
+		if (locks.has(node) || isScrollable(node, true)) {
+			return node;
+		}
+		node = node.parentElement;
+	}
+	return null;
+};
+
+/**
+ * Prevents scrolling of the trigger's nearest scrollable ancestor while an overlay is open.
+ *
+ * React Aria's `usePreventScroll` only locks `document.documentElement`. When an app scrolls in a
+ * nested container (e.g. an app shell with `overflow: auto` on a layout element) rather than on the
+ * document, that lock is a no-op and the page keeps scrolling behind an open overlay. This hook
+ * complements it by locking the actual scroll container. It is a no-op when the document itself is
+ * the scroller, so apps already handled by React Aria are unaffected.
+ */
+const usePreventScrollParent = ({
+	triggerRef,
+	isOpen,
+	isDisabled = false,
+}: PreventScrollParentOptions) => {
+	useLayoutEffect(() => {
+		if (isDisabled || !isOpen || !triggerRef?.current) {
+			return;
+		}
+
+		const scrollParent = findScrollParent(triggerRef.current);
+		if (!scrollParent) {
+			return;
+		}
+
+		lock(scrollParent);
+		return () => unlock(scrollParent);
+	}, [triggerRef, isOpen, isDisabled]);
+};
+
+export { usePreventScrollParent };
+export type { PreventScrollParentOptions };

--- a/packages/components/src/usePreventScrollParent.ts
+++ b/packages/components/src/usePreventScrollParent.ts
@@ -3,7 +3,7 @@ import type { RefObject } from 'react';
 import { isScrollable, useLayoutEffect } from '@react-aria/utils';
 
 interface PreventScrollParentOptions {
-	/** Ref to the element that triggers the overlay. Its nearest scrollable ancestor is locked. */
+	/** Ref to the element that triggers the overlay. Its scrollable ancestors are locked. */
 	triggerRef?: RefObject<Element | null> | null;
 	/** Whether the overlay is currently open. */
 	isOpen: boolean;
@@ -66,30 +66,36 @@ const unlock = (element: HTMLElement) => {
 };
 
 /**
- * Finds the nearest ancestor of `start` to lock. An element already locked by this hook is a valid
- * target even though its `overflow` is now `hidden` (which `isScrollable` would otherwise reject),
- * so nested overlays sharing a scroll container reference-count the same element. Returns `null`
- * when the document itself is the scroller, leaving those apps to React Aria's own lock.
+ * Collects the scrollable ancestors of `start` that should be locked while an overlay is open.
+ *
+ * Ancestors are matched by their `overflow` being scrollable, regardless of whether they currently
+ * overflow — React Aria's own lock also fires unconditionally, and content can grow to overflow
+ * while the overlay is open. Every scrollable ancestor is returned (not just the nearest) because
+ * app shells often nest several scroll containers; locking all of them mirrors a document-level
+ * lock. An element already locked by this hook is included even though its `overflow` is now
+ * `hidden` (which `isScrollable` would otherwise reject), so nested overlays reference-count the
+ * same containers. `document.body` and the document root are skipped, leaving those to React Aria.
  */
-const findScrollParent = (start: Element): HTMLElement | null => {
+const findScrollParents = (start: Element): HTMLElement[] => {
 	const root = document.scrollingElement ?? document.documentElement;
+	const parents: HTMLElement[] = [];
 	let node = start.parentElement;
 	while (node && node !== document.body && node !== root) {
-		if (locks.has(node) || isScrollable(node, true)) {
-			return node;
+		if (locks.has(node) || isScrollable(node, false)) {
+			parents.push(node);
 		}
 		node = node.parentElement;
 	}
-	return null;
+	return parents;
 };
 
 /**
- * Prevents scrolling of the trigger's nearest scrollable ancestor while an overlay is open.
+ * Prevents scrolling of the trigger's scrollable ancestors while an overlay is open.
  *
  * React Aria's `usePreventScroll` only locks `document.documentElement`. When an app scrolls in a
  * nested container (e.g. an app shell with `overflow: auto` on a layout element) rather than on the
  * document, that lock is a no-op and the page keeps scrolling behind an open overlay. This hook
- * complements it by locking the actual scroll container. It is a no-op when the document itself is
+ * complements it by locking the actual scroll containers. It is a no-op when the document itself is
  * the scroller, so apps already handled by React Aria are unaffected.
  */
 const usePreventScrollParent = ({
@@ -102,13 +108,19 @@ const usePreventScrollParent = ({
 			return;
 		}
 
-		const scrollParent = findScrollParent(triggerRef.current);
-		if (!scrollParent) {
+		const scrollParents = findScrollParents(triggerRef.current);
+		if (scrollParents.length === 0) {
 			return;
 		}
 
-		lock(scrollParent);
-		return () => unlock(scrollParent);
+		for (const parent of scrollParents) {
+			lock(parent);
+		}
+		return () => {
+			for (const parent of scrollParents) {
+				unlock(parent);
+			}
+		};
 	}, [triggerRef, isOpen, isDisabled]);
 };
 


### PR DESCRIPTION
## Summary

React Aria's built-in scroll lock for modal overlays only targets `document.documentElement` (`usePreventScroll` sets `overflow: hidden` on `<html>`). Apps that scroll inside a **nested container** — e.g. an app shell where `<html>`/`<body>` are `overflow: hidden` and layout elements have `overflow: auto` — get no effective lock: the page keeps scrolling behind an open `Popover`, `Select`, `Menu`, `ComboBox`, etc. This is the reported behavior in Gonfalon's release builder, where `Select` dropdowns don't lock the page the way the React Aria docs demo does.

This adds a **generic** scroll-parent lock at the `Popover` layer (the shared overlay all of the above compose), complementing React Aria's existing document lock:

- New internal hook `usePreventScrollParent({ triggerRef, isOpen, isDisabled })`.
- On open (modal only), it walks up from the **trigger** (not the portaled popover DOM) and locks **every scrollable ancestor** between the trigger and the document root: `overflow: hidden` plus scrollbar compensation (`scrollbar-gutter: stable`, falling back to `padding-right`).
- An ancestor is matched by its `overflow` being scrollable **regardless of whether it currently overflows** — this mirrors React Aria's own unconditional `<html>` lock, and content can grow to overflow while the overlay is open. App shells commonly nest several scroll containers, so all of them are locked.
- **No-op when the document itself is the scroller** — apps already handled by React Aria are unaffected — and **skipped for non-modal popovers** (mirrors `usePreventScroll`'s `isDisabled`).
- **Reference-counted** by element via a module-level map, so nested/simultaneous overlays sharing scroll containers lock once and only restore the original inline styles when the last overlay closes. The search treats an already-locked element as a valid target (its `overflow` is now `hidden`, which `isScrollable` would otherwise reject).

`Popover` resolves `triggerRef`/`isOpen` from props first, then React Aria's `PopoverContext` / `OverlayTriggerStateContext` (how `DialogTrigger`, `Select`, etc. pass them), and installs the hook.

```tsx
// Popover.tsx (wiring)
const triggerRef = props.triggerRef ?? getTriggerRef(useContext(AriaPopoverContext));
const isOpen = props.isOpen ?? useContext(OverlayTriggerStateContext)?.isOpen ?? false;
usePreventScrollParent({ triggerRef, isOpen, isDisabled: props.isNonModal ?? false });
```

`patch`: no public API change — additive internal behavior on `Popover`.

### Why the first iteration didn't work

The initial version only locked the trigger's nearest ancestor that was **currently overflowing** (`isScrollable(node, true)`). In Gonfalon's main workspace the nested `overflow: auto` layout containers frequently are **not** overflowing at the moment the dropdown opens (their `scrollHeight === clientHeight`), so the hook found nothing and locked nothing — even though the page could still scroll. Locking every scrollable ancestor unconditionally (matching React Aria's document-level lock) fixes this.

## Screenshots (if appropriate):

No visual diff (scroll-locking behavior only). Verified live against a Gonfalon flag targeting page with a build of this branch consumed locally, exercising a `Select` in the same main-workspace scroll container as `ReleaseBuilderContextKindSelect`:

- Before open: the three nested `overflow: auto` layout containers (`ProjectEntityLayout__main`, `ProjectEntityLayout__workspace`, `LayoutWithSidebar__workspace`) had no inline `overflow`.
- During open: all three had inline `overflow: hidden`.
- After close: all three restored to their original (empty) inline `overflow`.

## Testing approaches

- Unit tests in `packages/components/__tests__/usePreventScrollParent.spec.tsx`:
  - locks the trigger's scroll parent while open and restores on close;
  - **locks a scroll parent that is not currently overflowing** (the case that was missed before);
  - **locks every nested scroll container** between the trigger and the document;
  - does not lock when disabled (non-modal);
  - reference-counts nested overlays sharing a scroll parent (stays locked until the last closes).
- `pnpm typecheck`, Biome, and the `usePreventScrollParent` suite pass; `@launchpad-ui/components` builds.
- Manual live verification in Gonfalon as described above.

## Notes / limitations

- Ships as a separate LaunchPad release + version bump in Gonfalon; nothing lands in Gonfalon from this PR.
- Left as **draft** for a human to review and mark ready.

Link to Devin session: https://app.devin.ai/sessions/8a5d2d3d589541a9b4bf71891c8017a4
Requested by: @joannerd