### PR TITLE
feat(components): add labelPosition to Switch

### DIFF
--- a/.changeset/switch-label-position.md
+++ b/.changeset/switch-label-position.md
@@ -1,0 +1,5 @@
+---
+'@launchpad-ui/components': minor
+---
+
+Add `labelPosition` to `Switch`. Pass `labelPosition="start"` to render a visible label before the track instead of after it, while keeping the label inside the switch so it stays clickable and remains the accessible name. Defaults to `"end"`, matching current behavior.

--- a/packages/components/__tests__/Switch.spec.tsx
+++ b/packages/components/__tests__/Switch.spec.tsx
@@ -25,6 +25,16 @@ describe('Switch', () => {
 		expect(screen.queryByText('On')).not.toBeInTheDocument();
 	});
 
+	it('renders a visible label after the track by default', () => {
+		render(<Switch>Dark mode</Switch>);
+		expect(screen.getByRole('switch', { name: /Dark mode/ }).closest('label')?.className).not.toContain('labelStart');
+	});
+
+	it('renders a visible label before the track when labelPosition is start', () => {
+		render(<Switch labelPosition="start">Dark mode</Switch>);
+		expect(screen.getByRole('switch', { name: /Dark mode/ }).closest('label')?.className).toContain('labelStart');
+	});
+
 	it('renders with primary variant', () => {
 		render(<Switch variant="primary" defaultSelected />);
 		expect(screen.getByRole('switch')).toBeVisible();

--- a/packages/components/src/Switch.tsx
+++ b/packages/components/src/Switch.tsx
@@ -20,9 +20,14 @@ const switchStyles = cva(styles.switch, {
 		compact: {
 			true: styles.compact,
 		},
+		labelPosition: {
+			start: styles.labelStart,
+			end: '',
+		},
 	},
 	defaultVariants: {
 		variant: 'default',
+		labelPosition: 'end',
 	},
 });
 
@@ -38,19 +43,21 @@ const SwitchContext = createContext<ContextValue<SwitchProps, HTMLLabelElement>>
  * A switch allows a user to turn a setting on or off.
  *
  * Provide an accessible name via `children` (visible label) or `aria-label` (visually hidden label).
+ * A visible label renders after the track by default; pass `labelPosition="start"` to render it
+ * before the track while keeping it part of the switch's label and click target.
  *
  * https://react-spectrum.adobe.com/react-aria/Switch.html
  */
 const Switch = ({ ref, ...props }: SwitchProps) => {
 	const [mergedProps, mergedRef] = useLPContextProps(props, ref, SwitchContext);
-	const { switchLabels, variant } = mergedProps;
+	const { switchLabels, variant, labelPosition } = mergedProps;
 	const hideLabels = switchLabels === false ? true : undefined;
 	return (
 		<AriaSwitch
 			{...mergedProps}
 			ref={mergedRef}
 			className={composeRenderProps(mergedProps.className, (className, renderProps) =>
-				switchStyles({ ...renderProps, variant, compact: hideLabels, className }),
+				switchStyles({ ...renderProps, variant, labelPosition, compact: hideLabels, className }),
 			)}
 		>
 			{composeRenderProps(mergedProps.children, (children, { isSelected }) => (

--- a/packages/components/src/styles/Switch.module.css
+++ b/packages/components/src/styles/Switch.module.css
@@ -7,7 +7,9 @@
 }
 
 .switch.labelStart {
-	flex-direction: row-reverse;
+	& .track {
+		order: 1;
+	}
 }
 
 .track {

--- a/packages/components/src/styles/Switch.module.css
+++ b/packages/components/src/styles/Switch.module.css
@@ -6,6 +6,10 @@
 	isolation: isolate;
 }
 
+.switch.labelStart {
+	flex-direction: row-reverse;
+}
+
 .track {
 	position: relative;
 	display: flex;

--- a/packages/components/stories/Switch.stories.tsx
+++ b/packages/components/stories/Switch.stories.tsx
@@ -62,3 +62,7 @@ export const WithChildren: Story = {
 export const LabelStart: Story = {
 	args: { children: 'Dark mode', labelPosition: 'start' },
 };
+
+export const LabelStartHideLabels: Story = {
+	args: { children: 'Dark mode', labelPosition: 'start', switchLabels: false },
+};

--- a/packages/components/stories/Switch.stories.tsx
+++ b/packages/components/stories/Switch.stories.tsx
@@ -10,6 +10,10 @@ const meta: Meta<typeof Switch> = {
 			control: 'select',
 			options: ['default', 'primary'],
 		},
+		labelPosition: {
+			control: 'inline-radio',
+			options: ['start', 'end'],
+		},
 	},
 	parameters: {
 		figma: {
@@ -53,4 +57,8 @@ export const PrimaryHideLabels: Story = {
 
 export const WithChildren: Story = {
 	args: { children: 'Dark mode' },
+};
+
+export const LabelStart: Story = {
+	args: { children: 'Dark mode', labelPosition: 'start' },
 };


### PR DESCRIPTION
## Summary

`Switch` renders `[track][children]`, so a visible label always sits after the toggle and there's no way to put the label first without leaving the switch. Consumers that want label-before-toggle currently either override `flex-direction` locally (see launchdarkly/gonfalon#69412) or render the text as a sibling element with `aria-label` on the switch — the latter drops the text out of the `<label>`, so clicking the words no longer toggles and the visible text is no longer the accessible name.

This adds a `labelPosition` variant, defaulting to `end` (current behavior):

```jsx
<Switch labelPosition="start">AI assist</Switch>
```

```css
.switch.labelStart {
  flex-direction: row-reverse;
}
```

The label stays `children` of the switch, so it remains inside the `<label>` — clickable and still the accessible name — and only the visual order changes. Track internals (On/Off labels, handle translation, compact) are untouched.

Naming: RAC's `Switch` has no equivalent prop, so this follows React Spectrum's `labelPosition` name with CSS-logical `start`/`end` values rather than inventing something new.

## Screenshots (if appropriate):

New Storybook story `Components/Forms/Switch → LabelStart` covers it (Chromatic will diff it); to follow.

## Testing approaches

- `pnpm vitest run packages/components/__tests__/Switch.spec.tsx` — 7 passed, including new cases for the default (label after track) and `labelPosition="start"`.
- `pnpm typecheck`, `pnpm oxlint:js:path` on the changed files, `pnpm fmt:check`, `pnpm lint:css:path packages/components/src/styles/Switch.module.css`.
- Changeset included (`minor` on `@launchpad-ui/components`).

Follow-up: once this is released, gonfalon can drop its local `row-reverse` override in favor of the prop.


Link to Devin session: https://app.devin.ai/sessions/6458b07f375e44219f97c3a2beb73491
Requested by: @hsadhvani

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Adds **`labelPosition`** (`start` | `end`, default **`end`**) on **`Switch`** so visible **`children`** can render before the track without leaving the `<label>`.
> 
> Layout uses a **`labelStart`** class that sets **`order: 1`** on the track (not **`row-reverse`**), keeping the label clickable and the accessible name aligned with the visible text. On/Off track internals are unchanged.
> 
> Tests, Storybook stories, and a **minor** changeset for **`@launchpad-ui/components`** are included.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2fa94048e556e276b0962f61c4380eb24e199492. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->