### PR TITLE
fix(modal): make the header icon color independent of stylesheet order

### DIFF
--- a/.changeset/modal-header-icon-order.md
+++ b/.changeset/modal-header-icon-order.md
@@ -1,0 +1,5 @@
+---
+'@launchpad-ui/modal': patch
+---
+
+Fix the modal header warning icon losing its color depending on stylesheet order: the `headerIcon` fill now outranks the icon's default fill by specificity instead of tying with it.

--- a/packages/modal/src/styles/Modal.module.css
+++ b/packages/modal/src/styles/Modal.module.css
@@ -72,7 +72,10 @@
 	overflow-wrap: anywhere;
 }
 
-.headerIcon {
+/* Scoped under .header so the fill outranks the icon's own single-class
+   default instead of tying with it, where the winner would depend on
+   stylesheet order in the consuming bundle. */
+.header .headerIcon {
 	transform: translateY(2px);
 	fill: var(--lp-color-brand-lime-dark);
 }


### PR DESCRIPTION
## Summary

The modal header's warning icon is rendered as `<Icon className={styles.headerIcon}>`, so the svg carries both `headerIcon` (fill: `--lp-color-brand-lime-dark`) and the icon's own `default` class (fill: `--lp-color-fill-ui-primary`). Both selectors are a single class, so the winning fill depends on which package's stylesheet the consuming bundler happens to emit later, and that order can flip between builds. The rule is now scoped as `.header .headerIcon`, which outranks the icon's default by specificity and renders the same color under any stylesheet order.

## Screenshots

No intended visual change; this pins the already-intended color (`--lp-color-brand-lime-dark`) so it cannot silently flip to the icon default.

## Testing approaches

Modal unit specs pass. Verified the svg sits under the `.header` element so the scoped selector matches.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 73db11e8e6a255aeaeac1667dc9408809f66ec7f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->