### PR TITLE
feat(components): add data-lp-variant and data-lp-indicator styling hooks

### DIFF
--- a/.changeset/stable-styling-hooks.md
+++ b/.changeset/stable-styling-hooks.md
@@ -1,0 +1,5 @@
+---
+'@launchpad-ui/components': minor
+---
+
+Expose stable public `data-variant` attributes on `Button`, `IconButton`, `ToggleButton`, `ToggleIconButton`, `LinkButton`, `LinkIconButton`, `RadioButton`, and `RadioIconButton`, and `data-indicator` attributes (`"checkbox"` / `"radio"`) on the `Checkbox` and `Radio` indicator elements. These attributes let consumers and tests target components by a documented contract instead of compiled CSS Module class names, following the same pattern already used by the `data-icon` attribute.

--- a/.changeset/stable-styling-hooks.md
+++ b/.changeset/stable-styling-hooks.md
@@ -2,4 +2,4 @@
 '@launchpad-ui/components': minor
 ---
 
-Expose stable public `data-variant` attributes on `Button`, `IconButton`, `ToggleButton`, `ToggleIconButton`, `LinkButton`, `LinkIconButton`, `RadioButton`, and `RadioIconButton`, and `data-indicator` attributes (`"checkbox"` / `"radio"`) on the `Checkbox` and `Radio` indicator elements. These attributes let consumers and tests target components by a documented contract instead of compiled CSS Module class names, following the same pattern already used by the `data-icon` attribute.
+Expose stable public `data-lp-variant` attributes on `Button`, `IconButton`, `ToggleButton`, `ToggleIconButton`, `LinkButton`, `LinkIconButton`, `RadioButton`, and `RadioIconButton`, and `data-lp-indicator` attributes (`"checkbox"` / `"radio"`) on the `Checkbox` and `Radio` indicator elements. These attributes let consumers and tests target components by a documented contract instead of compiled CSS Module class names, following the same pattern already used by the `data-icon` attribute.

--- a/packages/components/__tests__/Button.spec.tsx
+++ b/packages/components/__tests__/Button.spec.tsx
@@ -13,4 +13,14 @@ describe('Button', () => {
 		render(<Button isPending>Button</Button>);
 		expect(screen.getByRole('progressbar')).toBeVisible();
 	});
+
+	it('exposes the resolved variant as a data attribute', () => {
+		render(<Button>Button</Button>);
+		expect(screen.getByRole('button')).toHaveAttribute('data-variant', 'default');
+	});
+
+	it('exposes an explicit variant as a data attribute', () => {
+		render(<Button variant="primary">Button</Button>);
+		expect(screen.getByRole('button')).toHaveAttribute('data-variant', 'primary');
+	});
 });

--- a/packages/components/__tests__/Button.spec.tsx
+++ b/packages/components/__tests__/Button.spec.tsx
@@ -16,11 +16,11 @@ describe('Button', () => {
 
 	it('exposes the resolved variant as a data attribute', () => {
 		render(<Button>Button</Button>);
-		expect(screen.getByRole('button')).toHaveAttribute('data-variant', 'default');
+		expect(screen.getByRole('button')).toHaveAttribute('data-lp-variant', 'default');
 	});
 
 	it('exposes an explicit variant as a data attribute', () => {
 		render(<Button variant="primary">Button</Button>);
-		expect(screen.getByRole('button')).toHaveAttribute('data-variant', 'primary');
+		expect(screen.getByRole('button')).toHaveAttribute('data-lp-variant', 'primary');
 	});
 });

--- a/packages/components/__tests__/Checkbox.spec.tsx
+++ b/packages/components/__tests__/Checkbox.spec.tsx
@@ -21,6 +21,6 @@ describe('Checkbox', () => {
 
 	it('exposes a stable indicator hook for styling and tests', () => {
 		const { container } = render(<Checkbox>Label</Checkbox>);
-		expect(container.querySelector('[data-indicator="checkbox"]')).toBeInTheDocument();
+		expect(container.querySelector('[data-lp-indicator="checkbox"]')).toBeInTheDocument();
 	});
 });

--- a/packages/components/__tests__/Checkbox.spec.tsx
+++ b/packages/components/__tests__/Checkbox.spec.tsx
@@ -18,4 +18,9 @@ describe('Checkbox', () => {
 		render(<Checkbox isSelected>Label</Checkbox>);
 		expect(screen.getByRole('checkbox')).toBeVisible();
 	});
