### PR TITLE
feat(table): add a data-lp-table attribute for consumer styling

### DIFF
--- a/.changeset/legacy-table-data-hook.md
+++ b/.changeset/legacy-table-data-hook.md
@@ -1,0 +1,5 @@
+---
+'@launchpad-ui/table': patch
+---
+
+Add a `data-lp-table` attribute to the table element so consumers can target the component without matching generated class names.

--- a/packages/table/src/Table.tsx
+++ b/packages/table/src/Table.tsx
@@ -34,7 +34,7 @@ const Table = ({
 	);
 
 	return (
-		<table {...rest} data-test-id={testId} className={classes}>
+		<table {...rest} data-lp-table="" data-test-id={testId} className={classes}>
 			{children}
 		</table>
 	);


### PR DESCRIPTION
> [!NOTE]
> This PR summary was written by AI.

The legacy `Table` offers no stable hook for consumer styling, so consumers match its generated class names by substring (`[class*='_Table']`), which breaks silently whenever the class-name scheme changes. This adds `data-lp-table` to the rendered `<table>` element, following the existing data-attribute pattern (`data-lp-variant`, `data-lp-indicator`).

One attribute on the root element is enough: descendants (`thead`, `tr`, `td`, `th`) are addressable relative to it. No visual or behavioral change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Adds **`data-lp-table=""`** on the root `<table>` in the deprecated **`@launchpad-ui/table`** `Table` component, matching the existing **`data-lp-*`** hook pattern used elsewhere in Launchpad.
> 
> Consumers can target the table (and descendants) with a stable selector instead of fragile CSS-module class substring matches like `[class*='_Table']`, which can break when hashing or naming changes. No visual or behavioral change; patch release via changeset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67804866d43ef0ed6b38decf0ed70bdec6512947. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->