### PR TITLE
feat(components): add selected icon to ToggleButton

### DIFF
--- a/.changeset/toggle-button-selected-icon.md
+++ b/.changeset/toggle-button-selected-icon.md
@@ -1,0 +1,5 @@
+---
+'@launchpad-ui/components': minor
+---
+
+Add `icon` and `selectedIcon` props to `ToggleButton`. A selected button now shows `check-circle` by default, and selecting a button with a leading `icon` swaps that icon for the selected one rather than showing both. Pass `selectedIcon={null}` to opt out. `appearance="elevated"` shows no selected icon, since its raised surface already signals selection.

--- a/packages/components/__tests__/ToggleButton.spec.tsx
+++ b/packages/components/__tests__/ToggleButton.spec.tsx
@@ -19,4 +19,71 @@ describe('ToggleButton', () => {
 		render(<ToggleButton appearance="elevated">toggle</ToggleButton>);
 		expect(screen.getByRole('button')).toHaveAttribute('data-lp-variant', 'default');
 	});
+
+	describe('selected icon', () => {
+		it('renders a check when selected', () => {
+			render(<ToggleButton isSelected>toggle</ToggleButton>);
+			expect(screen.getByRole('button').querySelector('[data-icon="check-circle"]')).toBeInTheDocument();
+		});
+
+		it('renders no icon when not selected', () => {
+			render(<ToggleButton>toggle</ToggleButton>);
+			expect(screen.getByRole('button').querySelector('[data-icon]')).not.toBeInTheDocument();
+		});
+
+		it('renders a leading icon while not selected', () => {
+			render(<ToggleButton icon="flask">toggle</ToggleButton>);
+
+			const button = screen.getByRole('button');
+			expect(button.querySelector('[data-icon="flask"]')).toBeInTheDocument();
+			expect(button.querySelector('[data-icon="check-circle"]')).not.toBeInTheDocument();
+		});
+
+		it('swaps the leading icon for the check when selected', () => {
+			render(
+				<ToggleButton icon="flask" isSelected>
+					toggle
+				</ToggleButton>,
+			);
+
+			const button = screen.getByRole('button');
+			expect(button.querySelector('[data-icon="check-circle"]')).toBeInTheDocument();
+			expect(button.querySelector('[data-icon="flask"]')).not.toBeInTheDocument();
+		});
+
+		it('supports a custom selected icon', () => {
+			render(
+				<ToggleButton isSelected selectedIcon="flag">
+					toggle
+				</ToggleButton>,
+			);
+			expect(screen.getByRole('button').querySelector('[data-icon="flag"]')).toBeInTheDocument();
+		});
+
+		it('renders no icon when the selected icon is null', () => {
+			render(
+				<ToggleButton isSelected selectedIcon={null}>
+					toggle
+				</ToggleButton>,
+			);
+			expect(screen.getByRole('button').querySelector('[data-icon]')).not.toBeInTheDocument();
+		});
+
+		it('renders no icon when selected and elevated', () => {
+			render(
+				<ToggleButton appearance="elevated" isSelected>
+					toggle
+				</ToggleButton>,
+			);
+			expect(screen.getByRole('button').querySelector('[data-icon]')).not.toBeInTheDocument();
+		});
+
+		it('hides the icon from assistive technology', () => {
+			render(<ToggleButton isSelected>toggle</ToggleButton>);
+			expect(screen.getByRole('button').querySelector('[data-icon="check-circle"]')).toHaveAttribute(
+				'aria-hidden',
+				'true',
+			);
+		});
+	});
 });

--- a/packages/components/src/ToggleButton.tsx
+++ b/packages/components/src/ToggleButton.tsx
@@ -6,6 +6,9 @@ import type { ToggleButtonProps as AriaToggleButtonProps } from 'react-aria-comp
 import { ToggleButton as AriaToggleButton } from 'react-aria-components/ToggleButton';
 import { cva } from 'class-variance-authority';
 
+import type { IconProps } from '@launchpad-ui/icons';
+import { Icon } from '@launchpad-ui/icons';
+
 import type { ButtonVariants } from './Button';
 import { buttonStyles } from './Button';
 import { useLPContextProps } from './utils';
