### PR TITLE
feat(components): add hasScrollLock prop to Select and ComboBox

### DIFF
--- a/.changeset/select-combobox-has-scroll-lock.md
+++ b/.changeset/select-combobox-has-scroll-lock.md
@@ -1,0 +1,5 @@
+---
+'@launchpad-ui/components': minor
+---
+
+Add a `hasScrollLock` prop to `Select` and `ComboBox` (defaults to `true`). When set to `false`, the component's popover is marked with the `data-no-scroll-lock` attribute so a consuming app can exclude that instance from any app-level background scroll lock.

--- a/packages/components/__tests__/ComboBox.spec.tsx
+++ b/packages/components/__tests__/ComboBox.spec.tsx
@@ -66,4 +66,43 @@ describe('ComboBox', () => {
 		await user.click(screen.getByRole('button'));
 		expect(await screen.findByRole('combobox')).toHaveValue('');
 	});
+
+	const renderComboBox = (hasScrollLock?: boolean) =>
+		render(
+			<ComboBox hasScrollLock={hasScrollLock}>
+				<Label>Label</Label>
+				<Group>
+					<Input />
+					<IconButton
+						icon="chevron-down"
+						size="small"
+						variant="minimal"
+						aria-label="Show suggestions"
+					/>
+				</Group>
+				<Popover>
+					<ListBox>
+						<ListBoxItem>Item one</ListBoxItem>
+					</ListBox>
+				</Popover>
+			</ComboBox>,
+		);
+
+	it('does not mark the popover when hasScrollLock defaults to true', async () => {
+		const user = userEvent.setup();
+		renderComboBox();
+
+		await user.click(screen.getByRole('button'));
+		const popover = (await screen.findByRole('listbox')).closest('[data-trigger="ComboBox"]');
+		expect(popover).not.toHaveAttribute('data-no-scroll-lock');
+	});
+
+	it('marks the popover with data-no-scroll-lock when hasScrollLock is false', async () => {
+		const user = userEvent.setup();
+		renderComboBox(false);
+
+		await user.click(screen.getByRole('button'));
+		const popover = (await screen.findByRole('listbox')).closest('[data-trigger="ComboBox"]');
+		expect(popover).toHaveAttribute('data-no-scroll-lock');
+	});
 });

--- a/packages/components/__tests__/Select.spec.tsx
+++ b/packages/components/__tests__/Select.spec.tsx
@@ -27,4 +27,38 @@ describe('Select', () => {
 		await user.click(screen.getByRole('button'));
 		expect(await screen.findByRole('listbox')).toBeVisible();
 	});
+
+	const renderSelect = (hasScrollLock?: boolean) =>
+		render(
+			<Select hasScrollLock={hasScrollLock}>
+				<Label>Label</Label>
+				<Button>
+					<SelectValue />
+					<Icon name="chevron-down" size="small" />
+				</Button>
+				<Popover>
+					<ListBox>
+						<ListBoxItem>Item one</ListBoxItem>
+					</ListBox>
+				</Popover>
+			</Select>,
+		);
+
+	it('does not mark the popover when hasScrollLock defaults to true', async () => {
+		const user = userEvent.setup();
+		renderSelect();
+
+		await user.click(screen.getByRole('button'));
+		const popover = (await screen.findByRole('listbox')).closest('[data-trigger="Select"]');
+		expect(popover).not.toHaveAttribute('data-no-scroll-lock');
+	});
+
+	it('marks the popover with data-no-scroll-lock when hasScrollLock is false', async () => {
+		const user = userEvent.setup();
+		renderSelect(false);
+
+		await user.click(screen.getByRole('button'));
+		const popover = (await screen.findByRole('listbox')).closest('[data-trigger="Select"]');
+		expect(popover).toHaveAttribute('data-no-scroll-lock');
+	});
 });

