### PR TITLE
fix(popover): take OffsetOptions from the package whose function uses it

### DIFF
--- a/.changeset/popover-offset-options-from-dom.md
+++ b/.changeset/popover-offset-options-from-dom.md
@@ -1,0 +1,7 @@
+---
+'@launchpad-ui/popover': patch
+---
+
+Take the `OffsetOptions` type from `@floating-ui/dom` instead of `@floating-ui/core`, and drop the direct dependency on core.
+
+`Popover` calls `offset()` from `@floating-ui/dom`, so the type that describes its argument should come from the same package. Importing it from core meant the type could come from a different copy of core than the one `@floating-ui/dom` resolved for itself, since dom asks for `^1.7.3` while popover pinned `1.7.4`. Two copies produce two structurally distinct declarations, and a consumer that compiles this package from source then fails to typecheck `Popover.tsx`. `@floating-ui/dom` re-exports the type, so nothing else changes.

--- a/packages/popover/package.json
+++ b/packages/popover/package.json
@@ -24,7 +24,6 @@
 		"test": "vitest run --coverage"
 	},
 	"dependencies": {
-		"@floating-ui/core": "1.7.4",
 		"@floating-ui/dom": "1.7.4",
 		"@launchpad-ui/focus-trap": "workspace:~",
 		"@launchpad-ui/overlay": "workspace:~",

--- a/packages/popover/src/Popover.tsx
+++ b/packages/popover/src/Popover.tsx
@@ -21,8 +21,7 @@ import {
 	useRef,
 	useState,
 } from 'react';
-import type { OffsetOptions } from '@floating-ui/core';
-import type { ComputePositionConfig, Placement, Strategy } from '@floating-ui/dom';
+import type { ComputePositionConfig, OffsetOptions, Placement, Strategy } from '@floating-ui/dom';
 import { arrow, computePosition, flip, offset as floatOffset, shift } from '@floating-ui/dom';
 import { cx } from 'classix';
 import { LazyMotion, m } from 'framer-motion';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -670,9 +670,6 @@ importers:
 
   packages/popover:
     dependencies:
-      '@floating-ui/core':
-        specifier: 1.7.4
-        version: 1.7.4
       '@floating-ui/dom':
         specifier: 1.7.4
         version: 1.7.4


### PR DESCRIPTION
## Summary

`Popover` calls `offset()` from `@floating-ui/dom`, but imported the type of its argument from `@floating-ui/core`:

```diff
- import type { OffsetOptions } from '@floating-ui/core';
- import type { ComputePositionConfig, Placement, Strategy } from '@floating-ui/dom';
+ import type { ComputePositionConfig, OffsetOptions, Placement, Strategy } from '@floating-ui/dom';
```

Those two packages do not have to agree on which copy of core they use. `@floating-ui/dom` asks for `^1.7.3`, while this package pinned `1.7.4` exactly, so a resolver is free to give dom its own 1.7.3 and popover 1.7.4. Two copies of core declare two structurally distinct `OffsetOptions`, and a consumer that compiles this package from source then fails on `Popover.tsx`:

```text
error TS2345: Argument of type 'OffsetOptions' is not assignable to
  parameter of type 'OffsetOptions | undefined'
```

The prebuilt `dist` never showed it, because the published `.d.ts` files already resolved the types at build time.

`@floating-ui/dom` re-exports `OffsetOptions`, so the import moves to the line that already pulls three other types from dom, and the direct dependency on `@floating-ui/core` goes away. Nothing else in this repository imports core.

## Screenshots (if appropriate)

None. A type import and a dependency entry, no runtime change.

## Testing approaches

`pnpm typecheck`, `pnpm oxlint:js`, `pnpm fmt:check`, and the popover, tooltip and menu unit tests (23 passing) all pass. The popover build succeeds and its published `Popover.d.ts` still names `OffsetOptions`, now imported from `@floating-ui/dom`.

The lockfile collapses to one copy of core:

```text
before   @floating-ui/core 1.7.3, @floating-ui/core 1.7.4
after    @floating-ui/core 1.7.4
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> **`OffsetOptions`** is now imported from **`@floating-ui/dom`** alongside the other floating-ui types used in **`Popover.tsx`**, instead of from **`@floating-ui/core`**. The direct **`@floating-ui/core`** dependency is removed from **`@launchpad-ui/popover`**.
> 
> That aligns the type with **`offset()`** from dom and avoids duplicate **`@floating-ui/core`** copies (dom’s **`^1.7.3`** vs popover’s pinned **`1.7.4`**), which caused **`TS2345`** when consumers typecheck this package from source. Runtime behavior is unchanged; the lockfile resolves to a single core copy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3b7ea313c8df0e24c395137c6294f7d8269ba17. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->