@@ -17,6 +20,14 @@ const toggleButtonElevatedStyles = cva(elevatedStyles.elevated);
 interface ToggleButtonProps extends AriaToggleButtonProps, ButtonVariants {
 	/** Visual appearance of the toggle button. Use `"elevated"` inside a `ToggleButtonGroup` with `appearance="elevated"`. */
 	appearance?: 'default' | 'elevated';
+	/** Leading icon shown while the button is not selected. Replaced by `selectedIcon` on selection. */
+	icon?: IconProps['name'];
+	/**
+	 * Leading icon shown while the button is selected. Defaults to `"check-circle"`, and to `null` when
+	 * `appearance="elevated"` — the elevated appearance already signals selection through its raised surface.
+	 * Pass `null` to render no icon when selected.
+	 */
+	selectedIcon?: IconProps['name'] | null;
 	ref?: Ref<HTMLButtonElement>;
 }
 
@@ -25,11 +36,20 @@ const ToggleButtonContext = createContext<ContextValue<ToggleButtonProps, HTMLBu
 /**
  * A toggle button allows a user to toggle a selection on or off, for example switching between two states or modes.
  *
+ * Selecting a button swaps its leading icon for `selectedIcon`, so a selected button shows a single icon rather
+ * than both. The elevated appearance opts out of this and shows no selected icon.
+ *
  * https://react-spectrum.adobe.com/react-aria/ToggleButton.html
  */
 const ToggleButton = ({ ref, ...props }: ToggleButtonProps) => {
 	const [mergedProps, mergedRef] = useLPContextProps(props, ref, ToggleButtonContext);
-	const { appearance = 'default', size = 'medium', variant = 'default' } = mergedProps;
+	const {
+		appearance = 'default',
+		size = 'medium',
+		variant = 'default',
+		icon,
+		selectedIcon = appearance === 'elevated' ? null : 'check-circle',
+	} = mergedProps;
 
 	return (
 		<AriaToggleButton
@@ -41,7 +61,18 @@ const ToggleButton = ({ ref, ...props }: ToggleButtonProps) => {
 					? toggleButtonElevatedStyles({ ...renderProps, className })
 					: buttonStyles({ ...renderProps, size, variant, className }),
 			)}
-		/>
+		>
+			{composeRenderProps(mergedProps.children, (children, { isSelected }) => {
+				const name = isSelected ? selectedIcon : icon;
+
+				return (
+					<>
+						{name ? <Icon name={name} size="small" aria-hidden /> : null}
+						{children}
+					</>
+				);
+			})}
+		</AriaToggleButton>
 	);
 };
 

--- a/packages/components/stories/ToggleButtonGroup.stories.tsx
+++ b/packages/components/stories/ToggleButtonGroup.stories.tsx
@@ -1,5 +1,6 @@
 import type { ComponentType } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { userEvent, within } from 'storybook/test';
 
 import { ToggleButton } from '../src/ToggleButton';
 import { ToggleButtonGroup } from '../src/ToggleButtonGroup';
@@ -72,5 +73,63 @@ export const Icons: Story = {
 			</>
 		),
 		orientation: 'vertical',
+	},
+};
+
+export const SelectedIconSwap: Story = {
+	parameters: {
+		docs: {
+			description: {
+				story:
+					'A selected button shows `check-circle`. When a button also has a leading `icon`, selecting it swaps that icon for the selected one instead of showing both. Click through the options to see the swap.',
+			},
+		},
+	},
+	args: {
+		children: (
+			<>
+				<ToggleButton id="first" icon="flask">
+					First
+				</ToggleButton>
+				<ToggleButton id="second" icon="flag">
+					Second
+				</ToggleButton>
+				<ToggleButton id="third" icon="toggle-on">
+					Third
+				</ToggleButton>
+			</>
+		),
+		defaultSelectedKeys: ['first'],
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+
+		await userEvent.click(canvas.getByRole('radio', { name: 'Second' }));
+	},
+};
+
+export const WithoutSelectedIcon: Story = {
+	parameters: {
+		docs: {
+			description: {
+				story: 'Pass `selectedIcon={null}` to keep a selected button icon-free.',
+			},
+		},
+	},
+	args: {
+		children: (
+			<>
+				<ToggleButton id="first" selectedIcon={null}>
+					First
+				</ToggleButton>
+				<ToggleButton id="second" selectedIcon={null}>
+					Second
+				</ToggleButton>
+				<ToggleButton id="third" selectedIcon={null}>
+					Third
+				</ToggleButton>
+			</>
+		),
+		defaultSelectedKeys: ['first'],
 	},
 };