--- a/packages/components/src/ComboBox.tsx
+++ b/packages/components/src/ComboBox.tsx
@@ -20,6 +20,13 @@ const comboBoxStyles = cva(styles.box);
 
 interface ComboBoxProps<T extends object> extends AriaComboBoxProps<T> {
 	ref?: Ref<HTMLDivElement>;
+	/**
+	 * Whether the app-level scroll lock should engage while this combo box's popover is open.
+	 * When `false`, the popover is marked with `data-no-scroll-lock` so a consuming app
+	 * (e.g. Gonfalon) can exclude this instance from its background scroll lock.
+	 * @default true
+	 */
+	hasScrollLock?: boolean;
 }
 
 interface ComboBoxClearButtonProps extends Partial<IconButtonProps> {}
@@ -34,7 +41,7 @@ const ComboBoxContext = createContext<ContextValue<ComboBoxProps<any>, HTMLDivEl
  */
 const ComboBox = <T extends object>({ ref, ...props }: ComboBoxProps<T>) => {
 	[props, ref] = useLPContextProps(props, ref, ComboBoxContext);
-	const { menuTrigger = 'focus' } = props;
+	const { menuTrigger = 'focus', hasScrollLock = true, ...comboBoxProps } = props;
 	const groupRef = useRef<HTMLDivElement>(null);
 	// https://github.com/adobe/react-spectrum/blob/main/packages/react-aria-components/src/ComboBox.tsx#L152-L166
 	const [groupWidth, setGroupWidth] = useState<string | null>(null);
@@ -53,13 +60,13 @@ const ComboBox = <T extends object>({ ref, ...props }: ComboBoxProps<T>) => {
 	return (
 		<AriaComboBox
 			menuTrigger={menuTrigger}
-			{...props}
+			{...comboBoxProps}
 			ref={ref}
-			className={composeRenderProps(props.className, (className, renderProps) =>
+			className={composeRenderProps(comboBoxProps.className, (className, renderProps) =>
 				comboBoxStyles({ ...renderProps, className }),
 			)}
 		>
-			{composeRenderProps(props.children, (children, { isInvalid, isDisabled }) => (
+			{composeRenderProps(comboBoxProps.children, (children, { isInvalid, isDisabled }) => (
 				<Provider
 					values={[
 						[GroupContext, { ref: groupRef, isInvalid, isDisabled }],
@@ -68,6 +75,7 @@ const ComboBox = <T extends object>({ ref, ...props }: ComboBoxProps<T>) => {
 							{
 								triggerRef: groupRef,
 								style: { '--trigger-width': groupWidth } as CSSProperties,
+								...(hasScrollLock ? {} : { 'data-no-scroll-lock': true }),
 							},
 						],
 					]}

--- a/packages/components/src/Popover.tsx
+++ b/packages/components/src/Popover.tsx
@@ -19,6 +19,12 @@ import { useLPContextProps } from './utils';
 
 interface PopoverProps extends AriaPopoverProps, VariantProps<typeof popoverStyles> {
 	ref?: Ref<HTMLElement>;
+	/**
+	 * Marks the popover element with the `data-no-scroll-lock` attribute so a consuming app
+	 * can exclude it from any app-level background scroll lock. Set indirectly via the
+	 * `hasScrollLock` prop on `Select`/`ComboBox`.
+	 */
+	'data-no-scroll-lock'?: boolean;
 }
 interface OverlayArrowProps extends Omit<AriaOverlayArrowProps, 'children'> {
 	ref?: Ref<HTMLDivElement>;

--- a/packages/components/src/Select.tsx
+++ b/packages/components/src/Select.tsx
@@ -12,6 +12,7 @@ import { Select as AriaSelect, SelectValue as AriaSelectValue } from 'react-aria
 import { Provider } from 'react-aria-components/slots';
 
 import { ButtonContext } from './Button';
+import { PopoverContext } from './Popover';
 import baseStyles from './styles/base.module.css';
 import styles from './styles/Select.module.css';
 import { useLPContextProps } from './utils';
@@ -21,6 +22,13 @@ const selectValueStyles = cva(styles.value);
 
 interface SelectProps<T extends object> extends AriaSelectProps<T> {
 	ref?: Ref<HTMLDivElement>;
+	/**
+	 * Whether the app-level scroll lock should engage while this select's popover is open.
+	 * When `false`, the popover is marked with `data-no-scroll-lock` so a consuming app
+	 * (e.g. Gonfalon) can exclude this instance from its background scroll lock.
+	 * @default true
+	 */
+	hasScrollLock?: boolean;
 }
 
 interface SelectValueProps<T extends object> extends AriaSelectValueProps<T> {
@@ -40,15 +48,16 @@ const SelectValueContext =
  */
 const Select = <T extends object>({ ref, ...props }: SelectProps<T>) => {
 	[props, ref] = useLPContextProps(props, ref, SelectContext);
+	const { hasScrollLock = true, ...selectProps } = props;
 	return (
 		<AriaSelect
-			{...props}
+			{...selectProps}
 			ref={ref}
-			className={composeRenderProps(props.className, (className, renderProps) =>
+			className={composeRenderProps(selectProps.className, (className, renderProps) =>
 				selectStyles({ ...renderProps, className }),
 			)}
 		>
-			{composeRenderProps(props.children, (children, { isInvalid }) => (
+			{composeRenderProps(selectProps.children, (children, { isInvalid }) => (
 				<Provider
 					values={[
 						[
@@ -59,6 +68,7 @@ const Select = <T extends object>({ ref, ...props }: SelectProps<T>) => {
 								size: null,
 							},
 						],
+						[PopoverContext, hasScrollLock ? {} : { 'data-no-scroll-lock': true }],
 					]}
 				>
 					{children}


### PR DESCRIPTION
## Summary

Adds a `hasScrollLock` prop (default `true`) to `Select` and `ComboBox`. When `false`, the component's popover is marked with the `data-no-scroll-lock` attribute so a consuming app can exclude that specific instance from an app-level background scroll lock.

Context: Gonfalon scrolls in nested layout containers rather than the document, so React Aria's document-level modal scroll lock is a no-op there. Gonfalon adds an app-shell hook (launchdarkly/gonfalon#67782) that locks its real scroll containers while a Select/Menu/ComboBox overlay is open, and honors `data-no-scroll-lock` on the open overlay as a per-instance opt-out. This PR gives design-system consumers a typed, discoverable way to set that opt-out instead of reaching for a raw attribute.

Mechanics (kept generic — no product logic):
- Both components already provide `PopoverContext` (Select via RAC internals + a new launchpad `PopoverContext` entry; ComboBox via its existing `Provider`). When `hasScrollLock` is `false`, they thread `data-no-scroll-lock` through that context.
- RAC's `Popover` forwards global DOM props onto the popover element (`filterDOMProps(props, { global: true })`), so the attribute lands on the `[data-trigger="Select"]` / `[data-trigger="ComboBox"]` popover element.
- `data-no-scroll-lock` is declared on launchpad's `PopoverProps` so it is typed (RAC's `GlobalDOMAttributes` has no `data-*` index signature).

```tsx
// opts this instance out of the consuming app's scroll lock
<Select hasScrollLock={false}>…</Select>
<ComboBox hasScrollLock={false}>…</ComboBox>
```

## Screenshots (if appropriate):

No visual change — this only conditionally adds a data attribute to the popover element.

## Testing approaches

- Added unit tests to `Select.spec.tsx` and `ComboBox.spec.tsx`: opening each component asserts the popover has `data-no-scroll-lock` when `hasScrollLock={false}` and lacks it by default.
- `pnpm vitest run` for both specs: 7/7 pass. `tsc` typecheck and Biome clean.


Link to Devin session: https://app.devin.ai/sessions/8a5d2d3d589541a9b4bf71891c8017a4
Requested by: @joannerd

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Opt-in DOM attribute and default-true behavior; no auth or data changes, covered by unit tests.
> 
> **Overview**
> Adds a **`hasScrollLock`** prop (default **`true`**) to **`Select`** and **`ComboBox`**. When set to **`false`**, the open popover gets **`data-no-scroll-lock`** so host apps can skip app-level background scroll lock for that instance.
> 
> **`Select`** now supplies **`PopoverContext`** (alongside existing button context) with that attribute when opted out; **`ComboBox`** extends its existing popover context the same way. **`PopoverProps`** documents/types **`data-no-scroll-lock`** for consumers and RAC forwarding.
> 
> Unit tests cover default vs **`hasScrollLock={false}`** for both components; changeset is **minor** for **`@launchpad-ui/components`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e46e38e2628ca45a3337e99ac7f8f109b2c90e90. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->