### PR TITLE
docs: add archive notice to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+> [!WARNING]
+> This repository is archived. These packages are no longer maintained or published from this repository.
+
 # LaunchPad
 
 A modern, intuitive, and accessible design system built and used by the LaunchDarkly team.


### PR DESCRIPTION
> [!NOTE]
> This content was written by AI.

This repository is being archived. The notice tells readers these packages are no longer published from here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Adds a GitHub **WARNING** callout at the top of `README.md` stating the repository is archived and that packages are no longer maintained or published from this repo.
> 
> No code, packages, or build config change—only reader-facing documentation so people see the archival status before install/contributing instructions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8555c558fa85c447b16a76c3a01652bcb7c2802. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->