### PR TITLE
chore: point the blame-ignore file at the reformat squash commit

### DIFF
--- a/.changeset/blame-ignore-squash-hash.md
+++ b/.changeset/blame-ignore-squash-hash.md
@@ -1,0 +1,4 @@
+---
+---
+
+Point the blame-ignore file at the reformat squash-merge commit on main; the pre-squash hash it referenced does not exist in mainline history. Tooling-only.

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,10 +1,17 @@
-# Commits listed here are ignored by `git blame` (see `git blame --ignore-revs-file`).
-# Configure locally with:
+# What this file is:
+#
+# `git blame` answers "who last touched this line?". When a commit reformats
+# every file at once, it becomes the answer for almost every line, and the
+# person who actually wrote the code disappears from blame.
+#
+# This file lists commits like that, so blame can skip them and point at the
+# real author instead. GitHub's blame view reads it automatically ("ignoring
+# revisions in .git-blame-ignore-revs"). For local git, opt in once with:
+#
 #   git config blame.ignoreRevsFile .git-blame-ignore-revs
+#
+# Only add commits that change how code looks, never what it does (reformats,
+# whitespace sweeps). Use the hash of the commit as it exists on main.
 
-# chore: reformat repository with oxfmt
-882dbcfd113aa59e7f00861105310743d8b63012
-# TODO: this is the LOCAL commit hash from the isolated reformat branch. The repo
-# squash-merges PRs, so once this PR merges, append the resulting SQUASH-MERGE hash
-# on main here too (the local hash above will differ from — and not replace — the
-# squash hash; keep both so blame is ignored regardless of which history a checkout has).
+# chore: reformat repository with oxfmt (#1971, squash-merge commit on main)
+dd83557174d5d942182b92ff64888119572312b5


### PR DESCRIPTION
## Summary

TL;DR: this ensures that when we import the Launchpad git history into Gonfalon, we omit the `oxfmt` commit.

---

#1971 reformatted the whole repo so our formatting matches gonfalon's before the code moves there. The side effect: the reformat commit touched nearly every line, so `git blame` would now name it for everything and bury the real authors.

Git's fix for that is `.git-blame-ignore-revs`: a file listing commits blame should look straight past, jumping to whoever last made a real change. GitHub's blame view reads it automatically; local git needs a one-time `git config blame.ignoreRevsFile .git-blame-ignore-revs`.

#1971 shipped the file, but pointing at the reformat commit's hash from the PR branch. Since the repo squash-merges, the commit that landed on main has a different hash — the file referenced a commit that isn't in main's history, and blame wasn't skipping the reformat at all.

- Replaced the stale hash with `dd83557174d5d942182b92ff64888119572312b5`, the #1971 squash commit on main.
- Rewrote the file's header comment so the next reader knows what the file does and what belongs in it (formatting-only commits, by their hash on main).

This matters again at the migration itself: the same reformat commit rides into gonfalon's history with the import, and this file (with the right hashes) is what keeps blame useful for design system code there.

## Screenshots (if appropriate)

n/a

## Testing approaches

Ran `git blame --ignore-revs-file .git-blame-ignore-revs` on a reformatted component: lines attribute to their real authors instead of the reformat. Empty changeset (tooling-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and git blame configuration only; no runtime or application code changes.
> 
> **Overview**
> After #1971’s whole-repo **oxfmt** reformat, blame was still attributing most lines to the reformat because `.git-blame-ignore-revs` listed the **pre-squash PR branch hash**, which is not on `main` after squash-merge.
> 
> This PR **replaces** that entry with `dd83557174d5d942182b92ff64888119572312b5` (the squash commit on main) and **rewrites** the file header to explain what belongs in the list (formatting-only commits, hashes as they exist on main). A **changeset** notes the tooling-only fix for migration/import scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4482d2a43d1fb21f8ecad00f254caf1adf6c4017. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->