+
+	it('exposes a stable indicator hook for styling and tests', () => {
+		const { container } = render(<Checkbox>Label</Checkbox>);
+		expect(container.querySelector('[data-indicator="checkbox"]')).toBeInTheDocument();
+	});
 });

--- a/packages/components/__tests__/RadioGroup.spec.tsx
+++ b/packages/components/__tests__/RadioGroup.spec.tsx
@@ -16,6 +16,16 @@ describe('Radio', () => {
 		expect(screen.getByRole('radiogroup')).toBeVisible();
 	});
 
+	it('exposes a stable indicator hook for styling and tests', () => {
+		const { container } = render(
+			<RadioGroup>
+				<Label>Label</Label>
+				<Radio value="1">First</Radio>
+			</RadioGroup>,
+		);
+		expect(container.querySelector('[data-indicator="radio"]')).toBeInTheDocument();
+	});
+
 	it('renders selected', () => {
 		render(
 			<RadioGroup defaultValue="2">

--- a/packages/components/__tests__/RadioGroup.spec.tsx
+++ b/packages/components/__tests__/RadioGroup.spec.tsx
@@ -23,7 +23,7 @@ describe('Radio', () => {
 				<Radio value="1">First</Radio>
 			</RadioGroup>,
 		);
-		expect(container.querySelector('[data-indicator="radio"]')).toBeInTheDocument();
+		expect(container.querySelector('[data-lp-indicator="radio"]')).toBeInTheDocument();
 	});
 
 	it('renders selected', () => {

--- a/packages/components/__tests__/ToggleButton.spec.tsx
+++ b/packages/components/__tests__/ToggleButton.spec.tsx
@@ -8,4 +8,14 @@ describe('ToggleButton', () => {
 		render(<ToggleButton>toggle</ToggleButton>);
 		expect(screen.getByRole('button')).toBeVisible();
 	});
+
+	it('exposes the resolved variant as a data attribute', () => {
+		render(<ToggleButton variant="primary">toggle</ToggleButton>);
+		expect(screen.getByRole('button')).toHaveAttribute('data-variant', 'primary');
+	});
+
+	it('exposes the variant as a data attribute when elevated', () => {
+		render(<ToggleButton appearance="elevated">toggle</ToggleButton>);
+		expect(screen.getByRole('button')).toHaveAttribute('data-variant', 'default');
+	});
 });

--- a/packages/components/__tests__/ToggleButton.spec.tsx
+++ b/packages/components/__tests__/ToggleButton.spec.tsx
@@ -11,11 +11,11 @@ describe('ToggleButton', () => {
 
 	it('exposes the resolved variant as a data attribute', () => {
 		render(<ToggleButton variant="primary">toggle</ToggleButton>);
-		expect(screen.getByRole('button')).toHaveAttribute('data-variant', 'primary');
+		expect(screen.getByRole('button')).toHaveAttribute('data-lp-variant', 'primary');
 	});
 
 	it('exposes the variant as a data attribute when elevated', () => {
 		render(<ToggleButton appearance="elevated">toggle</ToggleButton>);
-		expect(screen.getByRole('button')).toHaveAttribute('data-variant', 'default');
+		expect(screen.getByRole('button')).toHaveAttribute('data-lp-variant', 'default');
 	});
 });

--- a/packages/components/src/Button.tsx
+++ b/packages/components/src/Button.tsx
@@ -62,7 +62,7 @@ const Button = ({ ref, ...props }: ButtonProps) => {
 			{...mergedProps}
 			{...perceivableProps}
 			ref={mergedRef}
-			data-variant={variant}
+			data-lp-variant={variant}
 			className={composeRenderProps(mergedProps.className, (className, renderProps) =>
 				buttonStyles({ ...renderProps, size, variant, className }),
 			)}

--- a/packages/components/src/Button.tsx
+++ b/packages/components/src/Button.tsx
@@ -62,6 +62,7 @@ const Button = ({ ref, ...props }: ButtonProps) => {
 			{...mergedProps}
 			{...perceivableProps}
 			ref={mergedRef}
+			data-variant={variant}
 			className={composeRenderProps(mergedProps.className, (className, renderProps) =>
 				buttonStyles({ ...renderProps, size, variant, className }),
 			)}

--- a/packages/components/src/Checkbox.tsx
+++ b/packages/components/src/Checkbox.tsx
@@ -14,7 +14,7 @@ const checkboxStyles = cva(styles.checkbox);
 const checkboxIconStyles = cva(styles.box);
 
 const CheckboxIcon = ({ isSelected, isIndeterminate }: Partial<CheckboxRenderProps>) => (
-	<div className={checkboxIconStyles()}>
+	<div className={checkboxIconStyles()} data-indicator="checkbox">
 		{isIndeterminate ? (
 			<svg aria-hidden="true" className={styles.icon} viewBox="0 0 16 16">
 				<path fillRule="evenodd" clipPath="evenodd" d="M3.5 8a1 1 0 0 1 1-1h7a1 1 0 1 1 0 2h-7a1 1 0 0 1-1-1Z" />

--- a/packages/components/src/Checkbox.tsx
+++ b/packages/components/src/Checkbox.tsx
@@ -14,7 +14,7 @@ const checkboxStyles = cva(styles.checkbox);
 const checkboxIconStyles = cva(styles.box);
 
 const CheckboxIcon = ({ isSelected, isIndeterminate }: Partial<CheckboxRenderProps>) => (
-	<div className={checkboxIconStyles()} data-indicator="checkbox">
+	<div className={checkboxIconStyles()} data-lp-indicator="checkbox">
 		{isIndeterminate ? (
 			<svg aria-hidden="true" className={styles.icon} viewBox="0 0 16 16">
 				<path fillRule="evenodd" clipPath="evenodd" d="M3.5 8a1 1 0 0 1 1-1h7a1 1 0 1 1 0 2h-7a1 1 0 0 1-1-1Z" />

--- a/packages/components/src/IconButton.tsx
+++ b/packages/components/src/IconButton.tsx
@@ -63,7 +63,7 @@ const IconButton = ({ ref, ...props }: IconButtonProps) => {
 			{...mergedProps}
 			{...perceivableProps}
 			ref={mergedRef}
-			data-variant={variant}
+			data-lp-variant={variant}
 			className={composeRenderProps(mergedProps.className, (className, renderProps) =>
 				cx(buttonStyles({ ...renderProps, size, variant, className }), iconButtonStyles({ size })),
 			)}

--- a/packages/components/src/IconButton.tsx
+++ b/packages/components/src/IconButton.tsx
@@ -63,6 +63,7 @@ const IconButton = ({ ref, ...props }: IconButtonProps) => {
 			{...mergedProps}
 			{...perceivableProps}
 			ref={mergedRef}
+			data-variant={variant}
 			className={composeRenderProps(mergedProps.className, (className, renderProps) =>
 				cx(buttonStyles({ ...renderProps, size, variant, className }), iconButtonStyles({ size })),
 			)}

--- a/packages/components/src/LinkButton.tsx
+++ b/packages/components/src/LinkButton.tsx
@@ -25,7 +25,7 @@ const LinkButton = ({ ref, ...props }: LinkButtonProps) => {
 		<Link
 			{...mergedProps}
 			ref={mergedRef}
-			data-variant={variant}
+			data-lp-variant={variant}
 			className={composeRenderProps(mergedProps.className, (className, renderProps) =>
 				buttonStyles({ ...renderProps, size, variant, className }),
 			)}

--- a/packages/components/src/LinkButton.tsx
+++ b/packages/components/src/LinkButton.tsx
@@ -25,6 +25,7 @@ const LinkButton = ({ ref, ...props }: LinkButtonProps) => {
 		<Link
 			{...mergedProps}
 			ref={mergedRef}
+			data-variant={variant}
 			className={composeRenderProps(mergedProps.className, (className, renderProps) =>
 				buttonStyles({ ...renderProps, size, variant, className }),
 			)}

--- a/packages/components/src/LinkIconButton.tsx
+++ b/packages/components/src/LinkIconButton.tsx
@@ -29,6 +29,7 @@ const LinkIconButton = ({ ref, ...props }: LinkIconButtonProps) => {
 		<Link
 			{...mergedProps}
 			ref={mergedRef}
+			data-variant={variant}
 			className={composeRenderProps(mergedProps.className, (className, renderProps) =>
 				cx(buttonStyles({ ...renderProps, size, variant, className }), iconButtonStyles({ size })),
 			)}

--- a/packages/components/src/LinkIconButton.tsx
+++ b/packages/components/src/LinkIconButton.tsx
@@ -29,7 +29,7 @@ const LinkIconButton = ({ ref, ...props }: LinkIconButtonProps) => {
 		<Link
 			{...mergedProps}
 			ref={mergedRef}
-			data-variant={variant}
+			data-lp-variant={variant}
 			className={composeRenderProps(mergedProps.className, (className, renderProps) =>
 				cx(buttonStyles({ ...renderProps, size, variant, className }), iconButtonStyles({ size })),
 			)}

--- a/packages/components/src/Radio.tsx
+++ b/packages/components/src/Radio.tsx
@@ -20,7 +20,7 @@ interface RadioProps extends AriaRadioProps {
 const RadioContext = createContext<ContextValue<RadioProps, HTMLLabelElement>>(null);
 
 const RadioIcon = ({ isSelected }: Partial<RadioRenderProps>) => (
-	<div className={radioIconStyles()} data-indicator="radio">
+	<div className={radioIconStyles()} data-lp-indicator="radio">
 		{isSelected ? (
 			<svg aria-hidden="true" className={styles.icon} viewBox="0 0 16 16">
 				<path fillRule="evenodd" clipPath="evenodd" d="M6.852 5.228a3 3 0 1 1 2.296 5.544 3 3 0 0 1-2.296-5.544Z" />

--- a/packages/components/src/Radio.tsx
+++ b/packages/components/src/Radio.tsx
@@ -20,7 +20,7 @@ interface RadioProps extends AriaRadioProps {
 const RadioContext = createContext<ContextValue<RadioProps, HTMLLabelElement>>(null);
 
 const RadioIcon = ({ isSelected }: Partial<RadioRenderProps>) => (
-	<div className={radioIconStyles()}>
+	<div className={radioIconStyles()} data-indicator="radio">
 		{isSelected ? (
 			<svg aria-hidden="true" className={styles.icon} viewBox="0 0 16 16">
 				<path fillRule="evenodd" clipPath="evenodd" d="M6.852 5.228a3 3 0 1 1 2.296 5.544 3 3 0 0 1-2.296-5.544Z" />

--- a/packages/components/src/RadioButton.tsx
+++ b/packages/components/src/RadioButton.tsx
@@ -28,7 +28,7 @@ const RadioButton = ({ ref, ...props }: RadioButtonProps) => {
 		<AriaRadio
 			{...mergedProps}
 			ref={mergedRef}
-			data-variant={variant}
+			data-lp-variant={variant}
 			className={composeRenderProps(mergedProps.className, (className, renderProps) =>
 				buttonStyles({ ...renderProps, size, variant, className }),
 			)}

--- a/packages/components/src/RadioButton.tsx
+++ b/packages/components/src/RadioButton.tsx
@@ -28,6 +28,7 @@ const RadioButton = ({ ref, ...props }: RadioButtonProps) => {
 		<AriaRadio
 			{...mergedProps}
 			ref={mergedRef}
+			data-variant={variant}
 			className={composeRenderProps(mergedProps.className, (className, renderProps) =>
 				buttonStyles({ ...renderProps, size, variant, className }),
 			)}

--- a/packages/components/src/RadioIconButton.tsx
+++ b/packages/components/src/RadioIconButton.tsx
@@ -32,7 +32,7 @@ const RadioIconButton = ({ ref, ...props }: RadioIconButtonProps) => {
 		<AriaRadio
 			{...mergedProps}
 			ref={mergedRef}
-			data-variant={variant}
+			data-lp-variant={variant}
 			className={composeRenderProps(mergedProps.className, (className, renderProps) =>
 				cx(buttonStyles({ ...renderProps, size, variant, className }), iconButtonStyles({ size })),
 			)}

--- a/packages/components/src/RadioIconButton.tsx
+++ b/packages/components/src/RadioIconButton.tsx
@@ -32,6 +32,7 @@ const RadioIconButton = ({ ref, ...props }: RadioIconButtonProps) => {
 		<AriaRadio
 			{...mergedProps}
 			ref={mergedRef}
+			data-variant={variant}
 			className={composeRenderProps(mergedProps.className, (className, renderProps) =>
 				cx(buttonStyles({ ...renderProps, size, variant, className }), iconButtonStyles({ size })),
 			)}

--- a/packages/components/src/ToggleButton.tsx
+++ b/packages/components/src/ToggleButton.tsx
@@ -35,6 +35,7 @@ const ToggleButton = ({ ref, ...props }: ToggleButtonProps) => {
 		<AriaToggleButton
 			{...mergedProps}
 			ref={mergedRef}
+			data-variant={variant}
 			className={composeRenderProps(mergedProps.className, (className, renderProps) =>
 				appearance === 'elevated'
 					? toggleButtonElevatedStyles({ ...renderProps, className })

--- a/packages/components/src/ToggleButton.tsx
+++ b/packages/components/src/ToggleButton.tsx
@@ -35,7 +35,7 @@ const ToggleButton = ({ ref, ...props }: ToggleButtonProps) => {
 		<AriaToggleButton
 			{...mergedProps}
 			ref={mergedRef}
-			data-variant={variant}
+			data-lp-variant={variant}
 			className={composeRenderProps(mergedProps.className, (className, renderProps) =>
 				appearance === 'elevated'
 					? toggleButtonElevatedStyles({ ...renderProps, className })

--- a/packages/components/src/ToggleIconButton.tsx
+++ b/packages/components/src/ToggleIconButton.tsx
@@ -32,6 +32,7 @@ const ToggleIconButton = ({ ref, ...props }: ToggleIconButtonProps) => {
 		<ToggleButton
 			{...mergedProps}
 			ref={mergedRef}
+			data-variant={variant}
 			className={composeRenderProps(mergedProps.className, (className, renderProps) =>
 				cx(buttonStyles({ ...renderProps, size, variant, className }), iconButtonStyles({ size })),
 			)}

--- a/packages/components/src/ToggleIconButton.tsx
+++ b/packages/components/src/ToggleIconButton.tsx
@@ -32,7 +32,7 @@ const ToggleIconButton = ({ ref, ...props }: ToggleIconButtonProps) => {
 		<ToggleButton
 			{...mergedProps}
 			ref={mergedRef}
-			data-variant={variant}
+			data-lp-variant={variant}
 			className={composeRenderProps(mergedProps.className, (className, renderProps) =>
 				cx(buttonStyles({ ...renderProps, size, variant, className }), iconButtonStyles({ size })),
 			)}


### PR DESCRIPTION
## Summary

TL;DR: we have some rebrand work in an intermediate state in gonfalon that currently depends on hashed class names. I don't want to carry that forward so I'm instead exposing the hooks that will let us remove those wobbly references.

> [!WARNING]
> The content below was written by AI.


Buttons, toggle buttons, icon buttons, link buttons, and radio buttons now render a `data-lp-variant` attribute with the resolved variant (including the `default` default). `Checkbox` and `Radio` now render `data-lp-indicator="checkbox"` / `data-lp-indicator="radio"` on their indicator elements. This gives consumers and tests a documented, stable attribute to target instead of relying on compiled CSS Module class names, matching the precedent already set by the `data-icon` attribute on icons and React Aria's reference implementation: the official RAC docs starter renders `data-variant={props.variant || 'primary'}` on its Button and ToggleButton and styles them via `:where([data-variant='...'])` selectors ([starters/docs/src/Button.tsx](https://github.com/adobe/react-spectrum/blob/main/starters/docs/src/Button.tsx)). The attributes are namespaced with the `lp-` prefix, consistent with the `--lp-*` custom-property namespace, so they can never clash with consumer-authored `data-variant` attributes.

No visual or behavioral change: these are additive DOM attributes only.

## Screenshots

Not applicable, no visual change.

## Testing approaches

Extended existing unit specs (`Button.spec.tsx`, `ToggleButton.spec.tsx`, `Checkbox.spec.tsx`, `RadioGroup.spec.tsx`) with assertions that the new attributes render with the expected values, using the project's shared `render` test util. Ran `pnpm build:transform`, the affected vitest specs, and `pnpm typecheck`, all passing.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Adds **documented DOM hooks** on `@launchpad-ui/components` so apps and tests can target variants and control indicators without relying on hashed CSS Module class names—aligned with the existing `data-icon` pattern.
> 
> Button-family components (`Button`, `IconButton`, `ToggleButton`, `ToggleIconButton`, `LinkButton`, `LinkIconButton`, `RadioButton`, `RadioIconButton`) now render **`data-lp-variant`** with the resolved `variant` (including `"default"`). `Checkbox` and `Radio` indicator elements get **`data-lp-indicator="checkbox"`** and **`"radio"`** respectively.
> 
> Unit specs assert the new attributes; the changeset marks a **minor** release for the package. No styling or behavior changes beyond extra attributes on the DOM.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0b509776c6fb5edba496766b912da90c6148393. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->