### PR TITLE
fix(components): revert the default Modal height cap

### DIFF
--- a/.changeset/revert-modal-height-cap.md
+++ b/.changeset/revert-modal-height-cap.md
@@ -1,0 +1,5 @@
+---
+'@launchpad-ui/components': patch
+---
+
+Revert the default Modal height cap introduced in 0.23.1. Making the modal container a flex column changed layout behavior for consumers that pass custom children or style the dialog (content could shrink to fit-content width, and consumer `min-height` rules were overridden). The cap will return in a follow-up scoped so it cannot affect consumer-provided content.

--- a/packages/components/src/styles/Modal.module.css
+++ b/packages/components/src/styles/Modal.module.css
@@ -41,8 +41,6 @@
 }
 
 .base {
-	display: flex;
-	flex-direction: column;
 	border-radius: var(--lp-border-radius-medium);
 	background-color: var(--lp-color-bg-overlay-primary);
 	border: 1px solid light-dark(transparent, var(--lp-color-border-ui-primary));
@@ -63,8 +61,7 @@
 		display: flex;
 		flex-direction: column;
 		gap: var(--lp-spacing-600);
-		flex: 1;
-		min-height: 0;
+		height: 100%;
 	}
 
 	& [role='dialog'] > [slot='subtitle'],
@@ -93,7 +90,6 @@
 	& [slot='body'] {
 		overflow: auto;
 		flex: 1;
-		min-height: 0;
 	}
 
 	& [slot='footer'] {
@@ -125,8 +121,6 @@
 }
 
 .default {
-	max-height: calc(100% - var(--lp-size-64));
-
 	@media (prefers-reduced-motion: no-preference) {
 		&[data-entering] {
 			animation-name: zoom;

--- a/packages/components/stories/Modal.stories.tsx
+++ b/packages/components/stories/Modal.stories.tsx
@@ -152,49 +152,6 @@ export const WithHeader: Story = {
 };
 
 /**
- * A Modal whose content is taller than the viewport. The overlay caps the modal's
- * height, so the `body` slot scrolls while the `header` and `footer` stay visible.
- */
-export const LongContent: Story = {
-	render: (args) => (
-		<DialogTrigger>
-			<Button>Trigger</Button>
-			<ModalOverlay>
-				<Modal {...args}>
-					<Dialog>
-						{({ close }) => (
-							<>
-								<div slot="header">
-									<Heading slot="title">Title</Heading>
-									<IconButton aria-label="close" icon="cancel" size="small" variant="minimal" onPress={close} />
-								</div>
-								<div slot="body">
-									{Array.from({ length: 40 }, (_, index) => (
-										<p key={index}>Body text {index + 1}</p>
-									))}
-								</div>
-								<div slot="footer">
-									<Button slot="close">Cancel</Button>
-									<Button variant="primary">Confirm</Button>
-								</div>
-							</>
-						)}
-					</Dialog>
-				</Modal>
-			</ModalOverlay>
-		</DialogTrigger>
-	),
-	play,
-	parameters: {
-		chromatic: {
-			modes: {
-				mobile: allModes.mobile,
-			},
-		},
-	},
-};
-
-/**
  * Bug reproduction: Dialog closes when clicking a button inside it while Toast is active.
  *
  * Steps to reproduce:


### PR DESCRIPTION
## Summary

> [!NOTE]
> FYI I will fix this again once launchpad is in gonfalon. It'll be easier to do it right when it's there.

Reverts #1979 (components 0.23.1). The cap itself was right, but the implementation made the modal container (`.base`) a flex column, which changes layout behavior for consumers:

- Any child with `align-self` or horizontal auto margins loses cross-axis stretch and shrinks to fit-content width (content renders squished to one side).
- Multiple inline-level children stack vertically instead of flowing.
- The new `min-height: 0` on the dialog and body is authored at 3- and 2-selector specificity, so it silently overrides consumer `min-height` rules that previously applied.

We saw both symptom classes in downstream visual regression runs after picking up 0.23.1. Reverting restores 0.23.0 behavior while a scoped follow-up is designed (apply the flex chain only to dialog-shaped content and give the dialog `width: 100%`, so consumer-provided content can't be affected).

## Screenshots (if appropriate)

None — this restores the previous visual behavior exactly.

## Testing approaches

- Clean `git revert` of the original commit (CSS + stories; the original changeset was already consumed by the release).
- Modal unit tests pass.
- Verified with a side-by-side harness (0.23.0 vs 0.23.1 built CSS) that the reverted rules restore full-width content for the affected layout patterns.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Restores prior Modal CSS behavior; no auth, data, or API changes—main risk is intentional loss of the viewport height cap until a follow-up ships.
> 
> **Overview**
> Reverts the **0.23.1** Modal layout changes that capped default modal height and made `.base` a flex column. That flex chain caused downstream regressions: content could shrink to fit-content width, and library `min-height: 0` overrode consumer styles.
> 
> **`Modal.module.css`** removes flex on `.base`, drops `max-height` on `.default`, and restores the prior dialog/body sizing (`height: 100%` on the slotted dialog instead of `flex: 1` / `min-height: 0`). **`LongContent`** Storybook coverage for viewport-tall modals is removed with the cap. A **patch** changeset documents the revert; a scoped height-cap follow-up is planned.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4a8d71391cae9667b939ecd3aeba296c6756933. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->