### PR TITLE
refactor(tokens): consolidate editorial typography and prune unused tokens

### DIFF
--- a/.changeset/wet-melons-cheer.md
+++ b/.changeset/wet-melons-cheer.md
@@ -1,0 +1,11 @@
+---
+'@launchpad-ui/tokens': minor
+---
+
+Consolidate editorial typography and prune unused editorial tokens.
+
+- Remove the duplicate/near-duplicate editorial heading styles `editorial.h1-alt` (an exact clone of `h1`), `editorial.h2-alt`, and `editorial.h2-medium`.
+- Set letter-spacing on all remaining editorial styles (`display`, `h1`, `h2`, `h3`) to `-2px` for consistency.
+- Prune editorial primitives that are no longer referenced by any style: font sizes `14, 16, 18, 20, 24, 30, 32, 48, 50`; `fontWeight.editorial.medium`; line-heights `close`, `default`, `relaxed`; letter-spacings `tight-em-05`, `tight-em-03`, `tight-px-025`, `tight-px-050`, `tight-px-065`, `wide-em-06`, `normal`. `letterSpacing.editorial.tight-2px` and `tight-1px` are retained (`tight-2px` is now used by every editorial style; `tight-1px` is still consumed downstream).
+
+Breaking (token surface): the corresponding `--lp-text-editorial-h1-alt`, `--lp-text-editorial-h2-alt`, `--lp-text-editorial-h2-medium` CSS variables, the pruned `--lp-font-size|font-weight|line-height|letter-spacing-editorial-*` variables, and their `vars.*` entries are removed from the published package.

