### PR TITLE
chore: drop tsconfig baseUrl and enable type-aware oxlint

### DIFF
--- a/.changeset/drop-tsconfig-baseurl.md
+++ b/.changeset/drop-tsconfig-baseurl.md
@@ -1,0 +1,4 @@
+---
+---
+
+Drop `baseUrl` from `tsconfig.json` and `packages/tokens/tsconfig.json`, and enable oxlint's type-aware lane (`pnpm oxlint:js:full`, now also run in CI) ahead of launchpad-ui merging into gonfalon, whose oxlint-tsgolint type-aware lane hard-rejects any tsconfig containing `baseUrl` (tsgolint#351). Both files used `baseUrl: "."`, so `paths` already resolved correctly relative to each tsconfig and needed no changes. Fixed the real findings the type-aware lane surfaced on its first run (unawaited promises, awaiting non-promise values, async functions with no `await`, and two class fields that should be `readonly`) — tooling/config plus internal correctness fixes only, no published package's public API or behavior changed, so no version bump is needed.

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -99,7 +99,7 @@ jobs:
         run: pnpm install
 
       - name: Run Oxlint
-        run: pnpm oxlint:js
+        run: pnpm oxlint:js:full
 
       - name: Check formatting
         run: pnpm fmt:check

--- a/apps/vscode/src/client.ts
+++ b/apps/vscode/src/client.ts
@@ -31,7 +31,7 @@ export function activate(context: ExtensionContext) {
 	client = new LanguageClient('LaunchPadDesignSystem', 'LaunchPad Design System', serverOptions, clientOptions);
 
 	// Start the client. This will also launch the server
-	client.start();
+	void client.start();
 }
 
 export function deactivate(): Thenable<void> | undefined {

--- a/packages/button/__tests__/Button.spec.tsx
+++ b/packages/button/__tests__/Button.spec.tsx
@@ -52,12 +52,12 @@ describe('Button', () => {
 		expect(screen.getByRole('button')).toHaveFocus();
 	});
 
-	it('can render an icon', async () => {
+	it('can render an icon', () => {
 		const { container } = render(<Button kind="primary" icon={<Icon name="add" />} />);
 		expect(container.querySelector('svg')).not.toBeNull();
 	});
 
-	it('shows loading text when loading', async () => {
+	it('shows loading text when loading', () => {
 		render(
 			<Button isLoading loadingText="loading">
 				Primary Button

--- a/packages/button/__tests__/IconButton.spec.tsx
+++ b/packages/button/__tests__/IconButton.spec.tsx
@@ -52,7 +52,7 @@ describe('Button', () => {
 		expect(screen.getByRole('button', { name: 'Close' })).toHaveFocus();
 	});
 
-	it('can render an icon', async () => {
+	it('can render an icon', () => {
 		const { container } = render(<IconButton aria-label="Close" icon={<Icon name="cancel" />} />);
 		expect(container.querySelector('svg')).not.toBeNull();
 	});

--- a/packages/components/__tests__/Perceivable.spec.tsx
+++ b/packages/components/__tests__/Perceivable.spec.tsx
@@ -73,6 +73,6 @@ describe('Perceivable', () => {
 		);
 
 		await user.click(screen.getByRole('button', { hidden: true }));
-		expect(await screen.queryByRole('dialog')).toBeNull();
+		expect(screen.queryByRole('dialog')).toBeNull();
 	});
 });

--- a/packages/components/__tests__/ToggleButtonGroupElevated.spec.tsx
+++ b/packages/components/__tests__/ToggleButtonGroupElevated.spec.tsx
@@ -21,7 +21,7 @@ describe('ToggleButtonGroup appearance="elevated"', () => {
 		expect(screen.getByRole('radiogroup')).toBeVisible();
 	});
 
-	it('supports selection', async () => {
+	it('supports selection', () => {
 		render(
 			<ToggleButtonGroup appearance="elevated" defaultSelectedKeys={['first']}>
 				<ToggleButton appearance="elevated" id="first">

--- a/packages/components/stories/Autocomplete.stories.tsx
+++ b/packages/components/stories/Autocomplete.stories.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { expect, userEvent, within } from 'storybook/test';
+import { userEvent, within } from 'storybook/test';
 
 import { Icon } from '@launchpad-ui/icons';
 
@@ -30,7 +30,7 @@ const open = {
 
 		await userEvent.click(canvas.getByRole('button'));
 		const body = canvasElement.ownerDocument.body;
-		await expect(await within(body).findByRole('dialog'));
+		await within(body).findByRole('dialog');
 		await userEvent.keyboard('{arrowdown}');
 	},
 };

--- a/packages/components/stories/ComboBox.stories.tsx
+++ b/packages/components/stories/ComboBox.stories.tsx
@@ -1,6 +1,6 @@
 import type { ComponentType } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { expect, userEvent, within } from 'storybook/test';
+import { userEvent, within } from 'storybook/test';
 
 import { Icon } from '@launchpad-ui/icons';
 import { vars } from '@launchpad-ui/vars';
@@ -37,7 +37,7 @@ const open = {
 
 		await userEvent.click(canvas.getByRole('button'));
 		const body = canvasElement.ownerDocument.body;
-		await expect(await within(body).findByRole('listbox'));
+		await within(body).findByRole('listbox');
 	},
 };
 

--- a/packages/components/stories/DatePicker.stories.tsx
+++ b/packages/components/stories/DatePicker.stories.tsx
@@ -1,7 +1,7 @@
 import type { ComponentType } from 'react';
 import { parseDate } from '@internationalized/date';
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { expect, userEvent, within } from 'storybook/test';
+import { userEvent, within } from 'storybook/test';
 
 import { Icon } from '@launchpad-ui/icons';
 import { vars } from '@launchpad-ui/vars';
@@ -74,7 +74,7 @@ export const Example: Story = {
 
 		await userEvent.click(canvas.getByRole('button'));
 		const body = canvasElement.ownerDocument.body;
-		await expect(await within(body).findByRole('application'));
+		await within(body).findByRole('application');
 	},
 };
 
@@ -118,7 +118,7 @@ export const InForms: Story = {
 
 		await userEvent.click(canvas.getByRole('button'));
 		const body = canvasElement.ownerDocument.body;
-		await expect(await within(body).findByRole('application'));
+		await within(body).findByRole('application');
 	},
 };
 

--- a/packages/components/stories/DateRangePicker.stories.tsx
+++ b/packages/components/stories/DateRangePicker.stories.tsx
@@ -1,7 +1,7 @@
 import type { ComponentType } from 'react';
 import { parseDate } from '@internationalized/date';
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { expect, userEvent, within } from 'storybook/test';
+import { userEvent, within } from 'storybook/test';
 
 import { Icon } from '@launchpad-ui/icons';
 import { vars } from '@launchpad-ui/vars';
@@ -76,7 +76,7 @@ export const Example: Story = {
 
 		await userEvent.click(canvas.getByRole('button'));
 		const body = canvasElement.ownerDocument.body;
-		await expect(await within(body).findByRole('application'));
+		await within(body).findByRole('application');
 	},
 };
 
@@ -125,6 +125,6 @@ export const InForms: Story = {
 
 		await userEvent.click(canvas.getByRole('button'));
 		const body = canvasElement.ownerDocument.body;
-		await expect(await within(body).findByRole('application'));
+		await within(body).findByRole('application');
 	},
 };

--- a/packages/components/stories/Menu.stories.tsx
+++ b/packages/components/stories/Menu.stories.tsx
@@ -78,7 +78,7 @@ const open = {
 
 		await userEvent.click(canvas.getByRole('button'));
 		const body = canvasElement.ownerDocument.body;
-		await expect(await within(body).findByRole('menu'));
+		await within(body).findByRole('menu');
 	},
 };
 

--- a/packages/components/stories/Modal.stories.tsx
+++ b/packages/components/stories/Modal.stories.tsx
@@ -71,7 +71,7 @@ const play: PlayFunction<ReactRenderer> = async ({ canvasElement }) => {
 	await userEvent.click(canvas.getByRole('button'));
 	const body = canvasElement.ownerDocument.body;
 	await waitFor(async () => {
-		expect(await within(body).findByRole('dialog')).toBeVisible();
+		await expect(await within(body).findByRole('dialog')).toBeVisible();
 	});
 };
 

--- a/packages/components/stories/Popover.stories.tsx
+++ b/packages/components/stories/Popover.stories.tsx
@@ -1,7 +1,7 @@
 import type { ComponentType } from 'react';
 import type { Meta, ReactRenderer, StoryObj } from '@storybook/react-vite';
 import type { PlayFunction } from 'storybook/internal/types';
-import { expect, userEvent, within } from 'storybook/test';
+import { userEvent, within } from 'storybook/test';
 
 import { Button } from '../src/Button';
 import { Dialog, DialogTrigger } from '../src/Dialog';
@@ -36,7 +36,7 @@ const play: PlayFunction<ReactRenderer> = async ({ canvasElement }: { canvasElem
 
 	await userEvent.click(canvas.getByRole('button'));
 	const body = canvasElement.ownerDocument.body;
-	await expect(await within(body).findByRole('dialog'));
+	await within(body).findByRole('dialog');
 };
 
 export const Example: Story = {

--- a/packages/components/stories/Select.stories.tsx
+++ b/packages/components/stories/Select.stories.tsx
@@ -1,7 +1,7 @@
 import type { ComponentType } from 'react';
 import { useFilter } from 'react-aria-components/Autocomplete';
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { expect, userEvent, within } from 'storybook/test';
+import { userEvent, within } from 'storybook/test';
 
 import { Icon } from '@launchpad-ui/icons';
 import { vars } from '@launchpad-ui/vars';
@@ -46,7 +46,7 @@ const open = {
 
 		await userEvent.click(canvas.getByRole('button'));
 		const body = canvasElement.ownerDocument.body;
-		await expect(await within(body).findByRole('listbox'));
+		await within(body).findByRole('listbox');
 	},
 };
 

--- a/packages/components/stories/Toast.stories.tsx
+++ b/packages/components/stories/Toast.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { expect, userEvent, within } from 'storybook/test';
+import { userEvent, within } from 'storybook/test';
 
 import { Button } from '../src/Button';
 import { ButtonGroup } from '../src/ButtonGroup';
@@ -55,7 +55,7 @@ export const Example: Story = {
 
 		await userEvent.click(canvas.getAllByRole('button')[0]);
 		const body = canvasElement.ownerDocument.body;
-		await expect(await within(body).findByRole('alert'));
+		await within(body).findByRole('alert');
 	},
 };
 
@@ -95,6 +95,6 @@ export const Snackbar: Story = {
 
 		await userEvent.click(canvas.getAllByRole('button')[0]);
 		const body = canvasElement.ownerDocument.body;
-		await expect(await within(body).findByRole('alert'));
+		await within(body).findByRole('alert');
 	},
 };

--- a/packages/components/stories/Tooltip.stories.tsx
+++ b/packages/components/stories/Tooltip.stories.tsx
@@ -1,7 +1,7 @@
 import type { ComponentType } from 'react';
 import type { Meta, ReactRenderer, StoryObj } from '@storybook/react-vite';
 import type { PlayFunction } from 'storybook/internal/types';
-import { expect, userEvent, within } from 'storybook/test';
+import { userEvent, within } from 'storybook/test';
 
 import { Button } from '../src/Button';
 import { Focusable } from '../src/Focusable';
@@ -35,7 +35,7 @@ const play: PlayFunction<ReactRenderer> = async ({ canvasElement }: { canvasElem
 	await userEvent.hover(canvasElement);
 	await userEvent.hover(canvas.getByRole('button'));
 	const body = canvasElement.ownerDocument.body;
-	await expect(await within(body).findByRole('tooltip'));
+	await within(body).findByRole('tooltip');
 };
 
 export const Example: Story = {

--- a/packages/components/stories/recipes/composition.stories.tsx
+++ b/packages/components/stories/recipes/composition.stories.tsx
@@ -2,7 +2,7 @@ import type { ComponentPropsWithoutRef, Fragment } from 'react';
 import { useRef, useState } from 'react';
 import { VisuallyHidden } from 'react-aria/VisuallyHidden';
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { expect, userEvent, within } from 'storybook/test';
+import { userEvent, within } from 'storybook/test';
 
 import { Box } from '@launchpad-ui/box';
 import { Icon } from '@launchpad-ui/icons';
@@ -62,7 +62,7 @@ export const CopyToClipboard: Story = {
 					<Button
 						size="small"
 						onPress={() => {
-							navigator.clipboard.writeText('content');
+							void navigator.clipboard.writeText('content');
 							toastQueue.add({ title: 'Copied!', status: 'success' });
 						}}
 					>
@@ -80,7 +80,7 @@ export const CopyToClipboard: Story = {
 		await userEvent.hover(canvasElement);
 		await userEvent.hover(canvas.getByRole('button'));
 		const body = canvasElement.ownerDocument.body;
-		await expect(await within(body).findByRole('tooltip'));
+		await within(body).findByRole('tooltip');
 	},
 };
 

--- a/packages/drawer/__tests__/Drawer.spec.tsx
+++ b/packages/drawer/__tests__/Drawer.spec.tsx
@@ -30,7 +30,7 @@ describe('Drawer', () => {
 		expect(spy).toHaveBeenCalledTimes(1);
 	});
 
-	it('hides cancel button when hideCancel is passed in', async () => {
+	it('hides cancel button when hideCancel is passed in', () => {
 		render(
 			<Drawer hideCancel>
 				<DrawerHeader>Drawer</DrawerHeader>

--- a/packages/focus-trap/__tests__/FocusTrap.spec.tsx
+++ b/packages/focus-trap/__tests__/FocusTrap.spec.tsx
@@ -38,7 +38,7 @@ describe('FocusTrap', () => {
 		expect(screen.getByTestId('out-trap')).toHaveFocus();
 	});
 
-	it('returns context when useFocusTrapContext is called', async () => {
+	it('returns context when useFocusTrapContext is called', () => {
 		const { result } = renderHook(() => useFocusTrapContext());
 		expect(result.current.contain).toBeTruthy();
 	});

--- a/packages/icons/scripts/figma-connect.ts
+++ b/packages/icons/scripts/figma-connect.ts
@@ -27,4 +27,4 @@ ${components
 	);
 };
 
-generateIcons();
+void generateIcons();

--- a/packages/icons/scripts/figma-sync.ts
+++ b/packages/icons/scripts/figma-sync.ts
@@ -310,7 +310,7 @@ function buildSprite(symbols: SvgSymbol[]): string {
 }
 
 // Write file contents. Used to write the svg symbols to the sprite and to write the ids to types.ts
-async function writeFileAtomic(filePath: string, contents: string) {
+function writeFileAtomic(filePath: string, contents: string) {
 	if (DRY_RUN) {
 		log('fs', `(dry-run) would write ${path.relative(ROOT, filePath)} (${contents.length} bytes)`);
 		return;
@@ -470,13 +470,13 @@ async function main(): Promise<void> {
 
 	// 7) Build deterministic, alphabetically-sorted sprite
 	const sprite = buildSprite(symbols);
-	await writeFileAtomic(SPRITE_PATH, sprite);
+	writeFileAtomic(SPRITE_PATH, sprite);
 	log('build', `📦 sprite.svg written with ${symbols.length} symbol(s)`);
 
 	// 8) Write types.ts
 	const namesBlock = symbols.map((s) => `\t'${s.name}',`).join('\n');
 	const typesContent = generateTypes(namesBlock);
-	await writeFileAtomic(TYPES_PATH, typesContent);
+	writeFileAtomic(TYPES_PATH, typesContent);
 	log('build', `📦 types.ts written (${symbols.length} icons)`);
 
 	log('done', '✅ Icon refresh complete.');

--- a/packages/icons/stories/Icon.stories.tsx
+++ b/packages/icons/stories/Icon.stories.tsx
@@ -61,7 +61,7 @@ export const Gallery: Story = {
 								<Button
 									size="small"
 									onPress={() => {
-										navigator.clipboard.writeText(item);
+										void navigator.clipboard.writeText(item);
 										toastQueue.add({ title: 'Copied!', status: 'success' });
 									}}
 									variant="minimal"

--- a/packages/menu/__tests__/Menu.spec.tsx
+++ b/packages/menu/__tests__/Menu.spec.tsx
@@ -126,7 +126,7 @@ describe('Menu', () => {
 		expect(items[0]).toHaveFocus();
 	});
 
-	it('can render items into child slot', async () => {
+	it('can render items into child slot', () => {
 		const text = 'Click me';
 		render(
 			<Menu>

--- a/packages/modal/__tests__/Modal.spec.tsx
+++ b/packages/modal/__tests__/Modal.spec.tsx
@@ -46,7 +46,7 @@ describe('Modal', () => {
 		expect(spy).toHaveBeenCalledTimes(1);
 	});
 
-	it('calls onReady when modal is rendered', async () => {
+	it('calls onReady when modal is rendered', () => {
 		const spy = vi.fn();
 
 		render(<Modal onReady={spy}>Body</Modal>);
@@ -81,7 +81,7 @@ describe('Modal', () => {
 		expect(spy).toHaveBeenCalledTimes(1);
 	});
 
-	it('renders header icon when warning status is passed', async () => {
+	it('renders header icon when warning status is passed', () => {
 		render(
 			<Modal status="warning">
 				<ModalHeader title="Title" />
@@ -94,7 +94,7 @@ describe('Modal', () => {
 		expect(component).toBeInTheDocument();
 	});
 
-	it('renders required field when prop is passed', async () => {
+	it('renders required field when prop is passed', () => {
 		render(
 			<Modal>
 				<ModalHeader title="Title" hasRequiredField />
@@ -107,7 +107,7 @@ describe('Modal', () => {
 		expect(component).toBeInTheDocument();
 	});
 
-	it('renders description when passed', async () => {
+	it('renders description when passed', () => {
 		const content = 'test';
 
 		render(

--- a/packages/navigation/__tests__/Navigation.spec.tsx
+++ b/packages/navigation/__tests__/Navigation.spec.tsx
@@ -75,7 +75,7 @@ describe('Navigation', () => {
 		});
 	});
 
-	it('can render items with a chip', async () => {
+	it('can render items with a chip', () => {
 		render(
 			createComponent([
 				{
@@ -93,7 +93,7 @@ describe('Navigation', () => {
 		expect(screen.getByTestId('nav-item-chip')).not.toBeNull();
 	});
 
-	it('renders collapsed dropdown', async () => {
+	it('renders collapsed dropdown', () => {
 		vi.spyOn(ctx, 'useNavigationContext').mockReturnValue({
 			shouldCollapse: true,
 			refs: { wrapperRef: { current: null }, itemListRef: { current: null } },

--- a/packages/popover/src/Popover.tsx
+++ b/packages/popover/src/Popover.tsx
@@ -249,7 +249,7 @@ const Popover = ({
 				window.removeEventListener('resize', updatePosition);
 			}
 		};
-		updatePopover();
+		void updatePopover();
 	}, [isOpen, contentProp, popoverElement, updatePosition]);
 
 	useEffect(() => {

--- a/packages/tokens/src/build.ts
+++ b/packages/tokens/src/build.ts
@@ -222,7 +222,7 @@ const modes = new StyleDictionary({
 
 StyleDictionary.registerFormat({
 	name: 'css/themes',
-	format: async () => {
+	format: () => {
 		const lightMode = aliasTokens[`${light}.css`];
 		const darkMode = aliasTokens[`${dark}.css`];
 
@@ -232,7 +232,7 @@ StyleDictionary.registerFormat({
 
 StyleDictionary.registerFormat({
 	name: 'custom/font-face',
-	format: async ({ dictionary }) => {
+	format: ({ dictionary }) => {
 		return dictionary.allTokens
 			.map((token) => {
 				const {
@@ -252,14 +252,14 @@ StyleDictionary.registerFormat({
 
 StyleDictionary.registerFormat({
 	name: 'custom/json',
-	format: async ({ dictionary, options }) => {
+	format: ({ dictionary, options }) => {
 		return `${JSON.stringify(minifyDictionary(dictionary.tokens, options.usesDtcg), null, 2)}\n`;
 	},
 });
 
 StyleDictionary.registerFormat({
 	name: 'custom/media-query',
-	format: async ({ dictionary }) => {
+	format: ({ dictionary }) => {
 		return dictionary.allTokens
 			.map((token) => {
 				const { attributes, $value } = token;
@@ -284,7 +284,7 @@ StyleDictionary.registerFormat({
 
 StyleDictionary.registerFormat({
 	name: 'typescript/accurate-module-declarations',
-	format: async ({ dictionary, options }) => {
+	format: ({ dictionary, options }) => {
 		return `declare const root: RootObject\nexport default root\n${JsonToTS(
 			minifyDictionary(dictionary.tokens, options.usesDtcg),
 		).join('\n')}`;
@@ -293,7 +293,7 @@ StyleDictionary.registerFormat({
 
 StyleDictionary.registerFormat({
 	name: 'json/category',
-	format: async ({ dictionary }) => {
+	format: ({ dictionary }) => {
 		const groups = dictionary.allTokens.reduce((acc: TransformedToken, obj) => {
 			const key = obj.attributes?.category as string;
 			const group = acc[key] ?? [];
@@ -306,7 +306,7 @@ StyleDictionary.registerFormat({
 
 StyleDictionary.registerFormat({
 	name: 'json/figma',
-	format: async ({ dictionary }) => {
+	format: ({ dictionary }) => {
 		const tokens = dictionary.allTokens.map((token) => {
 			const { attributes, $description: description = '', $extensions } = token;
 			const { hiddenFromPublishing, scopes } = $extensions?.['com.figma'] || {};

--- a/packages/tokens/src/figma.ts
+++ b/packages/tokens/src/figma.ts
@@ -2,8 +2,8 @@ import type { GetLocalVariablesResponse, PostVariablesRequestBody, PostVariables
 import axios from 'axios';
 
 class FigmaApi {
-	private baseUrl = 'https://api.figma.com';
-	private token: string;
+	private readonly baseUrl = 'https://api.figma.com';
+	private readonly token: string;
 
 	constructor(token: string) {
 		this.token = token;

--- a/packages/tokens/src/sync.ts
+++ b/packages/tokens/src/sync.ts
@@ -51,4 +51,4 @@ const main = async () => {
 	console.log('%c ✅ Figma file has been updated with the new tokens', 'color:green;');
 };
 
-main();
+void main();

--- a/packages/tokens/stories/color.stories.tsx
+++ b/packages/tokens/stories/color.stories.tsx
@@ -89,7 +89,9 @@ const TokenTable = ({ tokens }: { tokens: Record<string, string> }) => {
 									<TooltipTrigger>
 										<Button
 											onPress={() => {
-												navigator.clipboard.writeText(value.substring(value.lastIndexOf('--'), value.lastIndexOf(')')));
+												void navigator.clipboard.writeText(
+													value.substring(value.lastIndexOf('--'), value.lastIndexOf(')')),
+												);
 												toastQueue.add({ title: 'Copied!', status: 'success' });
 											}}
 											style={{ font: 'var(--lp-text-code-1-regular)' }}

--- a/packages/tokens/stories/size.stories.tsx
+++ b/packages/tokens/stories/size.stories.tsx
@@ -30,7 +30,7 @@ export const Size = {
 						<TooltipTrigger>
 							<Button
 								onPress={() => {
-									navigator.clipboard.writeText(`--lp-size-${key}`);
+									void navigator.clipboard.writeText(`--lp-size-${key}`);
 									toastQueue.add({ title: 'Copied!', status: 'success' });
 								}}
 								style={{ font: 'var(--lp-text-code-1-regular)' }}

--- a/packages/tokens/stories/spacing.stories.tsx
+++ b/packages/tokens/stories/spacing.stories.tsx
@@ -45,7 +45,7 @@ export const Spacing = {
 						<TooltipTrigger>
 							<Button
 								onPress={() => {
-									navigator.clipboard.writeText(`--lp-spacing-${key}`);
+									void navigator.clipboard.writeText(`--lp-spacing-${key}`);
 									toastQueue.add({ title: 'Copied!', status: 'success' });
 								}}
 								style={{ font: 'var(--lp-text-code-1-regular)' }}

--- a/packages/tokens/stories/typography.stories.tsx
+++ b/packages/tokens/stories/typography.stories.tsx
@@ -190,7 +190,7 @@ const TokenTable = ({ tokens }: { tokens: Record<string, string> }) => {
 									<TooltipTrigger>
 										<Button
 											onPress={() => {
-												navigator.clipboard.writeText(`<${element} style="font: ${value}" />`);
+												void navigator.clipboard.writeText(`<${element} style="font: ${value}" />`);
 												toastQueue.add({ title: 'Copied!', status: 'success' });
 											}}
 											style={{ font: 'var(--lp-text-code-1-regular)' }}

--- a/packages/tokens/tsconfig.json
+++ b/packages/tokens/tsconfig.json
@@ -4,7 +4,6 @@
 	"compilerOptions": {
 		"lib": ["es2024", "dom", "dom.iterable"],
 		"moduleResolution": "bundler",
-		"baseUrl": ".",
 		"paths": {
 			"@launchpad-ui/*": ["../*/src"]
 		},

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,6 @@
 {
 	"extends": "./tsconfig.base.json",
 	"compilerOptions": {
-		"baseUrl": ".",
 		"paths": {
 			"@launchpad-ui/box": ["./packages/box/src"],
 			"@launchpad-ui/button": ["./packages/button/src"],


### PR DESCRIPTION
## Summary

Turns on oxlint's type-aware checks, which catch async and promise mistakes the basic checks can't see. One thing blocked them: the type checker rejects tsconfigs that set `baseUrl`, and ours set it without needing it — modern TypeScript resolves our `paths` aliases identically without it.

- `baseUrl` removed from the two tsconfigs that had it; every import in the repo was inventoried first to confirm nothing depended on it, and resolution is unchanged
- CI now runs the type-aware checks alongside the basic ones

The first-ever type-aware run found 42 real issues, all fixed at the source, none suppressed. Most were unnecessary `async` keywords and promises that were never awaited. One was a real test bug — a Modal assertion that could never retry — and 13 were checks that looked like assertions but asserted nothing.

Builds on #1971.

## Screenshots

None — tsconfig, CI, and test/lint fixes only.

## Testing approaches

Build, typecheck, 273 tests, both lint passes (0 findings), format check, and the Storybook build all green. Empty changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tooling and lint-driven internal fixes only; tsconfig and CI lint scope changes with no intended public API or product behavior changes.
> 
> **Overview**
> Prepares the repo for **gonfalon** merge by removing **`baseUrl`** from root and **`packages/tokens/tsconfig.json`** (paths still resolve the same) and running **type-aware oxlint** in CI via **`pnpm oxlint:js:full`** instead of the basic lane.
> 
> The first type-aware run fixed **42 issues** at the source—no rule suppressions: **`void`** on fire-and-forget promises (VS Code client, popover positioning, clipboard handlers, icon scripts), dropping mistaken **`async`** / **`await`** in tests and Storybook plays, **`readonly`** on Figma API fields, and synchronous Style Dictionary format handlers where **`async`** was unnecessary. Modal Storybook **`waitFor`** now actually asserts dialog visibility.
> 
> **No published package API or runtime behavior changes**; empty changeset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16bcf3b90fe27f76300d297edd719efc2bb434d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->