### PR TITLE
refactor: drop the deprecated chip and progress dependencies

### DIFF
--- a/.changeset/drop-deprecated-chip-progress-deps.md
+++ b/.changeset/drop-deprecated-chip-progress-deps.md
@@ -1,0 +1,15 @@
+---
+'@launchpad-ui/drawer': patch
+'@launchpad-ui/navigation': patch
+---
+
+Drop the dependencies on `@launchpad-ui/progress` and `@launchpad-ui/chip`. Both packages are
+deprecated and are no longer part of this workspace, so they resolved from the registry and
+pulled in their own older copies of `@launchpad-ui/icons` and `@launchpad-ui/tokens`. The
+spinner the drawer shows while suspended content loads, and the status label a navigation item
+renders, are now source files in the packages that use them, with the same markup and the same
+styles. Only the parts these two packages render are kept: the spinner has no value, size or
+delay variants, and the status label has no icon and no click handling. `NavItemProps['status']`
+accepts the same union of values as before, and the styles it needs now ship in
+`@launchpad-ui/navigation/style.css` and `@launchpad-ui/drawer/style.css` rather than in the
+stylesheets of the two deprecated packages.

--- a/packages/drawer/package.json
+++ b/packages/drawer/package.json
@@ -28,7 +28,6 @@
 		"@launchpad-ui/focus-trap": "workspace:~",
 		"@launchpad-ui/icons": "workspace:~",
 		"@launchpad-ui/portal": "workspace:~",
-		"@launchpad-ui/progress": "0.5.57",
 		"@launchpad-ui/tokens": "workspace:~",
 		"classix": "2.2.0",
 		"framer-motion": "12.23.22"

--- a/packages/drawer/src/Drawer.tsx
+++ b/packages/drawer/src/Drawer.tsx
@@ -10,9 +10,9 @@ import { IconButton } from '@launchpad-ui/button';
 import { FocusTrap } from '@launchpad-ui/focus-trap';
 import { Icon } from '@launchpad-ui/icons';
 import { Portal } from '@launchpad-ui/portal';
-import { Progress } from '@launchpad-ui/progress';
 
 import { DRAWER_LABELLED_BY } from './constants';
+import { Progress } from './Progress';
 
 import styles from './styles/Drawer.module.css';
 

--- a/packages/drawer/src/Progress.tsx
+++ b/packages/drawer/src/Progress.tsx
@@ -1,0 +1,45 @@
+import { cx } from 'classix';
+
+import styles from './styles/Progress.module.css';
+
+// The small indeterminate spinner the drawer shows while suspended content
+// loads. It previously came from `@launchpad-ui/progress`, which is deprecated
+// and is no longer part of this workspace, so the markup and styles live here
+// unchanged. Only the drawer's usage is kept: no value, no size, no delay.
+const DIAMETER = 16;
+const STROKE_WIDTH = DIAMETER * 0.1;
+const RADIUS = DIAMETER * 0.5 - STROKE_WIDTH * 0.5;
+const CIRCUMFERENCE = 2 * Math.PI * RADIUS;
+
+const Progress = () => (
+	<svg
+		className={cx(styles.Progress, styles['Progress--indeterminate'])}
+		width={DIAMETER}
+		height={DIAMETER}
+		viewBox={`0 0 ${DIAMETER} ${DIAMETER}`}
+		data-test-id="progress"
+		role="progressbar"
+		aria-valuemin={0}
+		aria-valuetext="loading"
+		aria-valuemax={100}
+	>
+		<circle
+			className={styles['Progress-track']}
+			cx={DIAMETER / 2}
+			cy={DIAMETER / 2}
+			r={RADIUS}
+			strokeWidth={STROKE_WIDTH}
+		/>
+		<circle
+			className={styles['Progress-head']}
+			cx={DIAMETER / 2}
+			cy={DIAMETER / 2}
+			r={RADIUS}
+			strokeWidth={STROKE_WIDTH}
+			strokeDasharray={CIRCUMFERENCE}
+			strokeDashoffset={CIRCUMFERENCE * 0.75}
+		/>
+	</svg>
+);
+
+export { Progress };