--- a/packages/tokens/stories/typography.stories.tsx
+++ b/packages/tokens/stories/typography.stories.tsx
@@ -13,7 +13,7 @@ export default {
 		docs: {
 			description: {
 				component:
-					'Typography tokens for the LaunchPad design system. Our typography is split between two type sets: Utility and Editorial. For components using these tokens, see [Text](/docs/components-content-text--docs), [Heading](/docs/components-content-heading--docs), [Label](/docs/components-content-label--docs), and [Code](/docs/components-content-code--docs). For the full framework, see the [Utility & Editorial Type System for LaunchPad](https://launchdarkly.atlassian.net/wiki/spaces/~712020490f77e4363240f1888e975e52e895be/pages/4939022523/) proposal.',
+					'Typography tokens for the LaunchPad design system. Our typography is split between two type sets: Utility and Editorial. For components using these tokens, see [Text](/docs/components-content-text--docs), [Heading](/docs/components-content-heading--docs), [Label](/docs/components-content-label--docs), and [Code](/docs/components-content-code--docs).',
 			},
 			page: () => (
 				<>
@@ -49,18 +49,14 @@ const getDisplayText = (key: string) => {
 
 	if (parts[0] === 'editorial') {
 		const variant = parts[1]; // display, h1, h2, h3
-		const modifiers = parts.slice(2); // alt, medium, etc. all treated as variant suffixes
 
-		let base: string;
 		if (variant === 'display') {
-			base = 'Display';
-		} else if (/^h\d+$/.test(variant)) {
-			base = `Heading ${variant.slice(1)}`;
-		} else {
-			base = capitalize(variant);
+			return 'Display';
 		}
-
-		return modifiers.length ? `${base} ${modifiers.map(capitalize).join(' ')}` : base;
+		if (/^h\d+$/.test(variant)) {
+			return `Heading ${variant.slice(1)}`;
+		}
+		return capitalize(variant);
 	}
 
 	const category = parts[0]; // heading, body, etc.
@@ -82,8 +78,8 @@ const getSemanticElement = (token: string, font: string) => {
 	const category = parts[0]; // heading, body, etc.
 	const size = parts[1]; // 1, 2, etc.
 
-	// Editorial tokens are keyed as editorial-<variant>[-modifier] (e.g. editorial-h1-alt),
-	// so the heading level lives in parts[1]. Map it to the matching tag instead of falling
+	// Editorial tokens are keyed as editorial-<variant> (e.g. editorial-h1), so the heading
+	// level lives in parts[1]. Map it to the matching tag instead of falling
 	// through to the generic div below.
 	if (category === 'editorial') {
 		const variant = parts[1]; // display, h1, h2, h3

--- a/packages/tokens/tokens/font.json
+++ b/packages/tokens/tokens/font.json
@@ -55,35 +55,8 @@
 			"$value": 60
 		},
 		"editorial": {
-			"14": {
-				"$value": "{size.14}"
-			},
-			"16": {
-				"$value": "{size.16}"
-			},
-			"18": {
-				"$value": "{size.18}"
-			},
-			"20": {
-				"$value": "{size.20}"
-			},
-			"24": {
-				"$value": "{size.24}"
-			},
-			"30": {
-				"$value": "{size.30}"
-			},
-			"32": {
-				"$value": "{size.32}"
-			},
 			"40": {
 				"$value": "{size.40}"
-			},
-			"48": {
-				"$value": "{size.48}"
-			},
-			"50": {
-				"$value": "{size.50}"
 			},
 			"56": {
 				"$value": "{size.56}"
@@ -124,9 +97,6 @@
 			"$value": 800
 		},
 		"editorial": {
-			"medium": {
-				"$value": 500
-			},
 			"semibold": {
 				"$value": 600
 			},
@@ -165,15 +135,6 @@
 			},
 			"snug": {
 				"$value": 1.05
-			},
-			"close": {
-				"$value": 1.1
-			},
-			"default": {
-				"$value": 1.15
-			},
-			"relaxed": {
-				"$value": 1.5
 			}
 		}
 	},
@@ -192,27 +153,6 @@
 			},
 			"tight-1px": {
 				"$value": "-1px"
-			},
-			"tight-em-05": {
-				"$value": "-0.05em"
-			},
-			"tight-em-03": {
-				"$value": "-0.03em"
-			},
-			"tight-px-065": {
-				"$value": "-0.65px"
-			},
-			"tight-px-050": {
-				"$value": "-0.5px"
-			},
-			"tight-px-025": {
-				"$value": "-0.25px"
-			},
-			"wide-em-06": {
-				"$value": "0.06em"
-			},
-			"normal": {
-				"$value": 0
 			}
 		}
 	}

--- a/packages/tokens/tokens/typography.json
+++ b/packages/tokens/tokens/typography.json
@@ -265,16 +265,7 @@
 					"fontWeight": "{fontWeight.editorial.bold}",
 					"fontSize": "{fontSize.editorial.64}",
 					"lineHeight": "{lineHeight.editorial.tight}",
-					"letterSpacing": "{letterSpacing.editorial.tight-em-05}"
-				}
-			},
-			"h1-alt": {
-				"$value": {
-					"fontFamily": "{fontFamily.sora}",
-					"fontWeight": "{fontWeight.editorial.bold}",
-					"fontSize": "{fontSize.editorial.64}",
-					"lineHeight": "{lineHeight.editorial.tight}",
-					"letterSpacing": "{letterSpacing.editorial.tight-em-05}"
+					"letterSpacing": "{letterSpacing.editorial.tight-2px}"
 				}
 			},
 			"h2": {
@@ -283,25 +274,7 @@
 					"fontWeight": "{fontWeight.editorial.semibold}",
 					"fontSize": "{fontSize.editorial.56}",
 					"lineHeight": "{lineHeight.editorial.tight}",
-					"letterSpacing": "{letterSpacing.editorial.tight-em-05}"
-				}
-			},
-			"h2-alt": {
-				"$value": {
-					"fontFamily": "{fontFamily.sora}",
-					"fontWeight": "{fontWeight.editorial.medium}",
-					"fontSize": "{fontSize.editorial.50}",
-					"lineHeight": "{lineHeight.editorial.tight}",
-					"letterSpacing": "{letterSpacing.editorial.tight-em-05}"
-				}
-			},
-			"h2-medium": {
-				"$value": {
-					"fontFamily": "{fontFamily.sora}",
-					"fontWeight": "{fontWeight.editorial.medium}",
-					"fontSize": "{fontSize.editorial.48}",
-					"lineHeight": "{lineHeight.editorial.tight}",
-					"letterSpacing": "{letterSpacing.editorial.tight-em-05}"
+					"letterSpacing": "{letterSpacing.editorial.tight-2px}"
 				}
 			},
 			"h3": {
@@ -310,7 +283,7 @@
 					"fontWeight": "{fontWeight.editorial.semibold}",
 					"fontSize": "{fontSize.editorial.40}",
 					"lineHeight": "{lineHeight.editorial.snug}",
-					"letterSpacing": "{letterSpacing.editorial.tight-1px}"
+					"letterSpacing": "{letterSpacing.editorial.tight-2px}"
 				}
 			}
 		}


