### PR TITLE
fix(popover): bump the pinned floating-ui packages to a matched pair

### DIFF
--- a/.changeset/floating-ui-matched-pair.md
+++ b/.changeset/floating-ui-matched-pair.md
@@ -1,0 +1,5 @@
+---
+'@launchpad-ui/popover': patch
+---
+
+Bump the pinned `@floating-ui/core` and `@floating-ui/dom` to a matched pair.

--- a/packages/popover/package.json
+++ b/packages/popover/package.json
@@ -24,8 +24,8 @@
 		"test": "vitest run --coverage"
 	},
 	"dependencies": {
-		"@floating-ui/core": "1.7.0",
-		"@floating-ui/dom": "1.7.0",
+		"@floating-ui/core": "1.7.4",
+		"@floating-ui/dom": "1.7.4",
 		"@launchpad-ui/focus-trap": "workspace:~",
 		"@launchpad-ui/overlay": "workspace:~",
 		"@launchpad-ui/tokens": "workspace:~",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -671,11 +671,11 @@ importers:
   packages/popover:
     dependencies:
       '@floating-ui/core':
-        specifier: 1.7.0
-        version: 1.7.0
+        specifier: 1.7.4
+        version: 1.7.4
       '@floating-ui/dom':
-        specifier: 1.7.0
-        version: 1.7.0
+        specifier: 1.7.4
+        version: 1.7.4
       '@launchpad-ui/focus-trap':
         specifier: workspace:~
         version: link:../focus-trap
@@ -1315,11 +1315,11 @@ packages:
     peerDependencies:
       react: ^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
-  '@floating-ui/core@1.7.0':
-    resolution: {integrity: sha512-FRdBLykrPPA6P76GGGqlex/e7fbe0F1ykgxHYNXQsH/iTEtjMj/f9bpY5oQqbjt5VgZvgz/uKXbGuROijh3VLA==}
+  '@floating-ui/core@1.7.4':
+    resolution: {integrity: sha512-C3HlIdsBxszvm5McXlB8PeOEWfBhcGBTZGkGlWc2U0KFY5IwG5OQEuQ8rq52DZmcHDlPLd+YFBK+cZcytwIFWg==}
 
-  '@floating-ui/dom@1.7.0':
-    resolution: {integrity: sha512-lGTor4VlXcesUMh1cupTUTDoCxMb0V6bm3CnxHzQcw8Eaf1jQbgQX4i02fYgT0vJ82tb5MZ4CZk1LRGkktJCzg==}
+  '@floating-ui/dom@1.7.4':
+    resolution: {integrity: sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA==}
 
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
@@ -6508,13 +6508,13 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
 
-  '@floating-ui/core@1.7.0':
+  '@floating-ui/core@1.7.4':
     dependencies:
       '@floating-ui/utils': 0.2.11
 
-  '@floating-ui/dom@1.7.0':
+  '@floating-ui/dom@1.7.4':
     dependencies:
-      '@floating-ui/core': 1.7.0
+      '@floating-ui/core': 1.7.4
       '@floating-ui/utils': 0.2.11
 
   '@floating-ui/utils@0.2.11': {}


### PR DESCRIPTION
> [!NOTE]
> This content was written by AI.

## Summary

`@launchpad-ui/popover` pins `@floating-ui/core` and `@floating-ui/dom` to exact versions. Both have been at 1.7.0 for a while. floating-ui has published several patches since then.

An exact pin is strict. Other libraries ask for floating-ui with a flexible range, such as `^1.7.0`. Our exact pin wins over those ranges. An app that installs Popover then gets one of two bad results:

- floating-ui drops back to 1.7.0, even though the app's other libraries accept a newer one.
- The app installs 1.7.0 and a newer version side by side. It then ships two copies of the same positioning library.

This is easy to hit. Ariakit, react-select, and the TipTap menu extensions all depend on `@floating-ui/dom`.

This change moves both packages to 1.7.4. Apps commonly resolve 1.7.4 already, so the pin stops fighting them. Both are patch releases inside 1.7, so there is no API change to absorb. Both packages now carry the same patch number, which makes the pair easier to read.

We stick to 1.7 to minimize risk: a patch version is supposedly safer than a minor version. 🤷 

## Testing approaches

This change is a version pin. Two things matter: the install resolves cleanly, and nothing downstream breaks.

For resolution, the lockfile now holds one copy of each package, both at 1.7.4. No duplicate remains. `syncpack lint` passes. The lockfile diff shows those two versions and nothing else.

For the consumers, all 21 packages build in dependency order. `typecheck` passes. The test run passes with 279 tests in 88 files, including Popover's own 8. `oxlint` and the format check pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> **@launchpad-ui/popover** pins `@floating-ui/core` and `@floating-ui/dom` to exact versions. This PR bumps both from **1.7.0** to **1.7.4** so the pair shares the same patch level and aligns with what many apps already resolve via `^1.7.x` from other libraries (e.g. Ariakit, react-select), reducing duplicate floating-ui copies or forced downgrades.
> 
> Changes are limited to `packages/popover/package.json`, `pnpm-lock.yaml`, and a patch changeset—no Popover source or API updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e75e88ccb70d13c6859f0432d14121032bae5b2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->