### PR TITLE
fix: use content hashing for css module class names

### DIFF
--- a/.changeset/css-module-content-hash.md
+++ b/.changeset/css-module-content-hash.md
@@ -1,0 +1,16 @@
+---
+'@launchpad-ui/button': patch
+'@launchpad-ui/components': patch
+'@launchpad-ui/drawer': patch
+'@launchpad-ui/filter': patch
+'@launchpad-ui/form': patch
+'@launchpad-ui/icons': patch
+'@launchpad-ui/menu': patch
+'@launchpad-ui/modal': patch
+'@launchpad-ui/navigation': patch
+'@launchpad-ui/popover': patch
+'@launchpad-ui/table': patch
+'@launchpad-ui/tooltip': patch
+---
+
+Use content hashing for CSS module class names so same-named module files in different packages no longer produce colliding class names.

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -50,7 +50,7 @@ export default defineConfig({
 				customMedia: true,
 			},
 			cssModules: {
-				pattern: '[hash]_[local]',
+				pattern: '[content-hash]_[local]',
 			},
 		},
 		devSourcemap: true,


### PR DESCRIPTION
> [!NOTE]
> This PR summary was written by AI.

## Why

lightningcss's `[hash]_[local]` css-modules pattern hashes only the module file's basename. Any two packages with a same-named module file emit identical class names, and a consumer that loads both stylesheets gets cross-package collisions resolved by stylesheet load order. Concretely, with both `@launchpad-ui/components` and `@launchpad-ui/modal` styles loaded:

- `Modal.module.css` exists in both packages, so both emit `.bYbWKG_overlay`. The components `ModalOverlay` renders the legacy modal's overlay color instead of `--lp-color-black-500`, and legacy modal overlays pick up the components overlay's `backdrop-filter: blur(1px)`.
- `Form.module.css` in `@launchpad-ui/form` collides with the components package's `Form.module.css` (`.QJPOUG_form`).
- `Icon.module.css` and the gradient module in `@launchpad-ui/icons` collide across published icons versions, so apps carrying two icons majors mix yellow and lime avatar gradients by load order.

## What

One line: change the pattern to `[content-hash]_[local]`, which hashes file content, so distinct files always get distinct prefixes. Same-content files still share a prefix, which is harmless because their rules are identical.

## Verification

- Full `pnpm build`: after the change, zero shared hash prefixes across all `packages/*/dist` css (previously 4 colliding basenames).
- Normalized diff (every hash prefix replaced with a placeholder) of before/after dist css for components and modal: byte-identical. Only the prefixes change.
- stylelint and the full vitest suite pass; no test, story, or snapshot references a hashed class name.
- Changeset included: patch bump for every package that ships css-module classes.

## Caveat for consumers

Class names in dist output change with this release (and will change whenever a module file's content changes). Anything that hard-codes a generated class name breaks, but nothing should be doing that.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Switches the shared Lightning CSS **CSS Modules** pattern in `vite.config.mts` from `[hash]_[local]` to **`[content-hash]_[local]`**, so class prefixes derive from module **content** instead of the file basename. That stops different packages with the same module filename (e.g. `Modal.module.css` in components vs modal) from emitting identical classes and fighting in the cascade when both stylesheets load.
> 
> A changeset requests **patch** releases for every package that ships CSS-module output (button, components, drawer, filter, form, icons, menu, modal, navigation, popover, table, tooltip).
> 
> **Consumer note:** published `dist` class strings change on upgrade and whenever a module file’s content changes; only hard-coded hashed class names would break.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c732a3a90ac5c35323c2b31f9c9ad5f74c49c78e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->