### PR DESCRIPTION
## Summary

Cleans up the Editorial typography set in `@launchpad-ui/tokens`:

- Remove duplicate/near-duplicate editorial heading styles: `editorial.h1-alt` (an exact clone of `h1`), `editorial.h2-alt`, and `editorial.h2-medium`. The Editorial set is now `display`, `h1`, `h2`, `h3`.
- Set letter-spacing on all editorial styles to `-2px` (`letterSpacing.editorial.tight-2px`). `h3` line-height stays at 105% (`snug`).
- Prune editorial primitives no longer referenced by any style: font sizes `14–32, 48, 50`; `fontWeight.editorial.medium`; line-heights `close`/`default`/`relaxed`; letter-spacings `tight-em-05`, `tight-em-03`, `tight-px-025/050/065`, `wide-em-06`, `normal`. Retained `tight-2px` (now used by every editorial style) and `tight-1px` (consumed directly by gonfalon's empty-state components).
- Story cleanup: drop the now-dead modifier-parsing branch (no editorial token has a `-alt`/`-medium` modifier anymore) and remove a stale proposal link from the docs description.
- Removed link to framework proposal hosted in confluence

**Breaking (token surface):** removes the `--lp-text-editorial-h1-alt|h2-alt|h2-medium` CSS vars, the pruned `--lp-{font-size|font-weight|line-height|letter-spacing}-editorial-*` vars, and their `vars.*` entries from the published package. Audited: the only editorial tokens consumed in gonfalon are `--lp-text-editorial-h3` and `--lp-letter-spacing-editorial-tight-1px`, both retained.

## Screenshots

Storybook `Tokens/Typography` docs, Editorial section:

| **Before**  | **After** |
|--------|--------|
| 7 rows — Display, Heading 1, Heading 1 Alt, Heading 2, Heading 2 Alt, Heading 2 Medium, Heading 3. | 4 rows — Display, Heading 1, Heading 2, Heading 3. |
| <img width="1043" height="814" alt="Screenshot 2026-08-13 at 3 27 56 PM" src="https://github.com/user-attachments/assets/81da7083-b544-424d-8161-b4b9299d2f7b" /> | <img width="1066" height="614" alt="Screenshot 2026-08-13 at 3 27 44 PM" src="https://github.com/user-attachments/assets/c830d14f-75d2-4348-9b4b-d473224fb4ee" /> | 





## Testing approaches

- `pnpm --filter @launchpad-ui/tokens build` (Style Dictionary + `tsc --noEmit`) passes. The "filtered token references" warning is pre-existing on `main`.
- `pnpm --filter @launchpad-ui/tokens test`: 20/20 pass.
- Verified generated `dist` exposes only `--lp-text-editorial-{display,h1,h2,h3}` and the reduced primitive set; all four styles resolve to `letter-spacing: -0.125rem` (−2px); no dangling references remain.
- Visually verified in Storybook (screenshots above).

via LD Research 🤖

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> **Consolidates** the Editorial typography set in `@launchpad-ui/tokens` to four styles (`display`, `h1`, `h2`, `h3`) by removing `editorial.h1-alt`, `h2-alt`, and `h2-medium`, and **unifies** letter-spacing on all of them to `-2px` via `letterSpacing.editorial.tight-2px` (including `h3`, which previously used `tight-1px` on the composite style).
> 
> **Prunes** unused editorial primitives from `font.json` (sizes, `fontWeight.editorial.medium`, line-heights, letter-spacings) while keeping `tight-1px` for downstream direct use. Storybook typography docs drop modifier parsing for `-alt`/`medium` keys and a stale Confluence proposal link.
> 
> **Breaking:** published `--lp-text-editorial-h1-alt|h2-alt|h2-medium` and the removed primitive CSS/`vars.*` entries are no longer emitted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3775d7c949756f52ad18d76100d4bf29783a93a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->