### PR TITLE
feat(tokens): add text.editorial.h4 typography token

### DIFF
--- a/.changeset/heavy-donuts-shout.md
+++ b/.changeset/heavy-donuts-shout.md
@@ -1,0 +1,5 @@
+---
+'@launchpad-ui/tokens': minor
+---
+
+Add `text.editorial.h4` typography token (Sora bold 24px/28px) — a smaller editorial heading for product-page titles like the SDK setup page, so consumers stop hand-composing the font from primitives.

--- a/packages/tokens/tokens/typography.json
+++ b/packages/tokens/tokens/typography.json
@@ -285,6 +285,15 @@
 					"lineHeight": "{lineHeight.editorial.snug}",
 					"letterSpacing": "{letterSpacing.editorial.tight-2px}"
 				}
+			},
+			"h4": {
+				"$value": {
+					"fontFamily": "{fontFamily.sora}",
+					"fontWeight": "{fontWeight.editorial.bold}",
+					"fontSize": "{fontSize.500}",
+					"lineHeight": "{lineHeight.400}",
+					"letterSpacing": "{letterSpacing.editorial.tight-1px}"
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

Adds a smaller editorial (Sora) heading to the typography scale: `text.editorial.h4` — **bold 24px/28px** — for product-page titles that use the editorial voice at content scale (first consumer: gonfalon's SDK setup page header, which currently hand-composes this from primitives with a TODO pointing here — see launchdarkly/gonfalon#69834).

Built output:

```css
--lp-text-editorial-h4: var(--lp-font-weight-editorial-bold) var(--lp-font-size-500)/var(--lp-line-height-400) var(--lp-font-family-sora);
```

Composition choices (flagging for design review — cc @adalene):

- **No new primitives**: references the core scale (`fontSize.500` = 24px, `lineHeight.400` = 28px) rather than adding `fontSize.editorial.24` + a new editorial line-height ratio (existing editorial line-heights are ratios 1/1.05; 24/28 ≈ 1.167 doesn't fit either). Happy to switch to editorial-scoped primitives if scale purity is preferred.
- **letterSpacing**: `editorial.tight-1px` (the family's other tokens use tight-2px, which felt too aggressive at 24px). As with the other editorial tokens this doesn't reach the CSS `font:` shorthand — consumers apply the letter-spacing primitive separately.

## Testing approaches

- `pnpm --filter @launchpad-ui/tokens build` — verified the emitted variable in `dist/index.css` (above); Figma payloads regenerate cleanly
- `pnpm --filter @launchpad-ui/tokens test` (4 pass) and `lint` clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Adds **`text.editorial.h4`** to `@launchpad-ui/tokens` — Sora **bold 24px / 28px line height** — as the next step down on the editorial heading scale after `h3`, for product-page titles at content scale (e.g. SDK setup headers that currently assemble primitives).
> 
> The token wires **core scale** refs (`fontSize.500`, `lineHeight.400`) and **`letterSpacing.editorial.tight-1px`** (lighter than the `tight-2px` used on larger editorial headings). A **minor** changeset records the package bump.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e57357d0a5706157176fe3a0e347b83d1ad66fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->