### PR TITLE
fix(components): top-align MenuItem checkbox with label

### DIFF
--- a/.changeset/menu-item-checkbox-alignment.md
+++ b/.changeset/menu-item-checkbox-alignment.md
@@ -1,0 +1,5 @@
+---
+'@launchpad-ui/components': patch
+---
+
+Top-align the `MenuItem` selection checkbox with the item label so it matches icon alignment when a description is present.

--- a/packages/components/src/Menu.tsx
+++ b/packages/components/src/Menu.tsx
@@ -78,7 +78,7 @@ const MenuItem = <T extends object>({ variant = 'default', ref, ...props }: Menu
 				<>
 					{selectionMode === 'multiple' && (
 						<div
-							className={checkboxStyles()}
+							className={checkboxStyles({ className: styles.checkbox })}
 							data-selected={isSelected || undefined}
 							data-disabled={isDisabled || undefined}
 						>

--- a/packages/components/src/styles/Menu.module.css
+++ b/packages/components/src/styles/Menu.module.css
@@ -28,6 +28,15 @@
 	forced-color-adjust: none;
 	text-decoration: none;
 
+	&:has(.checkbox) {
+		align-items: start;
+	}
+
+	& .checkbox {
+		height: 1lh;
+		align-items: center;
+	}
+
 	&[data-hovered] {
 		background-color: var(--lp-color-bg-interactive-secondary-hover);
 	}


### PR DESCRIPTION
## Summary

In a multiple-selection `Menu`, the selection checkbox was vertically centered against the whole item while a label icon aligns to the first line, so the two disagreed on items that also render a `description`. This applies the same pattern `ListBox` already uses: the item switches to `align-items: start` when it renders a checkbox, and the checkbox wrapper gets `height: 1lh; align-items: center` so it centers on the label line exactly like the icon.

```css
.item {
	&:has(.checkbox) { align-items: start; }
	& .checkbox { height: 1lh; align-items: center; }
}
```

`Menu.tsx` passes `styles.checkbox` into `checkboxStyles()` so the wrapper can be targeted.

## Screenshots (if appropriate):

Before (checkbox centered against label + description):

![before](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmdfaGVBMWRpc2owVHVLd2VVSyIsInVzZXJfaWQiOm51bGwsImJ1Y2tldF9uYW1lIjoiZGV2aW5hdHRhY2htZW50cyIsImJ1Y2tldF9rZXkiOiJhdHRhY2htZW50c19wcml2YXRlL29yZ19oZUExZGlzajBUdUt3ZVVLL2VlMWYyZTdmLTQwNTEtNDUzNy1hODFkLTBlNThmY2QxMTJlNyIsImlhdCI6MTc4NjY2NzA2MywiZXhwIjoxNzg3MjcxODYzLCJmaWxlbmFtZSI6InNzX3pvb21fYTgzNjExNTMucG5nIn0.Yut6cSEzZQsOXTflQPV9ThYVMURXOe1nTitsf6Bhn-A)

After (checkbox top-aligned, matching the icon):

![after](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmdfaGVBMWRpc2owVHVLd2VVSyIsInVzZXJfaWQiOm51bGwsImJ1Y2tldF9uYW1lIjoiZGV2aW5hdHRhY2htZW50cyIsImJ1Y2tldF9rZXkiOiJhdHRhY2htZW50c19wcml2YXRlL29yZ19oZUExZGlzajBUdUt3ZVVLL2I1ODE4ZDVmLWRhZDQtNDExOS04YmFjLTEzYTZkOTY4MTQ3NiIsImlhdCI6MTc4NjY2NzA2MywiZXhwIjoxNzg3MjcxODYzLCJmaWxlbmFtZSI6InNzX3pvb21fMWRiYTk4YzYucG5nIn0.ARaUwF3tVKTAOvxHtxpWFuG0mf5_6D3cEouwikVAcCU)

Verified in the DOM: the checkbox box and the label icon now share the same vertical bounds on the first line.

## Testing approaches

- Storybook `Components/Collections/Menu → Multiple Selection`, before/after comparison plus computed-style/bounding-box checks in DevTools.
- `pnpm oxlint:js`, `pnpm fmt:check`, `pnpm typecheck`, stylelint on the changed CSS module, and the `Menu`/`ListBox` unit tests.
- Chromatic will show the visual diff for `Menu` (and `ListBox`, unchanged) for sign-off.


Link to Devin session: https://app.devin.ai/sessions/85899105471c4021bc1d969982b6b831
Requested by: @cmwinters

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> **Multi-select `MenuItem` rows** now top-align the selection checkbox with the first line of the label instead of centering it against label + description.
> 
> `Menu.tsx` passes `styles.checkbox` into `checkboxStyles()` so the checkbox wrapper can be styled. **`Menu.module.css`** adds the same rules `ListBox` already used: `align-items: start` on the item when it has a checkbox, and `height: 1lh` with centered flex alignment on the checkbox wrapper so it lines up with label icons on described items.
> 
> A patch **changeset** documents the `@launchpad-ui/components` fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 496fff8c1c92c0c2b6ccdce75cf24723ee61021e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->