--- a/packages/drawer/src/styles/Progress.module.css
+++ b/packages/drawer/src/styles/Progress.module.css
@@ -1,0 +1,33 @@
+@keyframes indeterminate {
+	0% {
+		transform: rotate(0deg);
+	}
+
+	100% {
+		transform: rotate(359deg);
+	}
+}
+
+.Progress {
+	display: inline-block;
+	vertical-align: middle;
+	transform: rotate(-90deg);
+}
+
+.Progress--indeterminate {
+	animation-name: indeterminate;
+	animation-duration: var(--lp-duration-350);
+	animation-timing-function: linear;
+	animation-iteration-count: infinite;
+}
+
+.Progress-track {
+	fill: none;
+	stroke: var(--lp-color-gray-50);
+}
+
+.Progress-head {
+	transition: stroke-dashoffset var(--lp-duration-350);
+	fill: none;
+	stroke: var(--lp-color-gray-500);
+}

--- a/packages/navigation/package.json
+++ b/packages/navigation/package.json
@@ -24,7 +24,6 @@
 		"test": "vitest run --coverage"
 	},
 	"dependencies": {
-		"@launchpad-ui/chip": "0.9.58",
 		"@launchpad-ui/dropdown": "workspace:~",
 		"@launchpad-ui/icons": "workspace:~",
 		"@launchpad-ui/menu": "workspace:~",

--- a/packages/navigation/src/Chip.tsx
+++ b/packages/navigation/src/Chip.tsx
@@ -1,0 +1,27 @@
+import type { ComponentProps } from 'react';
+import { cx } from 'classix';
+
+import styles from './styles/Chip.module.css';
+
+// The small status label rendered next to a navigation item. It previously
+// came from `@launchpad-ui/chip`, which is deprecated and is no longer part of
+// this workspace, so the markup and styles live here unchanged. Only the
+// navigation usage is kept: no icon and no click handling.
+type ChipKind = 'success' | 'warning' | 'error' | 'info' | 'new' | 'beta' | 'federal';
+
+type ChipProps = ComponentProps<'span'> & {
+	kind?: ChipKind;
+	size?: 'tiny' | 'small';
+	'data-test-id'?: string;
+};
+
+const Chip = ({ kind, className, children, size = 'small', 'data-test-id': testId = 'chip', ...rest }: ChipProps) => {
+	return (
+		<span className={cx(styles.chip, kind && styles[kind], styles[size], className)} data-test-id={testId} {...rest}>
+			{children}
+		</span>
+	);
+};
+
+export { Chip };
+export type { ChipKind, ChipProps };

--- a/packages/navigation/src/NavItem.tsx
+++ b/packages/navigation/src/NavItem.tsx
@@ -2,9 +2,8 @@ import type { MouseEvent } from 'react';
 import { NavLink, useLocation } from 'react-router';
 import { cx } from 'classix';
 
-import type { ChipProps } from '@launchpad-ui/chip';
-import { Chip } from '@launchpad-ui/chip';
-
+import type { ChipProps } from './Chip';
+import { Chip } from './Chip';
 import { titlecase } from './utils';
 
 import styles from './styles/Navigation.module.css';

--- a/packages/navigation/src/NavigationMenuDropdown.tsx
+++ b/packages/navigation/src/NavigationMenuDropdown.tsx
@@ -3,11 +3,11 @@ import { NavLink, useLocation } from 'react-router';
 import { useListState } from 'react-stately/useListState';
 import type { CollectionBase } from '@react-types/shared';
 
-import { Chip } from '@launchpad-ui/chip';
 import { Dropdown, DropdownButton } from '@launchpad-ui/dropdown';
 import { Icon } from '@launchpad-ui/icons';
 import { Menu, MenuItem } from '@launchpad-ui/menu';
 
+import { Chip } from './Chip';
 import type { NavProps } from './Nav';
 import { titlecase } from './utils';
 

--- a/packages/navigation/src/styles/Chip.module.css
+++ b/packages/navigation/src/styles/Chip.module.css
@@ -1,0 +1,62 @@
+.chip {
+	display: inline-flex;
+	align-items: center;
+	font-weight: var(--lp-font-weight-semibold);
+	border-radius: 0.125rem;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	max-width: 100%;
+	color: var(--lp-color-text-ui-secondary);
+	background-color: var(--lp-color-bg-ui-tertiary);
+	transition: all 0.1s ease-in-out;
+}
+
+.small {
+	font-size: 0.875rem;
+	line-height: 1.4;
+	padding: 0.13437rem 0.375rem;
+	height: 1.5rem;
+}
+
+.chip.tiny {
+	font-size: 0.75rem;
+	line-height: 1.33;
+	padding: 0.125rem 0.25rem;
+	height: 1.25rem;
+}
+
+.info {
+	background-color: var(--lp-color-bg-feedback-info);
+	color: var(--lp-color-text-feedback-info);
+}
+
+.new {
+	background-color: var(--lp-color-bg-feedback-success);
+	color: var(--lp-color-text-feedback-success);
+}
+
+.beta {
+	background-color: var(--lp-color-bg-product-beta);
+	color: var(--lp-color-text-product-beta);
+}
+
+.success {
+	background-color: var(--lp-color-bg-feedback-success);
+	color: var(--lp-color-text-feedback-success);
+}
+
+.warning {
+	background-color: var(--lp-color-brand-yellow-light);
+	color: var(--lp-color-brand-orange-dark);
+}
+
+.error {
+	background-color: var(--lp-color-bg-feedback-error);
+	color: var(--lp-color-text-feedback-error);
+}
+
+.federal {
+	background-color: var(--lp-color-bg-product-federal);
+	color: var(--lp-color-text-product-federal);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -424,9 +424,6 @@ importers:
       '@launchpad-ui/portal':
         specifier: workspace:~
         version: link:../portal
-      '@launchpad-ui/progress':
-        specifier: 0.5.57
-        version: 0.5.57(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@launchpad-ui/tokens':
         specifier: workspace:~
         version: link:../tokens
@@ -689,9 +686,6 @@ importers:
 
   packages/navigation:
     dependencies:
-      '@launchpad-ui/chip':
-        specifier: 0.9.58
-        version: 0.9.58(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@launchpad-ui/dropdown':
         specifier: workspace:~
         version: link:../dropdown
@@ -1627,32 +1621,6 @@ packages:
 
   '@keyv/serialize@1.1.1':
     resolution: {integrity: sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==}
-
-  '@launchpad-ui/chip@0.9.58':
-    resolution: {integrity: sha512-57XRCU+XCLNGUS3pjdls0Oi2GDhly/QF4C4mEhswnhKg96pZ1pURKIV9AD3yEdLqMHgeNZKJBCNg78UHoZQFcA==}
-    deprecated: Use components from @launchpad-ui/components instead
-    peerDependencies:
-      react: ^18.0.0 || ^19.0.0
-      react-dom: ^18.0.0 || ^19.0.0
-
-  '@launchpad-ui/icons@0.21.20':
-    resolution: {integrity: sha512-5tDvc9bT/nii3YkGGEXO7Ij7LsFrgwP82j3gb2OutLy15dbLuaNXVroHtukUAoHN+X/FVnFbPAFpP0MqjVXwFQ==}
-    peerDependencies:
-      react: ^19.0.0
-      react-dom: ^19.0.0
-
-  '@launchpad-ui/progress@0.5.57':
-    resolution: {integrity: sha512-tRVb8Zo4DTrNEEFgB9cOLExC6LvOaPbo/KIGSFuSPO3u1VPwgnar92LMICm5U8gFfLIOUnkh8X0EuN4VvxAp2Q==}
-    deprecated: Use components from @launchpad-ui/components instead
-    peerDependencies:
-      react: ^18.0.0 || ^19.0.0
-      react-dom: ^18.0.0 || ^19.0.0
-
-  '@launchpad-ui/tokens@0.12.7':
-    resolution: {integrity: sha512-dEGzJV7hRvajB/9m9m9Fbg1lF6lSP/B4Jy7N4gIolKQ0dNRWtBCYIG5RE2S0li8T3IpZ9JfwX5Xy1CDFZ9YWVw==}
-
-  '@launchpad-ui/tokens@0.13.1':
-    resolution: {integrity: sha512-vmmtDgYvtHGvkVP9ASeotcIxpZnixhyYjHv+flN8/lB/tDKxYVIIJG0n8vHDh3ceIDhKwmszYoHeyxErx8kUww==}
 
   '@lit-labs/react@2.1.3':
     resolution: {integrity: sha512-OD9h2JynerBQUMNzb563jiVpxfvPF0HjQkKY2mx0lpVYvD7F+rtJpOGz6ek+6ufMidV3i+MPT9SX62OKWHFrQg==}
@@ -6829,32 +6797,6 @@ snapshots:
       keyv: 5.6.0
 
   '@keyv/serialize@1.1.1': {}
-
-  '@launchpad-ui/chip@0.9.58(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
-    dependencies:
-      '@launchpad-ui/icons': 0.21.20(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@launchpad-ui/tokens': 0.12.7
-      classix: 2.2.0
-      react: 19.2.8
-      react-dom: 19.2.8(react@19.2.8)
-
-  '@launchpad-ui/icons@0.21.20(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
-    dependencies:
-      '@launchpad-ui/tokens': 0.13.1
-      class-variance-authority: 0.7.0
-      react: 19.2.8
-      react-dom: 19.2.8(react@19.2.8)
-
-  '@launchpad-ui/progress@0.5.57(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
-    dependencies:
-      '@launchpad-ui/tokens': 0.12.7
-      classix: 2.2.0
-      react: 19.2.8
-      react-dom: 19.2.8(react@19.2.8)
-
-  '@launchpad-ui/tokens@0.12.7': {}
-
-  '@launchpad-ui/tokens@0.13.1': {}
 
   '@lit-labs/react@2.1.3(@types/react@19.2.15)':
     dependencies:


### PR DESCRIPTION
We have packages that depend on packages that aren't in the launchpad-ui repo/workspace anymore and have been fetched from old NPM packages, so we're inlining them for now.

> [!WARNING]
> This was written by AI

`@launchpad-ui/drawer` and `@launchpad-ui/navigation` depended on `@launchpad-ui/progress` and `@launchpad-ui/chip`, which are deprecated and are not workspace members, so they installed from the registry along with older copies of `@launchpad-ui/icons` and `@launchpad-ui/tokens`. The spinner and the status label those two packages actually render now live as source files in the packages that use them, with the same markup and the same styles, so nothing renders differently.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> **`@launchpad-ui/drawer`** and **`@launchpad-ui/navigation`** no longer depend on the deprecated **`@launchpad-ui/progress`** and **`@launchpad-ui/chip`** packages, which were resolving from the registry and dragging in older **`@launchpad-ui/icons`** and **`@launchpad-ui/tokens`**.
> 
> The drawer’s **Suspense** loading spinner is now a local **`Progress`** component with the same indeterminate SVG and CSS (no value/size/delay variants). Navigation status badges use a local **`Chip`** with the same kinds and sizes navigation already used (no icon or click behavior). **`NavItem`** / menu dropdown imports switch to these local modules; **`NavItemProps['status']`** stays the same union.
> 
> Related styles are bundled with each package’s **`style.css`** instead of the deprecated packages. **`pnpm-lock.yaml`** drops the registry entries for chip, progress, and the duplicate token/icon versions they pulled in.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e8e490790f1218f6277c6d1861e09852bcd56b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->