### PR TITLE
test(filter): stop two tests from depending on a spacing quirk of the test browser

### DIFF
--- a/.changeset/harden-filter-a11y-tests.md
+++ b/.changeset/harden-filter-a11y-tests.md
@@ -1,0 +1,4 @@
+---
+---
+
+Harden two accessible-name assertions in the filter package's tests against jsdom CSS-pipeline environment differences (test-only, no behavior change).

--- a/packages/filter/__tests__/AppliedFilter.spec.tsx
+++ b/packages/filter/__tests__/AppliedFilter.spec.tsx
@@ -17,7 +17,7 @@ const oneOption = [
 describe('AppliedFilter', () => {
 	it('renders the filter button', () => {
 		render(createComponent({ options: oneOption }));
-		expect(screen.getByRole('button', { name: 'author: osmo' })).toBeInTheDocument();
+		expect(screen.getByRole('button', { name: /^author:\s?osmo$/ })).toBeInTheDocument();
 	});
 
 	it('renders the filter button when there is no name', () => {

--- a/packages/filter/__tests__/AppliedFilterButton.spec.tsx
+++ b/packages/filter/__tests__/AppliedFilterButton.spec.tsx
@@ -14,7 +14,7 @@ describe('AppliedFilterButton', () => {
 	it('should render name and description', () => {
 		render(createComponent({ children: 'description' }));
 		expect(screen.getByRole('button')).toHaveTextContent('author:description');
-		expect(screen.getByRole('button')).toHaveAccessibleName('author: description');
+		expect(screen.getByRole('button')).toHaveAccessibleName(/^author:\s?description$/);
 	});
 
 	it('should hide name if not provided', () => {


### PR DESCRIPTION
## Summary

Two filter tests check the label of an applied-filter button, for example "author: osmo".

It turns out the space after the colon is not something our component produces. The label is stitched together from two side-by-side elements, and whether a space appears between them depends on the simulated browser we test in (jsdom). jsdom 26, our current version, applies no default styling to elements, and the label comes out as "author: osmo". jsdom 27 got more faithful to real browsers about default styles, and under it the same label comes out as "author:osmo". Same component, same code.

Our two tests currently insist on the version with the space, which means they block upgrading jsdom (#1981) even though the component is fine.

This change makes the two tests accept the label with or without that space, and nothing else. They still require the full label in the right order: the field name, the colon, the value.

## Testing approaches

- Whole filter test suite passes on jsdom 26 (current), run both ways: through the package's own test script and through vitest directly.
- The full suite also passes on jsdom 27 with these two assertions updated — that run lives on #1981, which builds on this.
- Test-only change, so the changeset is empty and nothing gets published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)