### PR TITLE
fix(components): make the breadcrumbs separator color independent of stylesheet order

### DIFF
--- a/.changeset/breadcrumb-separator-order.md
+++ b/.changeset/breadcrumb-separator-order.md
@@ -1,0 +1,5 @@
+---
+'@launchpad-ui/components': patch
+---
+
+Make the Breadcrumbs separator color independent of stylesheet order.

--- a/packages/components/src/styles/Breadcrumbs.module.css
+++ b/packages/components/src/styles/Breadcrumbs.module.css
@@ -19,7 +19,10 @@
 	}
 }
 
-.separator {
+/* Scoped under .crumb so the fill outranks the icon's own single-class
+   default instead of tying with it, where the winner would depend on
+   stylesheet order in the consuming bundle. */
+.crumb .separator {
 	fill: var(--lp-color-fill-ui-secondary);
 	height: var(--lp-size-24);
 	width: var(--lp-size-24);


### PR DESCRIPTION
> [!NOTE]
> This PR summary was written by AI.

The Breadcrumbs separator is rendered as `<Icon name="slash" className={styles.separator} />`, so the svg carries both this package's `.separator` class (fill: secondary) and the icon package's `.default` class (fill: primary). Both selectors have a single class, so they tie on specificity and the rendered color depends on which stylesheet the consuming bundle loads later.

Scoping the rule under `.crumb` outranks the tie deterministically, the same approach as the modal header icon fix (#1992).

Verification: components build emits `.crumb .separator { fill: ... }`; full components test suite passes; changeset included (patch).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> The slash separator between breadcrumb items was competing with the **Icon** package’s default fill at equal specificity, so apps could see primary instead of secondary depending on CSS load order.
> 
> The separator rule is now scoped as **`.crumb .separator`**, so the intended secondary fill wins consistently (same pattern as the modal header icon fix). A patch **changeset** documents the `@launchpad-ui/components` release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef89074795cd71802eb651c423657c530908efd5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->