### PR TITLE
refactor(popover): replace class-substring selectors with data attributes

### DIFF
--- a/.changeset/data-attributes-for-cross-package-selectors.md
+++ b/.changeset/data-attributes-for-cross-package-selectors.md
@@ -1,0 +1,13 @@
+---
+'@launchpad-ui/popover': patch
+'@launchpad-ui/button': patch
+'@launchpad-ui/tooltip': patch
+'@launchpad-ui/menu': patch
+'@launchpad-ui/form': patch
+---
+
+Replace class-name substring selectors with stable data attributes for cross-package styling.
+
+`Popover` now renders `data-popover-target` on its target element and `data-popover-content` on its content element. `Button` and `IconButton` render `data-button`, and `ButtonGroup` renders `data-button-group`. Stylesheets in `button`, `tooltip`, `menu` and `form` that previously matched one of those elements by a substring of its generated CSS module class name (`[class*='_Popover-target']`, `[class*='_Popover-content']`, `[class*='_Button']`) now match the data attribute instead.
+
+A generated class name is a build output, and its format follows the CSS module loader configuration rather than any published contract. A data attribute holds still. The selectors match the same elements as before.

--- a/packages/button/src/Button.tsx
+++ b/packages/button/src/Button.tsx
@@ -137,6 +137,7 @@ const ButtonComponent = forwardRef<HTMLButtonElement, ButtonProps>((props, ref) 
 			disabled={isDisabled}
 			type={asChild ? undefined : type}
 			data-test-id={testId}
+			data-button=""
 			{...rest}
 		>
 			{renderChildren()}

--- a/packages/button/src/ButtonGroup.tsx
+++ b/packages/button/src/ButtonGroup.tsx
@@ -23,7 +23,7 @@ const ButtonGroup = ({
 	const classes = cx(styles.ButtonGroup, styles[`ButtonGroup--${spacing}`], className);
 
 	return (
-		<div className={classes} data-test-id={testId} {...rest}>
+		<div className={classes} data-test-id={testId} data-button-group="" {...rest}>
 			{children}
 		</div>
 	);

--- a/packages/button/src/IconButton.tsx
+++ b/packages/button/src/IconButton.tsx
@@ -95,6 +95,7 @@ const IconButtonComponent = forwardRef<HTMLButtonElement, IconButtonProps>((prop
 			onKeyDown={onKeyDown || handleKeyDown}
 			type={type}
 			data-test-id={testId}
+			data-button=""
 			{...rest}
 		>
 			{renderChildren()}

--- a/packages/button/src/styles/Button.module.css
+++ b/packages/button/src/styles/Button.module.css
@@ -712,30 +712,30 @@
 }
 
 .ButtonGroup--compact > .Button + .Button,
-.ButtonGroup--compact > [class*='_Popover-target'] + .Button,
-.ButtonGroup--compact > .Button + [class*='_Popover-target'],
-.ButtonGroup--compact > [class*='_Popover-target'] + [class*='_Popover-target'] {
+.ButtonGroup--compact > [data-popover-target] + .Button,
+.ButtonGroup--compact > .Button + [data-popover-target],
+.ButtonGroup--compact > [data-popover-target] + [data-popover-target] {
 	margin-left: -1px;
 }
 
-.ButtonGroup--compact > .Button + [class*='_Popover-target'],
-.ButtonGroup--compact > [class*='_Popover-target'] + [class*='_Popover-target'] {
+.ButtonGroup--compact > .Button + [data-popover-target],
+.ButtonGroup--compact > [data-popover-target] + [data-popover-target] {
 	line-height: 1;
 }
 
 .ButtonGroup--compact > .Button:not(:first-child),
 .ButtonGroup--compact > .Button:not(:last-child),
-.ButtonGroup--compact > [class*='_Popover-target']:not(:first-child),
-.ButtonGroup--compact > [class*='_Popover-target']:not(:last-child) {
+.ButtonGroup--compact > [data-popover-target]:not(:first-child),
+.ButtonGroup--compact > [data-popover-target]:not(:last-child) {
 	border-radius: 0;
 }
 
 .ButtonGroup--compact > .Button:first-child,
-.ButtonGroup--compact > [class*='_Popover-target']:first-child button {
+.ButtonGroup--compact > [data-popover-target]:first-child button {
 	border-radius: var(--lp-border-radius-regular) 0 0 var(--lp-border-radius-regular);
 }
 
 .ButtonGroup--compact > .Button:last-child,
-.ButtonGroup--compact > [class*='_Popover-target']:last-child button {
+.ButtonGroup--compact > [data-popover-target]:last-child button {
 	border-radius: 0 var(--lp-border-radius-regular) var(--lp-border-radius-regular) 0;
 }

--- a/packages/form/src/styles/Form.module.css
+++ b/packages/form/src/styles/Form.module.css
@@ -111,7 +111,8 @@ select.formInput {
 }
 
 .inlineForm .formGroup + .formGroup,
-.inlineForm .formGroup + :global([class*='_Button']) {
+.inlineForm .formGroup + :global([data-button]),
+.inlineForm .formGroup + :global([data-button-group]) {
 	margin-left: 0.625rem;
 }
 
@@ -354,7 +355,7 @@ input[type='checkbox']:disabled {
 	fill: var(--lp-color-fill-field-base);
 }
 
-[class*='_Popover-target'].iconFieldButton {
+[data-popover-target].iconFieldButton {
 	display: block;
 }
 

--- a/packages/menu/src/styles/Menu.module.css
+++ b/packages/menu/src/styles/Menu.module.css
@@ -106,7 +106,7 @@
 	padding: var(--lp-spacing-300);
 }
 
-[class*='_Popover-content'] .Menu-search {
+[data-popover-content] .Menu-search {
 	width: 100%;
 
 	/* Removing anything that could give it some height */

--- a/packages/popover/__tests__/Popover.spec.tsx
+++ b/packages/popover/__tests__/Popover.spec.tsx
@@ -14,6 +14,18 @@ describe('Popover', () => {
 		expect(screen.getByRole('tooltip')).toBeInTheDocument();
 	});
 
+	it('marks its target and content with the attributes other packages style', () => {
+		render(
+			<Popover isOpen>
+				<button type="button">Target</button>
+				<span>Content</span>
+			</Popover>,
+		);
+
+		expect(screen.getByRole('button').closest('[data-popover-target]')).toBeInTheDocument();
+		expect(screen.getByText('Content').closest('[data-popover-content]')).toBeInTheDocument();
+	});
+
 	it('opens on click of the target', async () => {
 		const user = userEvent.setup();
 		render(

--- a/packages/popover/src/Popover.tsx
+++ b/packages/popover/src/Popover.tsx
@@ -101,6 +101,7 @@ type PopoverTargetProps = {
 	isopen?: boolean;
 	'data-test-id'?: string;
 	style?: CSSProperties;
+	'data-popover-target'?: string;
 };
 
 type PopoverContentProps = {
@@ -397,6 +398,7 @@ const Popover = ({
 						restrictWidth && styles['Popover-content--restrictWidth'],
 						popoverContentClassName,
 					)}
+					data-popover-content=""
 					tabIndex={interactionKind === 'click' ? -1 : undefined}
 				>
 					{enableArrow && <div id="arrow" ref={arrowRef} />}
@@ -435,6 +437,7 @@ const Popover = ({
 		className: cx(styles['Popover-target'], targetClassName, isTargetDisabled && styles['Popover-target--disabled']),
 		style: rootElementStyle,
 		'data-test-id': targetTestId || 'popover-target',
+		'data-popover-target': '',
 	};
 
 	if (interactionKind === 'hover' || interactionKind === 'hover-target-only' || interactionKind === 'hover-or-focus') {

--- a/packages/tooltip/src/styles/Tooltip.module.css
+++ b/packages/tooltip/src/styles/Tooltip.module.css
@@ -15,7 +15,7 @@
 	z-index: var(--lp-z-index-800);
 }
 
-[class*='_Popover-content'].Tooltip-popover-content {
+[data-popover-content].Tooltip-popover-content {
 	font-size: 0.8125rem;
 	padding: 0.3125rem 0.625rem;
 	border: 1px solid var(--lp-component-popover-color-border);
@@ -23,7 +23,7 @@
 	color: var(--lp-component-popover-color-text);
 }
 
-[class*='_Popover-content'].Tooltip-popover-content kbd {
+[data-popover-content].Tooltip-popover-content kbd {
 	color: var(--lp-color-gray-100);
 	background-color: var(--lp-color-gray-900);
 	border: 0.0625rem solid var(--lp-color-gray-700);


### PR DESCRIPTION
Missed some more brittle CSS selectors that are causing the migration agent in Gonfalon to introduce Launchpad-specific CSS hashing rules, which I want to avoid to minimize confusion/surprises. This PR uses the same trick as the previous similar PR and uses `data-*` to give downstream consumers a stable selector.

## Summary

> [!WARNING]
> This content was written by AI.

Four packages styled a popover, a button or a button group by matching a substring of its generated CSS module class name:

```css
/* tooltip, styling popover's content element */
[class*='_Popover-content'].Tooltip-popover-content { ... }

/* button, joining a popover target to its neighbour in a compact group */
.ButtonGroup--compact > [class*='_Popover-target'] + .Button { margin-left: -1px }
```

That works only because the build emits `_<hash>_<local>`. The format comes from the CSS module loader configuration, not from anything we publish, so every one of these rules stops applying the moment a consumer compiles these packages with a different `localIdentName`. Nothing fails when that happens: the CSS is still valid, the selector simply never matches, and a tooltip quietly loses its border.

The elements now carry an attribute for other packages to hold on to:

```text
Popover        data-popover-target   on the target wrapper
               data-popover-content  on the content element
Button         data-button
IconButton     data-button
ButtonGroup    data-button-group
```

14 selectors across `button` (9), `tooltip` (2), `menu` (1) and `form` (2) match those instead. They reach the same elements as before. `ButtonGroup` and `IconButton` are in the list because `[class*='_Button']` matched their class names too, and `form` has one rule that relied on that.

No component API changes, no dependency changes. `button` and `form` never depended on `@launchpad-ui/popover` and still do not; `tooltip` and `menu` import the component itself, so their dependency stays.

## Screenshots (if appropriate)

None. This renders identical output for every published build, because the old selectors still match under the published class-name format.

## Testing approaches

A new case in `packages/popover/__tests__/Popover.spec.tsx` asserts the target and content elements carry the attributes, which pins the contract the other packages now rely on. It caught a wrong assumption while writing it: the attribute belongs on the target wrapper that `Popover` renders, not on the child element it clones.

Built the five packages and checked the output: the attribute selectors survive unhashed next to the still-hashed class names, and the attributes appear in the compiled JS.

```text
[data-popover-content].BJljlG_Tooltip-popover-content
.sY80Kq_ButtonGroup--compact > [data-popover-target] + [data-popover-target]
```

`grep -rn "class\*='_" packages --include='*.css'` returns nothing, in source and in `dist`.

Also ran `pnpm typecheck`, `pnpm oxlint:js`, `pnpm fmt:check`, and the unit tests for the five packages (74 passing).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Cross-package CSS no longer depends on hashed CSS module class substrings (`[class*='_Popover-target']`, etc.), which could silently break when consumers use a different `localIdentName`.
> 
> **Stable data attributes** are added on the elements other packages style: `data-popover-target` / `data-popover-content` on `Popover`, `data-button` on `Button` and `IconButton`, and `data-button-group` on `ButtonGroup`. Fourteen selectors in `button`, `tooltip`, `menu`, and `form` now target those attributes instead of class substrings.
> 
> A **Popover test** asserts the target wrapper and content carry the new attributes, pinning the contract for downstream styles. No public component API or dependency graph changes; visual output should match published builds where the old selectors still matched.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 642674510bd2ef70181dfd045715061b89dd0a48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->