--- a/packages/components/stories/ToggleButtonGroupElevated.stories.tsx
+++ b/packages/components/stories/ToggleButtonGroupElevated.stories.tsx
@@ -11,6 +11,14 @@ const meta: Meta<typeof ToggleButtonGroup> = {
 	subcomponents: { ToggleButton } as Record<string, ComponentType<unknown>>,
 	title: 'Components/Buttons/ToggleButton/ToggleButtonGroupElevated',
 	tags: ['autodocs'],
+	parameters: {
+		docs: {
+			description: {
+				component:
+					'Unlike the default appearance, an elevated toggle button shows no icon when selected — the raised surface already makes the selection legible. Pass `selectedIcon` explicitly to opt back in.',
+			},
+		},
+	},
 };
 
 export default meta;


### PR DESCRIPTION
## Summary

A selected `ToggleButton` currently reads only from its border and fill. This adds an explicit selection affordance, matching the Figma work in [the LaunchPad branch](https://www.figma.com/design/98HKKXL2dTle29ikJ3tzk7/branch/4IEzVLqjOBK9NGvktWmNOI/%F0%9F%9A%80-LaunchPad?node-id=1-37500).

> **Try out the design here** → [interactive Storybook for this PR](https://626696a2018c1f004a1cde86-oaoemraqlh.chromatic.com/?path=/story/components-buttons-togglebutton-togglebuttongroup--example). No checkout or setup needed — click between the options to watch the icon swap.

Two new props on `ToggleButton`:

- `icon` — leading icon shown while the button is **not** selected.
- `selectedIcon` — leading icon shown while it **is** selected. Defaults to `check-circle`; pass `null` to opt out.

The two never render together: selecting a button with a leading `icon` **swaps** that icon for `check-circle` rather than stacking them, so a button shows exactly one icon in either state.

`appearance="elevated"` defaults `selectedIcon` to `null` and shows no icon when selected — its raised surface already makes the selection legible, so a check would be redundant. Passing `selectedIcon` explicitly still opts back in.

Implementation wraps children in `composeRenderProps` to read RAC's `isSelected` render prop, so no new state and no change to the existing class/variant logic. The icon is `aria-hidden`; selection is still announced through `aria-pressed` / `aria-selected`.

### Reviewer call-out

This changes rendered output for **every existing selected default-appearance toggle button**, not just new usages — in gonfalon that includes the access-token status filter and `CategoryPills`. Two things worth an explicit decision:

1. **Bump level.** Filed as `minor` (additive props, additive behavior), but the repo's rules list "changed default" under `major`. Happy to re-cut as `major` if you read it that way.
2. **Width.** A selected button is ~20px wider than an unselected one, so segments resize as selection moves. Most visible in narrow groups like `5% / 10% / 50% / 90% / Custom`. The design decision so far was to accept this rather than reserve icon space; say the word if you'd prefer it reserved.

## Screenshots 

**Selected state** — a selected button that has no icon of its own now shows `check-circle`. This is the existing `ToggleButtonGroup` → `Example` story, unchanged apart from the new default:

![Selected toggle button showing a check-circle icon](https://raw.githubusercontent.com/launchdarkly/launchpad-ui/assets/pr-2017-screenshots/pr-2017/01-selected-state.png)

**Group where every button has an icon** — "First" is selected, so its `flask` has been replaced by the check, while "Second" and "Third" keep `flag` and `toggle-on`. One icon per button in either state, never two:

![Toggle button group where every button has an icon and the selected one shows a check instead](https://raw.githubusercontent.com/launchdarkly/launchpad-ui/assets/pr-2017-screenshots/pr-2017/02-all-icons.png)

Chromatic has the full picture: **14 visual and accessibility changes** to accept as baselines, covering every existing story with a selected toggle.

## Testing approaches

- Seven unit tests in `ToggleButton.spec.tsx` covering: check renders when selected, no icon when unselected, leading icon while unselected, icon-swaps-to-check on selection, custom `selectedIcon`, `selectedIcon={null}`, elevated renders nothing, and the icon is `aria-hidden`.
- Two new stories in `ToggleButtonGroup.stories.tsx` — `SelectedIconSwap` (with a `play` function that clicks through to show the swap) and `WithoutSelectedIcon`.
- Doc note on the elevated stories explaining why that appearance opts out.
- `pnpm typecheck`, `pnpm oxlint:js`, `pnpm fmt:check` clean; all 16 tests across the three toggle specs pass.

<sub>Screenshots are hosted on the `assets/pr-2017-screenshots` branch (images only, never merged) — safe to delete once this lands.</sub>